### PR TITLE
Add support for application provided functors to do filtering on ContentFilteredTopics

### DIFF
--- a/src/ddscxx/include/dds/core/cond/TCondition.hpp
+++ b/src/ddscxx/include/dds/core/cond/TCondition.hpp
@@ -83,11 +83,7 @@ public:
      * @throw  dds::core::Exception
      */
     template <typename Functor>
-    void handler(Functor& func);
-
-    /** @copydoc dds::core::cond::TCondition::handler(Functor& func) */
-    template <typename Functor>
-    void handler(const Functor& func);
+    void handler(Functor func);
 
     /**
      * Resets the handler for this Condition.

--- a/src/ddscxx/include/dds/core/cond/TGuardCondition.hpp
+++ b/src/ddscxx/include/dds/core/cond/TGuardCondition.hpp
@@ -96,13 +96,7 @@ public:
      * @throw  dds::core::Exception
      */
     template <typename FUN>
-    TGuardCondition(FUN& functor);
-
-    /**
-     * @copydoc dds::core::cond::TGuardCondition::TGuardCondition(FUN& functor)
-     */
-    template <typename FUN>
-    TGuardCondition(const FUN& functor);
+    TGuardCondition(FUN functor);
 
     /** @cond */
     ~TGuardCondition();

--- a/src/ddscxx/include/dds/core/cond/TStatusCondition.hpp
+++ b/src/ddscxx/include/dds/core/cond/TStatusCondition.hpp
@@ -112,11 +112,7 @@ public:
      * @throw  dds::core::Exception
      */
     template <typename FUN>
-    TStatusCondition(const dds::core::Entity& e, FUN& functor);
-
-    /** @copydoc dds::core::cond::TStatusCondition::TStatusCondition(const dds::core::Entity& e, FUN& functor) */
-    template <typename FUN>
-    TStatusCondition(const dds::core::Entity& e, const FUN& functor);
+    TStatusCondition(const dds::core::Entity& e, FUN functor);
 
     /** @cond */
     ~TStatusCondition();

--- a/src/ddscxx/include/dds/core/cond/detail/TConditionImpl.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/TConditionImpl.hpp
@@ -38,7 +38,7 @@ TCondition<DELEGATE>::~TCondition()
 
 template <typename DELEGATE>
 template <typename Functor>
-void TCondition<DELEGATE>::handler(Functor& func)
+void TCondition<DELEGATE>::handler(Functor func)
 {
     this->delegate()->set_handler(func);
 }

--- a/src/ddscxx/include/dds/core/cond/detail/TGuardConditionImpl.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/TGuardConditionImpl.hpp
@@ -40,7 +40,7 @@ TGuardCondition<DELEGATE>::TGuardCondition()
 
 template <typename DELEGATE>
 template <typename FUN>
-TGuardCondition<DELEGATE>::TGuardCondition(FUN& functor)
+TGuardCondition<DELEGATE>::TGuardCondition(FUN functor)
 {
     this->set_ref(new DELEGATE);
     this->delegate()->init(this->impl_);

--- a/src/ddscxx/include/dds/core/cond/detail/TStatusConditionImpl.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/TStatusConditionImpl.hpp
@@ -41,7 +41,7 @@ TStatusCondition<DELEGATE>::TStatusCondition(const dds::core::Entity& e)
 
 template <typename DELEGATE>
 template <typename FUN>
-TStatusCondition<DELEGATE>::TStatusCondition(const dds::core::Entity& e, FUN& functor)
+TStatusCondition<DELEGATE>::TStatusCondition(const dds::core::Entity& e, FUN functor)
 {
     dds::core::Reference<DELEGATE>::impl_=
             OSPL_CXX11_STD_MODULE::dynamic_pointer_cast<org::eclipse::cyclonedds::core::cond::StatusConditionDelegate>(

--- a/src/ddscxx/include/dds/sub/cond/TQueryCondition.hpp
+++ b/src/ddscxx/include/dds/sub/cond/TQueryCondition.hpp
@@ -117,14 +117,7 @@ public:
      */
     template <typename FUN>
     TQueryCondition(const dds::sub::Query& query,
-                    const dds::sub::status::DataState& status, FUN& functor);
-
-    /**
-     * @copydoc dds::sub::cond::TQueryCondition::TQueryCondition(const dds::sub::Query& query, const dds::sub::status::DataState& status, FUN& functor)
-     */
-    template <typename FUN>
-    TQueryCondition(const dds::sub::Query& query,
-                    const dds::sub::status::DataState& status, const FUN& functor);
+                    const dds::sub::status::DataState& status, FUN functor);
 
     /**
      * Creates a QueryCondition instance.
@@ -189,18 +182,8 @@ public:
                     const std::string& expression,
                     const std::vector<std::string>& params,
                     const dds::sub::status::DataState& status,
-                    FUN& functor);
+                    FUN functor);
 
-
-  /**
-     * @copydoc dds::sub::cond::TQueryCondition::TQueryCondition(const dds::sub::AnyDataReader& dr, const std::string& expression, const std::vector<std::string>& params, const dds::sub::status::DataState& status, FUN& functor)
-     */
-    template <typename FUN>
-    TQueryCondition(const dds::sub::AnyDataReader& dr,
-                    const std::string& expression,
-                    const std::vector<std::string>& params,
-                    const dds::sub::status::DataState& status,
-                    const FUN& functor);
 
     /** @cond */
     ~TQueryCondition();

--- a/src/ddscxx/include/dds/sub/cond/TReadCondition.hpp
+++ b/src/ddscxx/include/dds/sub/cond/TReadCondition.hpp
@@ -113,13 +113,7 @@ public:
      * @throw  dds::core::Exception
      */
     template <typename FUN>
-    TReadCondition(const dds::sub::AnyDataReader& dr, const dds::sub::status::DataState& status, FUN& functor);
-
-    /**
-     * @copydoc dds::sub::cond::TReadCondition::TReadCondition(const dds::sub::AnyDataReader& dr, const dds::sub::status::DataState& status, FUN& functor)
-     */
-    template <typename FUN>
-    TReadCondition(const dds::sub::AnyDataReader& dr, const dds::sub::status::DataState& status, const FUN& functor);
+    TReadCondition(const dds::sub::AnyDataReader& dr, const dds::sub::status::DataState& status, FUN functor);
 
     /** @cond */
     ~TReadCondition();

--- a/src/ddscxx/include/dds/sub/cond/detail/TQueryConditionImpl.hpp
+++ b/src/ddscxx/include/dds/sub/cond/detail/TQueryConditionImpl.hpp
@@ -45,7 +45,7 @@ template <typename DELEGATE>
 template <typename FUN>
 TQueryCondition<DELEGATE>::TQueryCondition(
     const dds::sub::Query& query,
-    const dds::sub::status::DataState& status, FUN& functor)
+    const dds::sub::status::DataState& status, FUN functor)
 {
     this->set_ref(new DELEGATE(query.data_reader(),
                                query.expression(), query.delegate()->parameters(), status));
@@ -80,7 +80,7 @@ TQueryCondition<DELEGATE>::TQueryCondition(
     const std::string& expression,
     const std::vector<std::string>& params,
     const dds::sub::status::DataState& status,
-    FUN& functor)
+    FUN functor)
 {
     this->set_ref(new DELEGATE(dr, expression, params, status));
     this->delegate()->set_handler(functor);

--- a/src/ddscxx/include/dds/sub/cond/detail/TReadConditionImpl.hpp
+++ b/src/ddscxx/include/dds/sub/cond/detail/TReadConditionImpl.hpp
@@ -45,7 +45,7 @@ template <typename FUN>
 TReadCondition<DELEGATE>::TReadCondition(
         const dds::sub::AnyDataReader& dr,
         const dds::sub::status::DataState& status,
-        FUN& functor)
+        FUN functor)
 {
     this->set_ref(new DELEGATE(dr, status));
 	this->delegate()->init(this->impl_);

--- a/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
@@ -486,7 +486,7 @@ dds::sub::detail::DataReader<T>::common_constructor(
     org::eclipse::cyclonedds::sub::qos::DataReaderQosDelegate drQos = qos_.delegate();
 
     dds_entity_t ddsc_sub = (dds_entity_t)(sub_.delegate()->get_ddsc_entity());
-    dds_entity_t ddsc_top = ((dds::topic::Topic<T>)this->AnyDataReaderDelegate::td_).delegate()->get_ddsc_entity();
+    dds_entity_t ddsc_top = this->AnyDataReaderDelegate::td_.delegate()->get_ddsc_entity();
 
     // get and validate the ddsc qos
     drQos.check();

--- a/src/ddscxx/include/dds/topic/detail/ContentFilteredTopic.hpp
+++ b/src/ddscxx/include/dds/topic/detail/ContentFilteredTopic.hpp
@@ -35,8 +35,51 @@ namespace dds {
 namespace topic {
 namespace detail {
 
+class FunctorHolderBase
+{
+public:
+    FunctorHolderBase() { };
+
+    virtual ~FunctorHolderBase() { };
+
+    virtual bool check_sample(const void *sample) = 0;
+
+    static bool c99_check_sample(const void *sample, void *arg)
+    {
+        FunctorHolderBase *funcHolder = static_cast<FunctorHolderBase *>(arg);
+        return funcHolder->check_sample(sample);
+    }
+};
+
+template <typename FUN, typename T>
+class FunctorHolder : public FunctorHolderBase
+{
+public:
+    /* Remove const to be able to call non-const functors. */
+    FunctorHolder(FUN functor) : myFunctor(functor)
+    {
+    }
+
+    virtual ~FunctorHolder() { };
+
+    bool check_sample(const void *sample)
+    {
+        org::eclipse::cyclonedds::topic::copyOutFunction copyOut;
+        T cxxSample;
+
+        copyOut = org::eclipse::cyclonedds::topic::TopicTraits<T>::getCopyOut();
+        copyOut(sample, &cxxSample);
+        return myFunctor(cxxSample);
+    }
+
+private:
+    FUN myFunctor;
+};
+
 template <typename T>
-class ContentFilteredTopic  : public virtual org::eclipse::cyclonedds::topic::TopicDescriptionDelegate
+class ContentFilteredTopic  :
+    public virtual org::eclipse::cyclonedds::topic::TopicDescriptionDelegate,
+    public virtual org::eclipse::cyclonedds::core::DDScObjectDelegate
 {
 public:
     ContentFilteredTopic(
@@ -44,11 +87,11 @@ public:
         const std::string& name,
         const dds::topic::Filter& filter)
         : org::eclipse::cyclonedds::topic::TopicDescriptionDelegate(topic.domain_participant(), name, topic.type_name()),
+          org::eclipse::cyclonedds::core::DDScObjectDelegate(),
           myTopic(topic),
-          myFilter(filter)
+          myFilter(filter),
+          myFunctor(nullptr)
     {
-        ISOCPP_THROW_EXCEPTION(ISOCPP_UNSUPPORTED_ERROR, "Function not currently supported");
-        //@todo validate_filter();
         topic.delegate()->incrNrDependents();
         this->myParticipant.delegate()->add_cfTopic(*this);
     }
@@ -191,9 +234,33 @@ public:
     }
 #endif
 
+    template <typename Functor>
+    void filter_function(Functor func)
+    {
+        /* Make a private copy of the topic so my filter doesn't bother the original topic. */
+        dds_qos_t* ddsc_qos = myTopic.qos()->ddsc_qos();
+        dds_entity_t cfTopic = dds_create_topic(
+            myTopic.domain_participant().delegate()->get_ddsc_entity(),
+            org::eclipse::cyclonedds::topic::TopicTraits<T>::getDescriptor(),
+            myTopic.name().c_str(),
+            ddsc_qos,
+            NULL);
+        dds_delete_qos(ddsc_qos);
+        this->set_ddsc_entity(cfTopic);
+
+        org::eclipse::cyclonedds::core::ScopedObjectLock scopedLock(*this);
+        if (this->myFunctor)
+        {
+            delete this->myFunctor;
+        }
+        myFunctor = new FunctorHolder<Functor, T>(func);
+        dds_set_topic_filter_and_arg(cfTopic, FunctorHolderBase::c99_check_sample, myFunctor);
+    }
+
 private:
     dds::topic::Topic<T> myTopic;
     dds::topic::Filter myFilter;
+    FunctorHolderBase *myFunctor;
 };
 
 }

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/ConditionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/ConditionDelegate.hpp
@@ -70,7 +70,7 @@ public:
     virtual bool trigger_value() const = 0;
 
     template <typename FUN>
-    void set_handler(FUN& functor)
+    void set_handler(FUN functor)
     {
         org::eclipse::cyclonedds::core::ScopedObjectLock scopedLock(*this);
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/FunctorHolder.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/FunctorHolder.hpp
@@ -56,8 +56,7 @@ template <typename FUN>
 class FunctorHolder : public FunctorHolderBase
 {
 public:
-    /* Remove const to be able to call non-const functors. */
-    FunctorHolder(FUN &functor) : myFunctor(functor)
+    FunctorHolder(FUN functor) : myFunctor(functor)
     {
     }
 
@@ -69,7 +68,7 @@ public:
     }
 
 private:
-    FUN &myFunctor;
+    FUN myFunctor;
 };
 
 }

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/GuardConditionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/GuardConditionDelegate.hpp
@@ -37,12 +37,6 @@ class OMG_DDS_API GuardConditionDelegate :
 public:
     GuardConditionDelegate();
 
-    template<typename FUN>
-    GuardConditionDelegate(const FUN& functor) :
-       org::eclipse::cyclonedds::core::cond::ConditionDelegate(functor)
-    {
-    }
-
     ~GuardConditionDelegate();
 
     void close();

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/cond/QueryConditionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/cond/QueryConditionDelegate.hpp
@@ -55,31 +55,6 @@ public:
             const dds::sub::AnyDataReader& dr,
             const dds::sub::status::DataState& data_state);
 
-    template<typename FUN>
-    QueryConditionDelegate(
-            const dds::sub::AnyDataReader& dr,
-            const std::string& expression,
-            const dds::sub::status::DataState& data_state,
-            const FUN& functor) :
-                QueryDelegate(dr, expression, data_state),
-                ReadConditionDelegate(dr, data_state)
-    {
-        this->set_handler<FUN>(functor);
-    }
-
-    template<typename FUN>
-    QueryConditionDelegate(
-            const dds::sub::AnyDataReader& dr,
-            const std::string& expression,
-            const std::vector<std::string>& params,
-            const dds::sub::status::DataState& data_state,
-            const FUN& functor) :
-                QueryDelegate(dr, expression, params, data_state),
-                ReadConditionDelegate(dr, data_state)
-    {
-        this->set_handler<FUN>(functor);
-    }
-
     ~QueryConditionDelegate();
 
     typedef bool (*Filter_fn) (const void * sample);

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/cond/ReadConditionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/cond/ReadConditionDelegate.hpp
@@ -46,16 +46,6 @@ public:
             const dds::sub::AnyDataReader& dr,
             const dds::sub::status::DataState& state_filter);
 
-    template<typename FUN>
-    ReadConditionDelegate(
-            const dds::sub::AnyDataReader& dr,
-            const dds::sub::status::DataState& state_filter,
-            const FUN& functor)
-                :  QueryDelegate(dr, state_filter)
-     {
-        this->set_handler<FUN>(functor);
-     }
-
     ~ReadConditionDelegate();
 
     void init(ObjectDelegate::weak_ref_type weak_ref);

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.hpp
@@ -30,7 +30,7 @@ namespace cyclonedds
 namespace topic
 {
 
-class OMG_DDS_API TopicDescriptionDelegate : public virtual org::eclipse::cyclonedds::core::ObjectDelegate
+class OMG_DDS_API TopicDescriptionDelegate : public virtual org::eclipse::cyclonedds::core::DDScObjectDelegate
 {
 public:
     typedef ::dds::core::smart_ptr_traits< TopicDescriptionDelegate >::ref_type ref_type;


### PR DESCRIPTION
In this  pull request is one commit that modifies the way in which existing functors are passed (move to pass-by-value as apposed to pass-by-reference) to bring it more in line with common practice, and in anticipating of already agreed upon future changes to the OMG specification for this API.
The second commit is Cyclone specific, and allows you to set a filtering functor on the Delegate for the ContentFilteredTopic. This allows for content filtering based on for example lambda functions, as opposed to SQL expressions that Cyclone does not yet support.
Setting a filtering functor on a ContentFilteredTopic named "cft" may look like this:

cft->filter_function([](const Foo&sample)
            {
                return (sample.name() < "Dennis");
            });