### PR TITLE
Convert status mask representation in status_changes

### DIFF
--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/EntityDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/EntityDelegate.cpp
@@ -78,7 +78,7 @@ org::eclipse::cyclonedds::core::EntityDelegate::status_changes() const
     check();
     ret = dds_get_status_changes(ddsc_entity, &ddsc_mask);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ret, "Could not set internal listener.");
-    mask = ::dds::core::status::StatusMask(ddsc_mask);
+    mask = convertStatusMask(ddsc_mask);
 
     return mask;
 }


### PR DESCRIPTION
This makes the representation of the statuses in the result of status_changes() match the representation elsewhere in the C++ API. I'm not sure why there's a difference in representation between the C and the C++ API, but if there has be one, it should at least be consistent throughout.