### PR TITLE
Add buildfiles and missing header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,149 @@
+language: cpp
+
+ubuntu1804_gcc10: &ubuntu1804_gcc10
+  os: linux
+  dist: bionic
+  compiler: gcc
+  addons:
+    apt:
+      update: true
+      sources:
+        - sourceline: 'ppa:ubuntu-toolchain-r/test'
+      packages: [ gcc-10 g++-10 ]
+  before_install:
+    - eval "export CC=gcc-10 CXX=g++-10"
+    - eval "export COV_COMPTYPE=gcc COV_PLATFORM=linux64"
+    - eval "export BUILD_TOOL_OPTIONS='-j 4'"
+    - eval "export GENERATOR='Unix Makefiles'"
+  install:
+    - pip install conan --upgrade --user
+
+ubuntu1804_clang10: &ubuntu1804_clang10
+  os: linux
+  dist: bionic
+  compiler: clang
+  addons:
+    apt:
+      update: true
+      sources:
+        - sourceline: 'deb https://apt.llvm.org/bionic llvm-toolchain-bionic-10 main'
+          key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+      packages: [ clang-10 clang++-10 ]
+  before_install:
+    - eval "export CC=clang-10 CXX=clang++-10"
+    - eval "export COV_COMPTYPE=clang COV_PLATFORM=linux64"
+    - eval "export BUILD_TOOL_OPTIONS='-j 4'"
+    - eval "export GENERATOR='Unix Makefiles'"
+  install:
+    - pip install conan --upgrade --user
+
+macos1015_xcode11_6: &macos1015_xcode11_6
+  os: osx
+  osx_image: xcode11.6
+  compiler: clang
+  addons:
+    homebrew:
+      packages: [ pyenv-virtualenv ]
+  before_install:
+    - eval "export CC=clang CXX=clang++"
+    - eval "export COV_COMPTYPE=clang COV_PLATFORM=macOSX"
+    - eval "export BUILD_TOOL_OPTIONS='-j 4'"
+    - eval "export GENERATOR='Unix Makefiles'"
+    - eval "export PATH=\"${PATH}:$(python3 -m site --user-base)/bin\""
+  install:
+    - python3 -m pip install conan --upgrade --user
+
+windows1809_vs2017: &windows1809_vs2017
+  os: windows
+  # Microsoft Windows instances freeze at "install:" if secure environment
+  # variables are used. There is no option to export secrets only for
+  # specified platforms. The "filter_secrets: false" option is used to disable
+  # the filter for Microsoft Windows instances. This is not an issue if the
+  # secret is removed from the environment at the earliest opportunity, before
+  # risk of exposure, as secrets are always removed from the environment for
+  # pull requests and are still filtered when exported to the environment. The
+  # secret of course will not be available for Microsoft Windows builds, but
+  # for Coverity Scan, that is fine.
+  filter_secrets: false
+  before_install:
+    - eval "unset COVERITY_SCAN_TOKEN"
+    # Conan will automatically determine the best compiler for a given platform
+    # based on educated guesses. The first check is based on the CC and CXX
+    # environment variables, the second (on Windows) is to check if Microsoft
+    # Visual Studio is installed. On Travis CC and CXX are set to gcc on
+    # Microsoft Windows targets as well, this has the undesired effect that
+    # MSVC is not detected, unsetting CC and CXX solves that problem.
+    - eval "unset CC CXX"
+    - eval "export COV_COMPTYPE=msvc COV_PLATFORM=win64"
+    - eval "export BUILD_TOOL_OPTIONS='-nologo -verbosity:minimal -maxcpucount -p:CL_MPCount=2'"
+    - |
+      if [ "${ARCH}" = "x86_64" ]; then
+        eval "export GENERATOR='Visual Studio 15 2017 Win64'"
+      else
+        eval "export GENERATOR='Visual Studio 15 2017'"
+      fi
+    - JAVA_HOME=$(find "/c/Program Files/Android/jdk/" -name "*openjdk*" | sort | head -n 1)
+    - export JAVA_HOME
+    - export PATH="${PATH}:${JAVA_HOME}/bin"
+  install:
+    # Windows targets in Travis are still very much in beta and Python is not
+    # yet available and installation of Python through Chocolaty does not work
+    # well. The real fix is to wait until Python and pip are both available on
+    # the target. Until then download Conan from the official website and
+    # simply add the extracted folder to the path.
+    - choco install innoextract
+    - choco install maven --ignore-dependencies
+    - wget -q https://dl.bintray.com/conan/installers/conan-win-64_1_10_0.exe
+    - innoextract conan-win-64_1_10_0.exe
+    - eval "export PATH=\"$(pwd)/app/conan:${PATH}\""
+
+jobs:
+  include:
+    - <<: *ubuntu1804_gcc10
+      env: [ ARCH=x86_64, BUILD_TYPE=Debug ]
+    - <<: *ubuntu1804_gcc10
+      env: [ ARCH=x86_64, BUILD_TYPE=Release ]
+    - <<: *ubuntu1804_clang10
+      env: [ ARCH=x86_64, BUILD_TYPE=Debug, SANITIZER=address ]
+    - <<: *ubuntu1804_clang10
+      env: [ ARCH=x86_64, BUILD_TYPE=Release ]
+    - <<: *macos1015_xcode11_6
+      env: [ ARCH=x86_64, BUILD_TYPE=Debug, SANITIZER=address ]
+    - <<: *macos1015_xcode11_6
+      env: [ ARCH=x86_64, BUILD_TYPE=Release ]
+    - <<: *windows1809_vs2017
+      env: [ ARCH=x86, BUILD_TYPE=Debug ]
+    - <<: *windows1809_vs2017
+      env: [ ARCH=x86_64, BUILD_TYPE=Debug ]
+    - <<: *windows1809_vs2017
+      env: [ ARCH=x86_64, BUILD_TYPE=Release ]
+
+before_script:
+  - conan profile new default --detect
+  - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
+
+build_cyclonedds: &build_cyclonedds
+  - eval "export CYCLONEDDS_BRANCH=master"
+  - eval "export CYCLONEDDS_REPOSITORY=https://github.com/eclipse-cyclonedds/cyclonedds.git"
+  - git clone --single-branch --branch ${CYCLONEDDS_BRANCH} ${CYCLONEDDS_REPOSITORY} cyclonedds
+  - mkdir cyclonedds/build
+  - cd cyclonedds/build
+  - conan install -b missing -s arch=${ARCH} -s build_type=${BUILD_TYPE} ..
+  - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+          -DCMAKE_INSTALL_PREFIX=$(pwd)/install
+          -DUSE_SANITIZER=${SANITIZER}
+          -DWERROR=on
+          -G "${GENERATOR}" ..
+  - cmake --build . --config ${BUILD_TYPE} --target install -- ${BUILD_TOOL_OPTIONS}
+  - cd ../..
+
+script:
+  - *build_cyclonedds
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+          -DCMAKE_INSTALL_PREFIX=$(pwd)/install
+          -DCMAKE_PREFIX_PATH=${TRAVIS_BUILD_DIR}/cyclonedds/build/install
+          -DUSE_SANITIZER=${SANITIZER}
+          -G "${GENERATOR}" ..
+  - cmake --build . --config ${BUILD_TYPE} --target install -- ${BUILD_TOOL_OPTIONS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,7 @@ build_cyclonedds: &build_cyclonedds
   - git clone --single-branch --branch ${CYCLONEDDS_BRANCH} ${CYCLONEDDS_REPOSITORY} cyclonedds
   - mkdir cyclonedds/build
   - cd cyclonedds/build
-  - conan install -b missing -s arch=${ARCH} -s build_type=${BUILD_TYPE} ..
+  #- conan install -b missing -s arch=${ARCH} -s build_type=${BUILD_TYPE} ..
   - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
           -DCMAKE_INSTALL_PREFIX=$(pwd)/install
           -DUSE_SANITIZER=${SANITIZER}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,150 @@
+#
+# Copyright(c) 2020 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+cmake_minimum_required(VERSION 3.7)
+project(CycloneDDS-CXX VERSION 0.1.0 LANGUAGES C CXX)
+
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
+
+# Conan
+if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake" AND NOT CONAN_DEPENDENCIES)
+  include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+  if(APPLE)
+    # By default Conan strips all RPATHs (see conanbuildinfo.cmake), which
+    # causes tests to fail as the executables cannot find the library target.
+    # By setting KEEP_RPATHS, Conan does not set CMAKE_SKIP_RPATH and the
+    # resulting binaries still have the RPATH information. This is fine because
+    # CMake will strip the build RPATH information in the install step.
+    #
+    # NOTE:
+    # Conan's default approach is to use the "imports" feature, which copies
+    # all the dependencies into the bin directory. Of course, this doesn't work
+    # quite that well for libraries generated in this Project (see Conan
+    # documentation).
+    #
+    # See the links below for more information.
+    # https://github.com/conan-io/conan/issues/337
+    # https://docs.conan.io/en/latest/howtos/manage_shared_libraries/rpaths.html
+    # https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/RPATH-handling
+    conan_basic_setup(KEEP_RPATHS)
+  else()
+    conan_basic_setup()
+  endif()
+  conan_define_targets()
+endif()
+
+# By default don't treat warnings as errors, else anyone building it with a
+# different compiler that just happens to generate a warning, as well as
+# anyone adding or modifying something and making a small mistake would run
+# into errors.  CI builds can be configured differently.
+option(WERROR "Treat compiler warnings as errors." OFF)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  add_compile_options(/W3)
+  if(WERROR)
+    add_compile_options(/WX)
+  endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
+       CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+  add_compile_options(
+    -Wall -Wextra -Wconversion -Wstrict-prototypes
+    -Wunused -Winfinite-recursion -Wassign-enum -Wcomma -Wdocumentation
+    -Wconditional-uninitialized -Wshadow)
+  if(WERROR)
+    add_compile_options(-Werror)
+  endif()
+  if(CMAKE_GENERATOR STREQUAL "Ninja")
+    add_compile_options(-Xclang -fcolor-diagnostics)
+  endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  add_compile_options(
+    -Wall -Wextra -Wconversion)
+  if(WERROR)
+    add_compile_options(-Werror)
+  endif()
+  if(CMAKE_GENERATOR STREQUAL "Ninja")
+    add_compile_options(-fdiagnostics-color=always)
+  endif()
+endif()
+
+if(CMAKE_GENERATOR STREQUAL "Xcode")
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_EMPTY_BODY YES)
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_SHADOW YES)
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_BOOL_CONVERSION YES)
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_CONSTANT_CONVERSION YES)
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_64_TO_32_BIT_CONVERSION YES)
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_ENUM_CONVERSION YES)
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_FLOAT_CONVERSION YES)
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_INT_CONVERSION YES)
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_NON_LITERAL_NULL_CONVERSION YES)
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_IMPLICIT_SIGN_CONVERSION YES)
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_INFINITE_RECURSION YES)
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED YES)
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_ABOUT_RETURN_TYPE YES)
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_MISSING_PARENTHESES YES)
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS YES)
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_ABOUT_MISSING_NEWLINE YES)
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_ASSIGN_ENUM YES)
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_SEMICOLON_BEFORE_METHOD_BODY YES)
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_SIGN_COMPARE YES)
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_STRICT_PROTOTYPES YES)
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_COMMA YES)
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION YES)
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_UNINITIALIZED_AUTOS YES_AGGRESSIVE)
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_UNUSED_FUNCTION YES)
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_UNUSED_LABEL YES)
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_UNUSED_PARAMETER YES)
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_UNUSED_VALUE YES)
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_UNUSED_VARIABLE YES)
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_DOCUMENTATION_COMMENTS YES)
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_ABOUT_MISSING_PROTOTYPES YES)
+endif()
+
+if(CMAKE_VERSION VERSION_LESS 3.13)
+  macro(add_link_options)
+    link_libraries(${ARGV})
+  endmacro()
+endif()
+
+# Make it easy to enable Clang and GCC analyzers
+if(USE_SANITIZER)
+  string(REGEX REPLACE " " "" USE_SANITIZER "${USE_SANITIZER}")
+  string(REGEX REPLACE "[,;]+" ";" USE_SANITIZER "${USE_SANITIZER}")
+  foreach(san ${USE_SANITIZER})
+    if(san STREQUAL "address")
+      add_compile_options("-fno-omit-frame-pointer")
+      add_link_options("-fno-omit-frame-pointer")
+    endif()
+    if(san AND NOT san STREQUAL "none")
+      message(STATUS "Enabling sanitizer: ${san}")
+      add_compile_options("-fsanitize=${san}")
+      add_link_options("-fsanitize=${san}")
+    endif()
+  endforeach()
+endif()
+
+# Build all executables and libraries into the top-level /bin and /lib folders.
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+
+option(BUILD_DOCS "Build documentation." OFF)
+# By default building the testing tree is enabled by including CTest, but
+# since it is not required to build the project, switch to off by default.
+option(BUILD_TESTING "Build the testing tree." OFF)
+
+include(GNUInstallDirs)
+include(CTest)
+
+add_subdirectory(src)
+if(BUILD_DOCS)
+  add_subdirectory(docs)
+endif()

--- a/cmake/Modules/FindSphinx.cmake
+++ b/cmake/Modules/FindSphinx.cmake
@@ -1,0 +1,331 @@
+#
+# Copyright(c) 2019 Jeroen Koekkoek
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+include(FindPackageHandleStandardArgs)
+
+macro(_Sphinx_find_executable _exe)
+  string(TOUPPER "${_exe}" _uc)
+  # sphinx-(build|quickstart)-3 x.x.x
+  # FIXME: This works on Fedora (and probably most other UNIX like targets).
+  #        Windows targets and PIP installs might need some work.
+  find_program(
+    SPHINX_${_uc}_EXECUTABLE
+    NAMES "sphinx-${_exe}-3" "sphinx-${_exe}" "sphinx-${_exe}.exe")
+
+  if(SPHINX_${_uc}_EXECUTABLE)
+    execute_process(
+      COMMAND "${SPHINX_${_uc}_EXECUTABLE}" --version
+      RESULT_VARIABLE _result
+      OUTPUT_VARIABLE _output
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(_result EQUAL 0 AND _output MATCHES " v?([0-9]+\\.[0-9]+\\.[0-9]+)$")
+      set(SPHINX_${_uc}_VERSION "${CMAKE_MATCH_1}")
+    endif()
+
+    if(NOT TARGET Sphinx::${_exe})
+      add_executable(Sphinx::${_exe} IMPORTED GLOBAL)
+      set_target_properties(Sphinx::${_exe} PROPERTIES
+        IMPORTED_LOCATION "${SPHINX_${_uc}_EXECUTABLE}")
+    endif()
+    set(Sphinx_${_exe}_FOUND TRUE)
+  else()
+    set(Sphinx_${_exe}_FOUND FALSE)
+  endif()
+  unset(_uc)
+endmacro()
+
+macro(_Sphinx_find_extension _ext)
+  if(_SPHINX_PYTHON_EXECUTABLE)
+    execute_process(
+      COMMAND ${_SPHINX_PYTHON_EXECUTABLE} -c "import ${_ext}"
+      RESULT_VARIABLE _result)
+    if(_result EQUAL 0)
+      set(Sphinx_${_ext}_FOUND TRUE)
+    else()
+      set(Sphinx_${_ext}_FOUND FALSE)
+    endif()
+  elseif(CMAKE_HOST_WIN32 AND SPHINX_BUILD_EXECUTABLE)
+    # script-build on Windows located under (when PIP is used):
+    # C:/Program Files/PythonXX/Scripts
+    # C:/Users/username/AppData/Roaming/Python/PythonXX/Sripts
+    #
+    # Python modules are installed under:
+    # C:/Program Files/PythonXX/Lib
+    # C:/Users/username/AppData/Roaming/Python/PythonXX/site-packages
+    #
+    # To verify a given module is installed, use the Python base directory
+    # and test if either Lib/module.py or site-packages/module.py exists.
+    get_filename_component(_dirname "${SPHINX_BUILD_EXECUTABLE}" DIRECTORY)
+    get_filename_component(_dirname "${_dirname}" DIRECTORY)
+    if(IS_DIRECTORY "${_dirname}/Lib/${_ext}" OR
+       IS_DIRECTORY "${_dirname}/site-packages/${_ext}")
+      set(Sphinx_${_ext}_FOUND TRUE)
+    else()
+      set(Sphinx_${_ext}_FOUND FALSE)
+    endif()
+  endif()
+endmacro()
+
+#
+# Find sphinx-build and sphinx-quickstart.
+#
+_Sphinx_find_executable(build)
+_Sphinx_find_executable(quickstart)
+
+#
+# Verify both executables are part of the Sphinx distribution.
+#
+if(SPHINX_BUILD_EXECUTABLE AND SPHINX_QUICKSTART_EXECUTABLE)
+  if(NOT SPHINX_BUILD_VERSION STREQUAL SPHINX_QUICKSTART_VERSION)
+    message(FATAL_ERROR "Versions for sphinx-build (${SPHINX_BUILD_VERSION}) "
+                        "and sphinx-quickstart (${SPHINX_QUICKSTART_VERSION}) "
+                        "do not match")
+  endif()
+endif()
+
+#
+# To verify the required Sphinx extensions are available, the right Python
+# installation must be queried (2 vs 3). Of course, this only makes sense on
+# UNIX-like systems.
+#
+if(NOT CMAKE_HOST_WIN32 AND SPHINX_BUILD_EXECUTABLE)
+  file(READ "${SPHINX_BUILD_EXECUTABLE}" _contents)
+  if(_contents MATCHES "^#!([^\n]+)")
+    string(STRIP "${CMAKE_MATCH_1}" _shebang)
+    if(EXISTS "${_shebang}")
+      set(_SPHINX_PYTHON_EXECUTABLE "${_shebang}")
+    endif()
+  endif()
+endif()
+
+foreach(_comp IN LISTS Sphinx_FIND_COMPONENTS)
+  if(_comp STREQUAL "build")
+    # Do nothing, sphinx-build is always required.
+  elseif(_comp STREQUAL "quickstart")
+    # Do nothing, sphinx-quickstart is optional, but looked up by default.
+  elseif(_comp STREQUAL "breathe")
+    _Sphinx_find_extension(${_comp})
+  else()
+    message(WARNING "${_comp} is not a valid or supported Sphinx extension")
+    set(Sphinx_${_comp}_FOUND FALSE)
+    continue()
+  endif()
+endforeach()
+
+find_package_handle_standard_args(
+  Sphinx
+  VERSION_VAR SPHINX_BUILD_VERSION
+  REQUIRED_VARS SPHINX_BUILD_EXECUTABLE SPHINX_BUILD_VERSION
+  HANDLE_COMPONENTS)
+
+
+# Generate a conf.py template file using sphinx-quickstart.
+#
+# sphinx-quickstart allows for quiet operation and a lot of settings can be
+# specified as command line arguments, therefore its not required to parse the
+# generated conf.py.
+function(_Sphinx_generate_confpy _target _cachedir)
+  if(NOT TARGET Sphinx::quickstart)
+    message(FATAL_ERROR "sphinx-quickstart is not available, needed by"
+                        "sphinx_add_docs for target ${_target}")
+  endif()
+
+  if(NOT DEFINED SPHINX_PROJECT)
+    set(SPHINX_PROJECT ${PROJECT_NAME})
+  endif()
+
+  if(NOT DEFINED SPHINX_AUTHOR)
+    set(SPHINX_AUTHOR "${SPHINX_PROJECT} committers")
+  endif()
+
+  if(NOT DEFINED SPHINX_COPYRIGHT)
+    string(TIMESTAMP "%Y, ${SPHINX_AUTHOR}" SPHINX_COPYRIGHT)
+  endif()
+
+  if(NOT DEFINED SPHINX_VERSION)
+    set(SPHINX_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
+  endif()
+
+  if(NOT DEFINED SPHINX_RELEASE)
+    set(SPHINX_RELEASE "${PROJECT_VERSION}")
+  endif()
+
+  if(NOT DEFINED SPHINX_LANGUAGE)
+    set(SPHINX_LANGUAGE "en")
+  endif()
+
+  if(NOT DEFINED SPHINX_MASTER)
+    set(SPHINX_MASTER "index")
+  endif()
+
+  set(_known_exts autodoc doctest intersphinx todo coverage imgmath mathjax
+                  ifconfig viewcode githubpages)
+
+  if(DEFINED SPHINX_EXTENSIONS)
+    foreach(_ext ${SPHINX_EXTENSIONS})
+      set(_is_known_ext FALSE)
+      foreach(_known_ext ${_known_exsts})
+        if(_ext STREQUAL _known_ext)
+          set(_opts "${opts} --ext-${_ext}")
+          set(_is_known_ext TRUE)
+          break()
+        endif()
+      endforeach()
+      if(NOT _is_known_ext)
+        if(_exts)
+          set(_exts "${_exts},${_ext}")
+        else()
+          set(_exts "${_ext}")
+        endif()
+      endif()
+    endforeach()
+  endif()
+
+  if(_exts)
+    set(_exts "--extensions=${_exts}")
+  endif()
+
+  set(_templatedir "${CMAKE_CURRENT_BINARY_DIR}/${_target}.template")
+  file(MAKE_DIRECTORY "${_templatedir}")
+  execute_process(
+    COMMAND "${SPHINX_QUICKSTART_EXECUTABLE}"
+              -q --no-makefile --no-batchfile
+              -p "${SPHINX_PROJECT}"
+              -a "${SPHINX_AUTHOR}"
+              -v "${SPHINX_VERSION}"
+              -r "${SPHINX_RELEASE}"
+              -l "${SPHINX_LANGUAGE}"
+              --master "${SPHINX_MASTER}"
+              ${_opts} ${_exts} "${_templatedir}"
+    RESULT_VARIABLE _result
+    OUTPUT_QUIET)
+
+  if(_result EQUAL 0 AND EXISTS "${_templatedir}/conf.py")
+    file(COPY "${_templatedir}/conf.py" DESTINATION "${_cachedir}")
+  endif()
+
+  file(REMOVE_RECURSE "${_templatedir}")
+
+  if(NOT _result EQUAL 0 OR NOT EXISTS "${_cachedir}/conf.py")
+    message(FATAL_ERROR "Sphinx configuration file not generated for "
+                        "target ${_target}")
+  endif()
+endfunction()
+
+function(sphinx_add_docs _target)
+  set(_opts)
+  set(_single_opts BUILDER OUTPUT_DIRECTORY SOURCE_DIRECTORY)
+  set(_multi_opts BREATHE_PROJECTS)
+  cmake_parse_arguments(_args "${_opts}" "${_single_opts}" "${_multi_opts}" ${ARGN})
+
+  unset(SPHINX_BREATHE_PROJECTS)
+
+  if(NOT _args_BUILDER)
+    message(FATAL_ERROR "Sphinx builder not specified for target ${_target}")
+  elseif(NOT _args_SOURCE_DIRECTORY)
+    message(FATAL_ERROR "Sphinx source directory not specified for target ${_target}")
+  else()
+    if(NOT IS_ABSOLUTE "${_args_SOURCE_DIRECTORY}")
+      get_filename_component(_sourcedir "${_args_SOURCE_DIRECTORY}" ABSOLUTE)
+    else()
+      set(_sourcedir "${_args_SOURCE_DIRECTORY}")
+    endif()
+    if(NOT IS_DIRECTORY "${_sourcedir}")
+      message(FATAL_ERROR "Sphinx source directory '${_sourcedir}' for"
+                          "target ${_target} does not exist")
+    endif()
+  endif()
+
+  set(_builder "${_args_BUILDER}")
+  if(_args_OUTPUT_DIRECTORY)
+    set(_outputdir "${_args_OUTPUT_DIRECTORY}")
+  else()
+    set(_outputdir "${CMAKE_CURRENT_BINARY_DIR}/${_target}")
+  endif()
+
+
+  if(_args_BREATHE_PROJECTS)
+    if(NOT Sphinx_breathe_FOUND)
+      message(FATAL_ERROR "Sphinx extension 'breathe' is not available. Needed"
+                          "by sphinx_add_docs for target ${_target}")
+    endif()
+    list(APPEND SPHINX_EXTENSIONS breathe)
+
+    foreach(_doxygen_target ${_args_BREATHE_PROJECTS})
+      if(TARGET ${_doxygen_target})
+        list(APPEND _depends ${_doxygen_target})
+
+        # Doxygen targets are supported. Verify that a Doxyfile exists.
+        get_target_property(_dir ${_doxygen_target} BINARY_DIR)
+        set(_doxyfile "${_dir}/Doxyfile.${_doxygen_target}")
+        if(NOT EXISTS "${_doxyfile}")
+          message(FATAL_ERROR "Target ${_doxygen_target} is not a Doxygen"
+                              "target, needed by sphinx_add_docs for target"
+                              "${_target}")
+        endif()
+
+        # Read the Doxyfile, verify XML generation is enabled and retrieve the
+        # output directory.
+        file(READ "${_doxyfile}" _contents)
+        if(NOT _contents MATCHES "GENERATE_XML *= *YES")
+          message(FATAL_ERROR "Doxygen target ${_doxygen_target} does not"
+                              "generate XML, needed by sphinx_add_docs for"
+                              "target ${_target}")
+        elseif(_contents MATCHES "OUTPUT_DIRECTORY *= *([^ ][^\n]*)")
+          string(STRIP "${CMAKE_MATCH_1}" _dir)
+          set(_name "${_doxygen_target}")
+          set(_dir "${_dir}/xml")
+        else()
+          message(FATAL_ERROR "Cannot parse Doxyfile generated by Doxygen"
+                              "target ${_doxygen_target}, needed by"
+                              "sphinx_add_docs for target ${_target}")
+        endif()
+      elseif(_doxygen_target MATCHES "([^: ]+) *: *(.*)")
+        set(_name "${CMAKE_MATCH_1}")
+        string(STRIP "${CMAKE_MATCH_2}" _dir)
+      endif()
+
+      if(_name AND _dir)
+        if(_breathe_projects)
+          set(_breathe_projects "${_breathe_projects}, \"${_name}\": \"${_dir}\"")
+        else()
+          set(_breathe_projects "\"${_name}\": \"${_dir}\"")
+        endif()
+        if(NOT _breathe_default_project)
+          set(_breathe_default_project "${_name}")
+        endif()
+      endif()
+    endforeach()
+  endif()
+
+  set(_cachedir "${CMAKE_CURRENT_BINARY_DIR}/${_target}.cache")
+  file(MAKE_DIRECTORY "${_cachedir}")
+  file(MAKE_DIRECTORY "${_cachedir}/_static")
+
+  _Sphinx_generate_confpy(${_target} "${_cachedir}")
+
+  if(_breathe_projects)
+    file(APPEND "${_cachedir}/conf.py"
+      "\nbreathe_projects = { ${_breathe_projects} }"
+      "\nbreathe_default_project = '${_breathe_default_project}'")
+  endif()
+
+  add_custom_target(
+    ${_target} ALL
+    COMMAND ${SPHINX_BUILD_EXECUTABLE}
+              -b ${_builder}
+              -d "${CMAKE_CURRENT_BINARY_DIR}/${_target}.cache/_doctrees"
+              -c "${CMAKE_CURRENT_BINARY_DIR}/${_target}.cache"
+              "${_sourcedir}"
+              "${_outputdir}"
+    DEPENDS ${_depends})
+endfunction()
+

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+# Copyright(c) 2020 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+find_package(Sphinx REQUIRED breathe)
+
+sphinx_add_docs(
+  docs
+  BREATHE_PROJECTS ddscxx_api_docs
+  BUILDER html
+  SOURCE_DIRECTORY manual)
+
+install(
+  DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/docs"
+  DESTINATION "${CMAKE_INSTALL_DOCDIR}/manual"
+  COMPONENT dev)

--- a/docs/manual/ddscxx.rst
+++ b/docs/manual/ddscxx.rst
@@ -1,0 +1,16 @@
+..
+   Copyright(c) 2020 ADLINK Technology Limited and others
+
+   This program and the accompanying materials are made available under the
+   terms of the Eclipse Public License v. 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+   v. 1.0 which is available at
+   http://www.eclipse.org/org/documents/edl-v10.php.
+
+   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+Eclipse Cyclone DDS C++ API Reference
+=====================================
+
+.. doxygenindex::
+   :project: ddscxx_api_docs

--- a/docs/manual/index.rst
+++ b/docs/manual/index.rst
@@ -1,0 +1,28 @@
+..
+   Copyright(c) 2020 ADLINK Technology Limited and others
+
+   This program and the accompanying materials are made available under the
+   terms of the Eclipse Public License v. 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+   v. 1.0 which is available at
+   http://www.eclipse.org/org/documents/edl-v10.php.
+
+   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+.. Eclipse Cyclone DDS documentation master file
+
+Welcome to Eclipse Cyclone DDS's documentation!
+===============================================
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Contents
+
+   ddscxx
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,12 @@
+#
+# Copyright(c) 2020 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+add_subdirectory(ddscxx)

--- a/src/ddscxx/CMakeLists.txt
+++ b/src/ddscxx/CMakeLists.txt
@@ -1,0 +1,238 @@
+#
+# Copyright(c) 2020 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+include(GenerateExportHeader)
+
+find_package(CycloneDDS REQUIRED)
+
+set(sources
+    src/dds/core/Duration.cpp
+    src/dds/core/Exception.cpp
+    src/dds/core/Reference.cpp
+    src/dds/core/Time.cpp
+    src/dds/core/policy/CorePolicy.cpp
+    src/dds/core/status/State.cpp
+    src/dds/domain/discovery.cpp
+    src/dds/domain/find.cpp
+    src/dds/pub/pubdiscovery.cpp
+    src/dds/sub/subdiscovery.cpp
+    src/dds/sub/subfind.cpp
+    src/dds/sub/status/DataState.cpp
+    src/org/eclipse/cyclonedds/core/Mutex.cpp
+    src/org/eclipse/cyclonedds/core/ObjectDelegate.cpp
+    src/org/eclipse/cyclonedds/core/DDScObjectDelegate.cpp
+    src/org/eclipse/cyclonedds/core/ObjectSet.cpp
+    src/org/eclipse/cyclonedds/core/EntityDelegate.cpp
+    src/org/eclipse/cyclonedds/core/ReportUtils.cpp
+    src/org/eclipse/cyclonedds/core/ListenerDispatcher.cpp
+    src/org/eclipse/cyclonedds/core/InstanceHandleDelegate.cpp
+    src/org/eclipse/cyclonedds/core/EntitySet.cpp
+    src/org/eclipse/cyclonedds/core/MiscUtils.cpp
+    src/org/eclipse/cyclonedds/core/cond/ConditionDelegate.cpp
+    src/org/eclipse/cyclonedds/core/cond/GuardConditionDelegate.cpp
+    src/org/eclipse/cyclonedds/core/cond/StatusConditionDelegate.cpp
+    src/org/eclipse/cyclonedds/core/cond/WaitSetDelegate.cpp
+    src/org/eclipse/cyclonedds/core/policy/PolicyDelegate.cpp
+    src/org/eclipse/cyclonedds/domain/Domain.cpp
+    src/org/eclipse/cyclonedds/domain/DomainWrap.cpp
+    src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
+    src/org/eclipse/cyclonedds/domain/DomainParticipantRegistry.cpp
+    src/org/eclipse/cyclonedds/domain/qos/DomainParticipantQosDelegate.cpp
+    src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
+    src/org/eclipse/cyclonedds/pub/PublisherDelegate.cpp
+    src/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.cpp
+    src/org/eclipse/cyclonedds/pub/qos/PublisherQosDelegate.cpp
+    src/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.cpp
+    src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
+    src/org/eclipse/cyclonedds/sub/SubscriberDelegate.cpp
+    src/org/eclipse/cyclonedds/sub/BuiltinSubscriberDelegate.cpp
+    src/org/eclipse/cyclonedds/sub/QueryDelegate.cpp
+    src/org/eclipse/cyclonedds/sub/cond/ReadConditionDelegate.cpp
+    src/org/eclipse/cyclonedds/sub/cond/QueryConditionDelegate.cpp
+    src/org/eclipse/cyclonedds/sub/qos/SubscriberQosDelegate.cpp
+    src/org/eclipse/cyclonedds/topic/find.cpp
+    src/org/eclipse/cyclonedds/topic/AnyTopicDelegate.cpp
+    src/org/eclipse/cyclonedds/topic/FilterDelegate.cpp
+    src/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.cpp
+    src/org/eclipse/cyclonedds/topic/qos/TopicQosDelegate.cpp)
+
+if(BUILD_SHARED_LIBS OR NOT DEFINED BUILD_SHARED_LIBS)
+  add_library(ddscxx SHARED ${sources})
+else()
+  add_library(ddscxx ${sources})
+endif()
+
+# SOVERSION should increase on incompatible ABI change
+set_target_properties(ddscxx PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+
+# Create a pseudo-target that other targets (i.e. examples, tests) can depend
+# on and can also be provided as import-target by a package-file when building
+# those targets outside the regular Cyclone build-tree (i.e. the installed tree)
+add_library(${CMAKE_PROJECT_NAME}::ddscxx ALIAS ddscxx)
+
+target_include_directories(
+  ddscxx
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ddscxx>)
+
+set_property(TARGET ddscxx PROPERTY CXX_STANDARD 11)
+target_link_libraries(ddscxx PUBLIC CycloneDDS::ddsc)
+
+generate_export_header(
+  ddscxx
+  BASE_NAME OMG_DDS_API_DETAIL
+  EXPORT_MACRO_NAME OMG_DDS_API_DETAIL
+  EXPORT_FILE_NAME "include/dds/core/detail/export.hpp")
+
+install(
+  TARGETS ddscxx
+  EXPORT "${CMAKE_PROJECT_NAME}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT lib
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib)
+
+install(
+  DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/dds"
+            "${CMAKE_CURRENT_BINARY_DIR}/include/dds"
+            "${CMAKE_CURRENT_SOURCE_DIR}/include/org"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ddscxx"
+  COMPONENT dev)
+
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()
+
+# Preprocess headers to make the documentation more readable. The steps
+# involved have been converted from a Python script into CMake logic. This is
+# better solved in another way, but it will have to do for now.
+if(BUILD_DOCS)
+  set(input_dir "${CMAKE_CURRENT_SOURCE_DIR}/include")
+  set(output_dir "${CMAKE_CURRENT_BINARY_DIR}/include")
+  file(GLOB_RECURSE headers RELATIVE "${input_dir}" CONFIGURE_DEPENDS "include/*.hpp")
+  foreach(header ${headers})
+    get_filename_component(directory ${header} DIRECTORY)
+    get_filename_component(filename ${header} NAME)
+    # Templates are documented. e.g. dds/sub/TQuery.hpp contains the code
+    # and documentation for a the dds::sub::Query class which is a typedef of
+    # dds::sub::detail::Query, which itself is a typedef to the delegate that
+    # implements the template. This must be hidden from the user, so replace
+    # the original header by that of the template and replace the typenames in
+    # the source file.
+    if(("${filename}" MATCHES "^T") AND
+       (NOT "${filename}" MATCHES "^(Topic|Time|Type)"))
+      string(SUBSTRING "${filename}" 1 -1 non_template)
+      list(APPEND rename "${directory}/${filename}:${directory}/${non_template}")
+      if(EXISTS "${input_dir}/${directory}/${non_template}")
+        list(APPEND remove "${directory}/${non_template}")
+      endif()
+    # Use file located in detail for Qoses (filename ends with Qos.hpp).
+    # Except TEntityQos.hpp, EntityQos container is not a real Qos and must
+    # not be treated as such.
+    elseif((filename MATCHES "Qos.hpp$") AND
+           (EXISTS "${input_dir}/${directory}/detail/${filename}"))
+      list(APPEND remove "${directory}/${filename}")
+      list(APPEND rename "${directory}/detail/${filename}:${header}")
+    endif()
+  endforeach()
+
+  foreach(header ${remove})
+    list(REMOVE_ITEM headers ${header})
+  endforeach()
+
+  # Template class names that must be replaced.
+  set(templates
+    "TBuiltinTopic" "TDomainParticipant" "TEntity" "TInstanceHandle"
+    "TQosProvider" "TCondition" "TGuardCondtion" "TStatusCondition"
+    "TWaitSet" "TCorePolicy" "TQosPolicy" "TStatus" "TDomainParticipant"
+    "TCoherentSet" "TPublisher" "TSuspendedPublication" "TCoherentAccess"
+    "TDataReader" "TGenerationCount" "TQuery" "TRank" "TSample" "TSubscriber"
+    "TReadCondition" "TFilter" "TGuardCondition" "THolder" "TDHolder"
+    "TAnyDataReader" "TAnyTopic" "TAnyDataWriter"
+    # XTypes
+    "TAnnotation" "TCollectionTypes" "TDynamic" "TMember" "TStruct" "TType"
+    "TCollectionType" "TExtensibilityAnnotation" "TidAnnotation"
+    "TKeyAnnotation" "TPrimitiveType" "TSequenceType" "TStringType"
+    "TUnionForwardDeclaration" "TVerbatimAnnotation" "TBitBoundAnnotation"
+    "TBitsetAnnotation" "TMapType" "TMustUnderstandAnnotation"
+    "TNestedAnnotation" "TIdAnnotation" "TUnionForwardDeclaration"
+    # QoS
+    "TUserData" "TGroupData" "TTopic" "TTransportPriority" "TLifespan"
+    "TDeadline" "TLatencyBudget" "TTimeBasedFilter" "TPartition" "TOwnership"
+    "TWriterDataLifecycle" "TReaderDataLifecycle" "TDurability" "TPresentation"
+    "TReliability" "TDestinationOrder" "THistory" "TResourceLimits"
+    "TLiveliness" "TDurabilityService" "TShare" "TProductData"
+    "TSubscriptionKey" "TDataRepresentation" "TRequestedDeadlineMissedStatus"
+    "TInconsistentTopicStatus" "TOffered" "TRequested"
+    # TBuiltinStuff
+    "TSubscription" "TPublication" "TParticipant" "TTopicBuiltinTopicData"
+    "TCM" "TBuiltinTopicTypes" "TBytesTopicType" "TKeyedBytesTopicType"
+    "TKeyedStringTopicType" "TStringTopicType"
+    # Streams
+    "TStreamDataReader" "TStreamDataWriter" "TCorePolicy" "TStreamSample"
+    "TStreamFlush")
+
+  # Sequences with DELAGATE that must be removed.
+  set(delegates
+    "template <typename DELEGATE>" "<typename DELEGATE>" "<D>" "<DELEGATE>"
+    "< DELEGATE >" "template <typename D>" "< DELEGATE<T> >"
+    ", template <typename Q> class DELEGATE" ", DELEGATE")
+
+  foreach(input ${headers})
+    set(output "${input}")
+    foreach(fromto ${rename})
+      if(fromto MATCHES "^${input}:")
+        string(REPLACE "${input}:" "" output "${fromto}")
+        break()
+      endif()
+    endforeach()
+
+    file(READ "${input_dir}/${input}" content)
+
+    # Rename the struct to the typedef and remove the typedef from the sources
+    # for readability.
+    set(safe_enum "typedef +dds::core::safe_enum<([a-zA-Z0-9_]+)> +([a-zA-Z0-9]+)")
+    string(REGEX MATCHALL "${safe_enum};" typedefs "${content}")
+    foreach(typedef ${typedefs})
+      string(REGEX REPLACE "${safe_enum}" "\\1" struct_name "${typedef}")
+      string(REGEX REPLACE "${safe_enum}" "\\2" typedef_name "${typedef}")
+      string(REPLACE "${struct_name}" "${typedef_name}" content "${content}")
+      string(REGEX REPLACE "${safe_enum};" "" content "${content}")
+    endforeach()
+
+    foreach(search ${templates})
+      string(SUBSTRING ${search} 1 -1 replace)
+      string(REPLACE ${search} ${replace} content "${content}")
+    endforeach()
+    foreach(search ${delegates})
+      string(REPLACE ${search} "" content "${content}")
+    endforeach()
+    file(WRITE "${output_dir}/${output}" "${content}")
+    list(APPEND input_files "${output_dir}/${output}")
+  endforeach()
+
+  find_package(Doxygen REQUIRED)
+  set(DOXYGEN_PROJECT_NAME "Eclipse CycloneDDS C++ API Reference Guide")
+  set(DOXYGEN_STRIP_FROM_PATH "${CMAKE_CURRENT_BINARY_DIR}/include")
+  set(DOXYGEN_EXCLUDE_PATTERNS
+    "*/include/dds/*/detail/*"
+    "*/include/org/eclipse/*"
+    "*/dds/core/xtypes/*")
+  set(DOXYGEN_GENERATE_HTML YES)
+  set(DOXYGEN_GENERATE_XML YES)
+  set(DOXYGEN_MACRO_EXPANSION YES)
+  set(DOXYGEN_PREDEFINED
+    "DOXYGEN_FOR_ISOCPP=1"
+    "OSPL_ISOCPP_IMPL_API="
+    "OMG_DDS_API=")
+  doxygen_add_docs(ddscxx_api_docs ${input_files})
+endif()

--- a/src/ddscxx/include/dds/core/detail/array.hpp
+++ b/src/ddscxx/include/dds/core/detail/array.hpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef CYCLONEDDS_DDS_CORE_DETAIL_ARRAY_HPP_
+#define CYCLONEDDS_DDS_CORE_DETAIL_ARRAY_HPP_
+
+#include <dds/core/detail/macros.hpp>
+
+/* Compiling explicitly w/ C++ 11 support */
+#if defined(OSPL_USE_CXX11)
+#  include <array>
+#  define OSPL_CXX11_STD_MODULE ::std
+/* Compiling to use Tech Report 1 headers */
+#elif defined(OSPL_USE_TR1)
+#  ifdef _MSC_VER
+#    include <array>
+#  else
+#    include <tr1/array>
+#  endif
+#  define OSPL_CXX11_STD_MODULE ::std::tr1
+/* Compiling with boost */
+#elif defined(OSPL_USE_BOOST)
+#  include <boost/array.hpp>
+#  define OSPL_CXX11_STD_MODULE ::boost
+#endif
+
+
+namespace dds
+{
+namespace core
+{
+namespace detail
+{
+using OSPL_CXX11_STD_MODULE::array;
+}
+}
+}
+
+#endif /* CYCLONEDDS_DDS_CORE_DETAIL_ARRAY_HPP_ */

--- a/src/ddscxx/include/dds/core/types.hpp
+++ b/src/ddscxx/include/dds/core/types.hpp
@@ -57,7 +57,7 @@ class OMG_DDS_API null_type { };
  *     // The participant is not yet properly created.
  *     // Using it now will trigger the dds::core::NullReferenceError exception.
  * }
- * @encode
+ * @endcode
  */
 extern const null_type OMG_DDS_API null;
 


### PR DESCRIPTION
This PR adds a missing header `dds/core/detail/array.hpp` and build instructions. I've chosen to switch to Ubuntu 18.04 (as opposed to 16.04, which is used by Eclipse Cyclone DDS) and use both GCC 10 and Clang 10. I've also included the newest macOS target and a Windows target. The `.travis.yml` file is a little cleaner that the one in Eclipse Cyclone DDS (notice `GENERATOR` and `BUILD_TOOL_OPTIONS` exported in each platforms specific section), I'm planning to port those changes back to the example. Other than that, this PR adds support for building documentation. I've ported the `predoxygen.py` script in @ThijsSassen's [cdds-cxx](https://github.com/thijssassen/cdds-cxx) repository to CMake. I ported the script so that there's at least some documentation and we don't introduce yet another dependency, but I don't particularly like the logic (both that of the original script or the CMake code). The GCC 10 release build fails, but I'm under the impression that the warning is a false-positive. I (or someone) else can have a look after these changes have been merged, so that there's builds available to validate. Next up would be to add tests and examples... @eboasson, if you can find some time to have a quick look... I'm hoping @e-hndrks is willing to do a full review(?)