### PR TITLE
Add CMake package confige, example and update README.md

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,8 +141,37 @@ option(BUILD_DOCS "Build documentation." OFF)
 # since it is not required to build the project, switch to off by default.
 option(BUILD_TESTING "Build the testing tree." OFF)
 
+include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 include(CTest)
+
+set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+
+# Generate <Package>Config.cmake
+configure_package_config_file(
+  "PackageConfig.cmake.in"
+  "${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_CMAKEDIR}")
+
+# Generate <Package>Version.cmake
+write_basic_package_version_file(
+  "${PROJECT_NAME}Version.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion)
+
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Version.cmake"
+  DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
+  COMPONENT dev)
+
+# Generate <Package>Targets.cmake
+install(
+  EXPORT ${PROJECT_NAME}
+  FILE "${PROJECT_NAME}Targets.cmake"
+  NAMESPACE "${PROJECT_NAME}::"
+  DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
+  COMPONENT dev)
 
 add_subdirectory(src)
 if(BUILD_DOCS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,9 @@ option(BUILD_DOCS "Build documentation." OFF)
 # By default building the testing tree is enabled by including CTest, but
 # since it is not required to build the project, switch to off by default.
 option(BUILD_TESTING "Build the testing tree." OFF)
+# Disable building the examples by default until the Idlpp-cxx has been
+# deprecated.
+option(BUILD_EXAMPLES "Build examples." OFF)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
@@ -174,6 +177,9 @@ install(
   COMPONENT dev)
 
 add_subdirectory(src)
+if(BUILD_EXAMPLES)
+  add_subdirectory(examples)
+endif()
 if(BUILD_DOCS)
   add_subdirectory(docs)
 endif()

--- a/PackageConfig.cmake.in
+++ b/PackageConfig.cmake.in
@@ -1,0 +1,18 @@
+#
+# Copyright(c) 2020 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+@PACKAGE_INIT@
+
+find_package(CycloneDDS REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+
+check_required_components("@PROJECT_NAME@")

--- a/README.md
+++ b/README.md
@@ -1,92 +1,180 @@
-# CXX API for CycloneDDS
+# C++ binding for Eclipse Cyclone DDS
 
-This project provides a CXX API for [CycloneDDS](https://github.com/eclipse-cyclonedds/cyclonedds/)
+An implementation of the [ISO/IEC C++ PSM][1], or simply put, a C++ binding
+for [Eclipse Cyclone DDS][2]. Cyclone DDS is developed completely in the open
+as an Eclipse IoT project (see [eclipse-cyclone-dds][3]) with a growing list
+of [adopters][4] (if you're one of them, please add your [logo][5]). It is a
+tier-1 middleware for the Robot Operating System [ROS 2][6].
 
-[![Build Status](https://dev.azure.com/thijssassen/CXX-API/_apis/build/status/ThijsSassen.cdds-cxx?branchName=master)](https://dev.azure.com/thijssassen/CXX-API/_build/latest?definitionId=4&branchName=master)
-
-## Requirements for the CXX API
-
-In order to build the Idl compiler you need a Linux, Mac or Windows 10 machine with the following
-installed on your host:
-
-  * Git
-  * [Conan](https://conan.io/), this is needed to install build dependencies
-  * [CMake](https://cmake.org/download/), version 3.7 or later.  (Version 3.6 should work but you
-    will have to edit the ``cmake_minimum_required`` version.)
-  * [CycloneDDS](https://github.com/eclipse-cyclonedds/cyclonedds/)
-  * [CXX Idl compiler](https://github.com/ADLINK-IST/idlpp-cxx/)
+[1]: https://www.omg.org/spec/DDS-PSM-Cxx/
+[2]: https://github.com/eclipse-cyclonedds/cyclonedds/
+[3]: https://projects.eclipse.org/projects/iot.cyclonedds
+[4]: https://iot.eclipse.org/adopters/?#iot.cyclonedds
+[5]: https://github.com/EclipseFdn/iot.eclipse.org/issues/new?template=adopter_request.md
+[6]: https://index.ros.org/doc/ros2/
 
 
-## Building
+# Getting Started
 
-Building the CXX API, requires only a few simple steps. There are some small differences
-between Linux and macOS on the one hand, and Windows on the other. For Linux or macOS:
+## Building the Eclipse Cyclone DDS C++ binding
 
-    $ git clone https://github.com/ThijsSassen/cdds-cxx.git
+In order to build the C++ binding for Cyclone DDS you need a Linux, Mac or
+Windows 10 machine (or, with some caveats, a \*BSD, OpenIndiana one) with the
+following installed on your host:
+
+ * C and C++ compilers (most commonly GCC on Linux, Visual Studio on Windows,
+   Xcode on macOS);
+ * [Git](https://git-scm.com/) version control system;
+ * [CMake](https://cmake.org/download/), version 3.7 or later;
+ * [Eclipse Cyclone DDS](https://github.com/eclipse-cyclonedds/cyclonedds/)
+ * [CXX Idl compiler](https://github.com/ADLINK-IST/idlpp-cxx/)
+
+*Eclipse Cyclone DDS* and the *CXX Idl compiler* have dependencies of their
+own, most notably Java and Apache Maven. To build and install the respective
+projects, please consult their build instructions. Ensure both projects are
+installed into locations convenient for you by specifying
+`CMAKE_INSTALL_PREFIX`.
+
+> The *CXX Idl compiler* is a temporary dependency, a new IDL compiler for
+> both Eclipse Cyclone DDS and Eclipse Cyclone DDS CXX is in the works.
+
+To obtain the C++ binding for Cyclone DDS, do
+
+    $ git clone https://github.com/eclipse-cyclonedds/cyclonedds-cxx.git
+    $ cd cyclonedds-cxx
     $ mkdir build
+
+Depending on whether you want to develop applications using the C++ binding
+for Cyclone DDS or contribute to it you can follow different procedures.
+
+### For application developers
+
+To build and install the required libraries needed to develop your own
+applications using the C++ binding for Cyclone DDS requires a few simple
+steps. There are some small differences between Linux and macOS on the one
+hand, and Windows on the other. For Linux or macOS:
+
     $ cd build
-    $ cmake -DCMAKE_PREFIX_PATH="<idlpp-cxx install path>/lib/cmake/Idlpp-cxx;<CycloneDDS install path>/lib/cmake/CycloneDDS" <cmake-config_options> ..
+    $ cmake -DCMAKE_INSTALL_PREFIX=<install-location> \
+            -DCMAKE_PREFIX_PATH="<idlpp-cxx-install-location>;<cyclonedds-install-location>" \
+            ..
     $ cmake --build .
 
 and for Windows:
 
-    $ git clone https://github.com/ThijsSassen/cdds-cxx.git
-    $ mkdir build
     $ cd build
-    $ cmake -DCMAKE_PREFIX_PATH="<idlpp-cxx install path>\lib\cmake\Idlpp-cxx;<CycloneDDS install path>\lib\cmake\CycloneDDS" -G "<generator-name>" <cmake-config_options> ..
+    $ cmake -G "<generator-name>" \
+            -DCMAKE_INSTALL_PREFIX=<install-location> \
+            -DCMAKE_PREFIX_PATH="<idlpp-cxx-install-location>;<cyclonedds-install-location>" \
+            ..
     $ cmake --build .
 
-where you replace ``<generator-name>`` by one of the ways
-CMake [generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html) offer for
-generating build files.  For example, "Visual Studio 15 2017 Win64" would target a 64-bit build
-using Visual Studio 2017.
+where you should replace `<install-location>` by the directory under which you
+would like to install the C++ binding for Cyclone DDS and `<generator-name>`
+by one of the ways CMake [generators][6] offer for generating build files. For
+example, "Visual Studio 15 2017 Win64" would target a 64-bit build using
+Visual Studio 2017.
 
-The ``<cmake-config_options>`` can be ignored or replaced. A few of the most common options are:
--DCMAKE_INSTALL_PREFIX=``<install-location>``
--DCMAKE_BUILD_TYPE=Debug
--DBUILD_TESTING=ON, to enable testing
--DUSE_DOCS=1, to generate documentation
+To install it after a successful build, do:
 
-    $ cmake -DCMAKE_BUILD_TYPE=Debug ..
-
-
-## Packaging
-
-If you want to package the product, the config step and build step are slightly different compared
-to how it is normally build.
-
-The -DCMAKE_INSTALL_PREFIX=``<install-location>`` option should be added to the configuration,
-where the ``<install-location>`` is replaced by the directory under which you would like to
-install the Idl compiler.
-
-During the build step, you have to specify that you want to build the install target as well.
-
-
-This would make the build look like
-
-    $ mkdir build
-    $ cd build
-    $ cmake -DCMAKE_PREFIX_PATH="<idlpp-cxx install path>/lib/cmake/Idlpp-cxx;<CycloneDDS install path>/lib/cmake/CycloneDDS" -DCMAKE_INSTALL_PREFIX=<install-location>  ..
     $ cmake --build . --target install
 
-Don't forget the generator when building on Windows.
+Which will copy everything to:
 
-After the build, required files are copied to:
+ * `<install-location>/lib`
+ * `<install-location>/bin`
+ * `<install-location>/include/ddsc`
+ * `<install-location>/share/CycloneDDS-CXX`
 
-  * ``<install-location>/lib``
-  * ``<install-location>/share``
+Depending on the installation location you may need administrator privileges.
 
-The ``<install-location>`` directory is will be used to create the package(s).
+At this point you are ready to use Eclipse Cyclone DDS in your own projects.
 
-    $ cpack
+Note that the default build type is a release build with debug information
+included (RelWithDebInfo), which is generally the most convenient type of
+build to use from applications because of a good mix between performance and
+still being able to debug things. If you'd rather have a Debug or pure Release
+build, set `CMAKE_BUILD_TYPE` accordingly.
 
-Depending on the target, you now have packages.
+[6]: https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html
+
+### Contributing to Eclipse Cyclone DDS
+
+We very much welcome all contributions to the project, whether that is
+questions, examples, bug fixes, enhancements or improvements to the
+documentation, or anything else really. When considering contributing code,
+it might be good to know that build configurations for Travis CI and AppVeyor
+are present in the repository and that there is a test suite using CTest and
+Google Test that can be built locally if desired. To build it, set the cmake
+variable `BUILD_TESTING` to on when configuring, e.g.:
+
+    $ cd build
+    $ cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON ..
+    $ cmake --build .
+    $ ctest
+
+Such a build requires the presence of [Google Test][7]. You can install this
+yourself, or you can choose to instead rely on the [Conan][8] package manager
+that the CI build infrastructure also uses. In that case, install Conan and do:
+
+    $ conan install .. --build missing
+
+in the build directory prior to running `cmake`. This will automatically
+download and/or build Google Test.
+
+The Google Test Conan package is hosted in the Bincrafters Bintray repository.
+In case this repository was not added to your Conan remotes list yet (and the
+above mentioned install command failed because it could not find the
+Google Test package), you can add the Bintray repository by:
+
+    $ conan remote add <REMOTE> https://api.bintray.com/conan/bincrafters/public-conan
+
+Replace `<REMOTE>` with a name that identifies the repository (e.g. `bincrafters`).
+
+For Windows, depending on the generator, you might also need to add switches
+to select the architecture and build type, e.g.,
+
+    $ conan install -s arch=x86_64 -s build_type=Debug ..
+
+[7]: https://github.com/google/googletest
+[8]: https://conan.io/
 
 ## Documentation
 
-Documentation for the CXX API can be found [here](https://atolab.github.io/cdds-docs/api/cxx/index.html)
+The documentation is still rather limited, and at the moment only available in
+the sources (in the form of restructured text files in ``docs`` and Doxygen
+comments in the header files). The intent is to automate the process of
+building the documentation and have them available in more convenient formats
+and in the usual locations.
 
-## License
+## Building and Running the HelloWorld Example
+
+We will show you how to build and run an example program that illustrates the
+necessary steps to setup DCPS entities. The examples are built automatically
+when you build the C++ language binding for Cyclone DDS, so you don't need to
+follow these steps to be able to run the program, it is merely to illustrate
+the process.
+
+    $ mkdir helloworld
+    $ cd helloworld
+    $ cmake <install-location>/share/CycloneDDS-CXX/examples/helloworld
+    $ cmake --build .
+
+On one terminal start the application that will be responding to messages:
+
+    $ ./ddscxxHelloWorldSubscriber
+
+On another terminal, start the application that will be sending the messages:
+
+    $ ./ddscxxHelloWorldPublisher
+
+# Trademarks
+
+ * "Eclipse Cyclone DDS" and "Cyclone DDS" are trademarks of the Eclipse Foundation.
+ * "DDS" is a trademark of the Object Management Group, Inc.
+ * "ROS" is a trademark of Open Source Robotics Foundation, Inc.
+
+# License
 
 This project contains 2 types of license: Apache2 and Eclipse Public License / Eclipse Distribution License
 * The Apache2 license located in src/ddscxx/include/dds is for all files under src/ddscxx/include/dds except the details directories

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,21 @@
+#
+# Copyright(c) 2020 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+add_subdirectory(helloworld)
+
+install(
+  FILES helloworld/publisher.cpp
+        helloworld/subscriber.cpp
+        helloworld/HelloWorldData.idl
+        helloworld/CMakeLists.txt
+        helloworld/readme.rst
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/helloworld"
+  COMPONENT dev)

--- a/examples/ddscxx_examples.rst
+++ b/examples/ddscxx_examples.rst
@@ -1,0 +1,21 @@
+..
+   Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+
+   This program and the accompanying materials are made available under the
+   terms of the Eclipse Public License v. 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+   v. 1.0 which is available at
+   http://www.eclipse.org/org/documents/edl-v10.php.
+
+   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+Examples
+========
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents:
+
+   helloworld/readme
+
+

--- a/examples/helloworld/CMakeLists.txt
+++ b/examples/helloworld/CMakeLists.txt
@@ -1,0 +1,33 @@
+#
+# Copyright(c) 2020 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+project(helloworld LANGUAGES C CXX)
+cmake_minimum_required(VERSION 3.5)
+
+find_package(Idlpp-cxx REQUIRED)
+if (NOT TARGET CycloneDDS-CXX::ddscxx)
+  find_package(CycloneDDS-CXX REQUIRED)
+endif()
+
+# Convenience function, provided by the Idlpp-cxx that generates a CMake
+# target for the given IDL file. The function calls Idlcpp-cxx to generate
+# source files and compiles them into a library.
+idl_ddscxx_generate(ddscxxHelloWorldData_lib "HelloWorldData.idl")
+
+add_executable(ddscxxHelloworldPublisher publisher.cpp)
+add_executable(ddscxxHelloworldSubscriber subscriber.cpp)
+
+# Link both executables to idl data type library and ddscxx.
+target_link_libraries(ddscxxHelloworldPublisher ddscxxHelloWorldData_lib CycloneDDS-CXX::ddscxx)
+target_link_libraries(ddscxxHelloworldSubscriber ddscxxHelloWorldData_lib CycloneDDS-CXX::ddscxx)
+
+set_property(TARGET ddscxxHelloworldPublisher PROPERTY CXX_STANDARD 11)
+set_property(TARGET ddscxxHelloworldSubscriber PROPERTY CXX_STANDARD 11)

--- a/examples/helloworld/HelloWorldData.idl
+++ b/examples/helloworld/HelloWorldData.idl
@@ -1,0 +1,20 @@
+/*
+ * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+module HelloWorldData
+{
+  struct Msg
+  {
+    long userID;
+    string message;
+  };
+  #pragma keylist Msg userID
+};

--- a/examples/helloworld/publisher.cpp
+++ b/examples/helloworld/publisher.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <cstdlib>
+#include <iostream>
+#include <chrono>
+#include <thread>
+
+/* Include the C++ DDS API. */
+#include "dds/dds.hpp"
+
+/* Include data type and specific traits to be used with the C++ DDS API. */
+#include "HelloWorldData_DCPS.hpp"
+
+using namespace org::eclipse::cyclonedds;
+
+int main() {
+    try {
+        std::cout << "=== [Publisher] Create writer." << std::endl;
+
+        /* First, a domain participant is needed.
+         * Create one on the default domain. */
+        dds::domain::DomainParticipant participant(domain::default_id());
+
+        /* To publish something, a topic is needed. */
+        dds::topic::Topic<HelloWorldData::Msg> topic(participant, "ddscxx_helloworld_example");
+
+        /* A writer also needs a publisher. */
+        dds::pub::Publisher publisher(participant);
+
+        /* Now, the writer can be created to publish a HelloWorld message. */
+        dds::pub::DataWriter<HelloWorldData::Msg> writer(publisher, topic);
+
+        /* For this example, we'd like to have a subscriber to actually read
+         * our message. This is not always necessary. Also, the way it is
+         * done here is just to illustrate the easiest way to do so. It isn't
+         * really recommended to do a wait in a polling loop, however.
+         * Please take a look at Listeners and WaitSets for much better
+         * solutions, albeit somewhat more elaborate ones. */
+        std::cout << "=== [Publisher] Waiting for subscriber." << std::endl;
+        while (writer.publication_matched_status().current_count() == 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+
+        /* Create a message to write. */
+        HelloWorldData::Msg msg(1, "Hello World");
+
+        /* Write the message. */
+        std::cout << "=== [Publisher] Write sample." << std::endl;
+        writer.write(msg);
+
+        /* With a normal configuration (see dds::pub::qos::DataWriterQos
+         * for various different writer configurations), deleting a writer will
+         * dispose all its related message.
+         * Wait for the subscriber to have stopped to be sure it received the
+         * message. Again, not normally necessary and not recommended to do
+         * this in a polling loop. */
+        std::cout << "=== [Publisher] Waiting for sample to be accepted." << std::endl;
+        while (writer.publication_matched_status().current_count() > 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+    }
+    catch (const dds::core::Exception& e) {
+        std::cerr << "=== [Publisher] Exception: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "=== [Publisher] Done." << std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/examples/helloworld/readme.rst
+++ b/examples/helloworld/readme.rst
@@ -1,0 +1,45 @@
+..
+   Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+
+   This program and the accompanying materials are made available under the
+   terms of the Eclipse Public License v. 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+   v. 1.0 which is available at
+   http://www.eclipse.org/org/documents/edl-v10.php.
+
+   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+HelloWorld
+==========
+
+Description
+***********
+
+The basic ddscxx HelloWorld example is used to illustrate the necessary steps to setup DCPS entities.
+
+Design
+******
+
+It consists of 2 units:
+
+- ddscxxHelloworldPublisher: implements the publisher's main
+- ddscxxHelloworldSubscriber: implements the subscriber's main
+
+Scenario
+********
+
+The publisher sends a single HelloWorld sample. The sample contains two fields:
+
+- a userID field (long type)
+- a message field (string type)
+
+When it receives the sample, the subscriber displays the userID and the message field.
+
+Running the example
+*******************
+
+It is recommended that you run the subscriber and publisher in separate terminals to avoid mixing the output.
+
+- Open 2 terminals.
+- In the first terminal start the subscriber by running ddscxxHelloWorldSubscriber
+- In the second terminal start the publisher by running ddscxxHelloWorldPublisher

--- a/examples/helloworld/subscriber.cpp
+++ b/examples/helloworld/subscriber.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <cstdlib>
+#include <iostream>
+#include <chrono>
+#include <thread>
+
+/* Include the C++ DDS API. */
+#include "dds/dds.hpp"
+
+/* Include data type and specific traits to be used with the C++ DDS API. */
+#include "HelloWorldData_DCPS.hpp"
+
+using namespace org::eclipse::cyclonedds;
+
+int main() {
+    try {
+        std::cout << "=== [Subscriber] Create reader." << std::endl;
+
+        /* First, a domain participant is needed.
+         * Create one on the default domain. */
+        dds::domain::DomainParticipant participant(domain::default_id());
+
+        /* To subscribe to something, a topic is needed. */
+        dds::topic::Topic<HelloWorldData::Msg> topic(participant, "ddscxx_helloworld_example");
+
+        /* A reader also needs a subscriber. */
+        dds::sub::Subscriber subscriber(participant);
+
+        /* Now, the reader can be created to subscribe to a HelloWorld message. */
+        dds::sub::DataReader<HelloWorldData::Msg> reader(subscriber, topic);
+
+        /* Poll until a message has been read.
+         * It isn't really recommended to do this kind wait in a polling loop.
+         * It's done here just to illustrate the easiest way to get data.
+         * Please take a look at Listeners and WaitSets for much better
+         * solutions, albeit somewhat more elaborate ones. */
+        std::cout << "=== [Subscriber] Wait for message." << std::endl;
+        bool poll = true;
+        while (poll) {
+            /* For this example, the reader will return a set of messages (aka
+             * Samples). There are other ways of getting samples from reader.
+             * See the various read() and take() functions that are present. */
+            dds::sub::LoanedSamples<HelloWorldData::Msg> samples;
+
+            /* Try taking samples from the reader. */
+            samples = reader.take();
+
+            /* Are samples read? */
+            if (samples.length() > 0) {
+                /* Use an iterator to run over the set of samples. */
+                dds::sub::LoanedSamples<HelloWorldData::Msg>::const_iterator sample_iter;
+                for (sample_iter = samples.begin();
+                     sample_iter < samples.end();
+                     ++sample_iter) {
+                    /* Get the message and sample information. */
+                    const HelloWorldData::Msg& msg = sample_iter->data();
+                    const dds::sub::SampleInfo& info = sample_iter->info();
+
+                    /* Sometimes a sample is read, only to indicate a data
+                     * state change (which can be found in the info). If
+                     * that's the case, only the key value of the sample
+                     * is set. The other data parts are not.
+                     * Check if this sample has valid data. */
+                    if (info.valid()) {
+                        std::cout << "=== [Subscriber] Message received:" << std::endl;
+                        std::cout << "    userID  : " << msg.userID() << std::endl;
+                        std::cout << "    Message : \"" << msg.message() << "\"" << std::endl;
+
+                        /* Only 1 message is expected in this example. */
+                        poll = false;
+                    }
+                }
+            } else {
+                std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            }
+        }
+    }
+    catch (const dds::core::Exception& e) {
+        std::cerr << "=== [Subscriber] Exception: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "=== [Subscriber] Done." << std::endl;
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This PR adds a proper CMake package config file and a helloworld example. Apart from that it also updates the README.md to be a little more in line with that of Eclipse Cyclone DDS and point to the correct repositories etc.