### PR TITLE
Idlcxx martijn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,6 +148,7 @@ windows1809_vs2017: &windows1809_vs2017
     # simply add the extracted folder to the path.
     - choco install innoextract
     - choco install maven --ignore-dependencies
+    - choco install winflexbison3
     - wget -q https://dl.bintray.com/conan/installers/conan-win-64_1_10_0.exe
     - innoextract conan-win-64_1_10_0.exe
     - eval "export PATH=\"$(pwd)/app/conan:${PATH}\""

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,13 +97,14 @@ macos1015_xcode11_6: &macos1015_xcode11_6
   compiler: clang
   addons:
     homebrew:
-      packages: [ pyenv-virtualenv ]
+      packages: [ pyenv-virtualenv, bison ]
   before_install:
     - eval "export CC=clang CXX=clang++"
     - eval "export COV_COMPTYPE=clang COV_PLATFORM=macOSX"
     - eval "export BUILD_TOOL_OPTIONS='-j 4'"
     - eval "export GENERATOR='Unix Makefiles'"
     - eval "export PATH=\"${PATH}:$(python3 -m site --user-base)/bin\""
+    - eval "export PATH=\"/usr/local/opt/bison/bin:${PATH}\""
   install:
     - python3 -m pip install conan --upgrade --user
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -199,12 +199,15 @@ script:
   - *build_cyclonedds
   - mkdir build
   - cd build
+  - conan install -b missing -s arch=${ARCH} -s build_type=${BUILD_TYPE} ../${CONANFILE:-conanfile.txt}
   - ${SCAN_BUILD} cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
           -DCMAKE_INSTALL_PREFIX=$(pwd)/install
           -DCMAKE_PREFIX_PATH=${TRAVIS_BUILD_DIR}/cyclonedds/build/install
           -DUSE_SANITIZER=${SANITIZER}
+          -DBUILD_TESTING=on
           -G "${GENERATOR}" ..
   - cmake --build . --config ${BUILD_TYPE} --target install -- ${BUILD_TOOL_OPTIONS}
+  - ctest -j 4 --output-on-failure -T test -C ${BUILD_TYPE}
 
 after_success:
   - *submit_to_coverity_scan

--- a/.travis.yml
+++ b/.travis.yml
@@ -180,7 +180,7 @@ before_script:
   - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
 
 build_cyclonedds: &build_cyclonedds
-  - eval "export CYCLONEDDS_BRANCH=master"
+  - eval "export CYCLONEDDS_BRANCH=idlcxx"
   - eval "export CYCLONEDDS_REPOSITORY=https://github.com/eclipse-cyclonedds/cyclonedds.git"
   - git clone --single-branch --branch ${CYCLONEDDS_BRANCH} ${CYCLONEDDS_REPOSITORY} cyclonedds
   - mkdir cyclonedds/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -185,7 +185,7 @@ build_cyclonedds: &build_cyclonedds
   - git clone --single-branch --branch ${CYCLONEDDS_BRANCH} ${CYCLONEDDS_REPOSITORY} cyclonedds
   - mkdir cyclonedds/build
   - cd cyclonedds/build
-  #- conan install -b missing -s arch=${ARCH} -s build_type=${BUILD_TYPE} ..
+  - conan install -b missing -s arch=${ARCH} -s build_type=${BUILD_TYPE} ..
   - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
           -DCMAKE_INSTALL_PREFIX=$(pwd)/install
           -DUSE_SANITIZER=${SANITIZER}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,8 @@ if(CMAKE_VERSION VERSION_LESS 3.13)
   endmacro()
 endif()
 
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
+
 # Make it easy to enable Clang and GCC analyzers
 if(USE_SANITIZER)
   string(REGEX REPLACE " " "" USE_SANITIZER "${USE_SANITIZER}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,8 @@ install(
   DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
   COMPONENT dev)
 
+find_package(CycloneDDS REQUIRED)
+
 add_subdirectory(src)
 if(BUILD_EXAMPLES)
   add_subdirectory(examples)

--- a/cmake/Modules/CUnit.cmake
+++ b/cmake/Modules/CUnit.cmake
@@ -1,0 +1,316 @@
+#
+# Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+find_package(CUnit REQUIRED)
+
+set(CUNIT_DIR "${CMAKE_CURRENT_LIST_DIR}/CUnit")
+
+
+function(get_cunit_header_file SOURCE_FILE HEADER_FILE)
+  # Return a unique (but consistent) filename where Theory macros can be
+  # written. The path that will be returned is the location to a header file
+  # located in the same relative directory, using the basename of the source
+  # file postfixed with .h. e.g. <project>/foo/bar.h would be converted to
+  # <project>/build/foo/bar.h.
+  get_filename_component(SOURCE_FILE "${SOURCE_FILE}" ABSOLUTE)
+  file(RELATIVE_PATH SOURCE_FILE "${PROJECT_SOURCE_DIR}" "${SOURCE_FILE}")
+  get_filename_component(basename "${SOURCE_FILE}" NAME_WE)
+  get_filename_component(dir "${SOURCE_FILE}" DIRECTORY)
+  set(${HEADER_FILE} "${CMAKE_BINARY_DIR}/${dir}/${basename}.h" PARENT_SCOPE)
+endfunction()
+
+function(parse_cunit_fixtures INPUT TEST_DISABLED TEST_TIMEOUT)
+  if(INPUT MATCHES ".disabled${s}*=${s}*([tT][rR][uU][eE]|[0-9]+)")
+    set(${TEST_DISABLED} "TRUE" PARENT_SCOPE)
+  else()
+    set(${TEST_DISABLED} "FALSE" PARENT_SCOPE)
+  endif()
+
+  if(INPUT MATCHES ".timeout${s}*=${s}*([0-9]+)")
+    set(${TEST_TIMEOUT} "${CMAKE_MATCH_1}" PARENT_SCOPE)
+  else()
+    set(${TEST_TIMEOUT} "0" PARENT_SCOPE)
+  endif()
+endfunction()
+
+# Parse a single source file, generate a header file with theory definitions
+# (if applicable) and return suite and test definitions.
+function(process_cunit_source_file SOURCE_FILE HEADER_FILE SUITES TESTS)
+  set(x "\\*")
+  set(s "[ \t\r\n]")
+  set(s_or_x "[ \t\r\n\\*]")
+  set(w "[_a-zA-Z0-9]")
+  set(ident_expr "(${s}*${w}+${s}*)")
+  # Very basic type recognition, only things that contain word characters and
+  # pointers are handled. And since this script does not actually have to
+  # compile any code, type checking is left to the compiler. An error (or
+  # warning) will be thrown if something is off.
+  #
+  # The "type" regular expression below will match things like:
+  #  - <word> <word>
+  #  - <word> *<word>
+  #  - <word>* <word> *<word>
+  set(type_expr "(${s}*${w}+${x}*${s}+${s_or_x}*)+")
+  set(param_expr "${type_expr}${ident_expr}")
+  # Test fixture support (based on test fixtures as implemented in Criterion),
+  # to enable per-test (de)initializers, which is very different from
+  # per-suite (de)initializers, and timeouts.
+  #
+  # The following fixtures are supported:
+  #  - init
+  #  - fini
+  #  - disabled
+  #  - timeout
+  set(data_expr "(${s}*,${s}*\\.${w}+${s}*=[^,\\)]+)*")
+
+  set(suites_wo_init_n_clean)
+  set(suites_w_init)
+  set(suites_w_clean)
+
+  file(READ "${SOURCE_FILE}" content)
+
+  # CU_Init and CU_Clean
+  #
+  # Extract all suite initializers and deinitializers so that the list of
+  # suites can be probably populated when tests and theories are parsed. Suites
+  # are only registered if it contains at least one test or theory.
+  set(suite_expr "CU_(Init|Clean)${s}*\\(${ident_expr}\\)")
+  string(REGEX MATCHALL "${suite_expr}" matches "${content}")
+  foreach(match ${matches})
+    string(REGEX REPLACE "${suite_expr}" "\\2" suite "${match}")
+
+    if("${match}" MATCHES "CU_Init")
+      list(APPEND suites_w_init ${suite})
+    elseif("${match}" MATCHES "CU_Clean")
+      list(APPEND suites_w_deinit ${suite})
+    endif()
+  endforeach()
+
+  # CU_Test
+  set(test_expr "CU_Test${s}*\\(${ident_expr},${ident_expr}${data_expr}\\)")
+  string(REGEX MATCHALL "${test_expr}" matches "${content}")
+  foreach(match ${matches})
+    string(REGEX REPLACE "${test_expr}" "\\1" suite "${match}")
+    string(REGEX REPLACE "${test_expr}" "\\2" test "${match}")
+    # Remove leading and trailing whitespace
+    string(STRIP "${suite}" suite)
+    string(STRIP "${test}" test)
+
+    # Extract fixtures that must be handled by CMake (.disabled and .timeout).
+    parse_cunit_fixtures("${match}" disabled timeout)
+    list(APPEND suites_wo_init_n_clean "${suite}")
+    list(APPEND tests "${suite}:${test}:${disabled}:${timeout}")
+  endforeach()
+
+  # CU_Theory
+  #
+  # CU_Theory signatures must be recognized in order to generate structures to
+  # hold the CU_DataPoints declarations. The generated type is added to the
+  # compile definitions and inserted by the preprocessor when CU_TheoryDataPoints
+  # is expanded.
+  #
+  # NOTE: Since not all compilers support pushing function-style definitions
+  #       from the command line (CMake will generate a warning too), a header
+  #       file is generated instead. A define is pushed and expanded at
+  #       compile time. It is included by CUnit/Theory.h.
+  get_cunit_header_file("${SOURCE_FILE}" header)
+
+  set(theory_expr "CU_Theory${s}*\\(${s}*\\((${param_expr}(,${param_expr})*)\\)${s}*,${ident_expr},${ident_expr}${data_expr}\\)")
+  string(REGEX MATCHALL "${theory_expr}" matches "${content}")
+  foreach(match ${matches})
+    if(NOT theories)
+      # Ensure generated header is truncated before anything is written.
+      file(WRITE "${header}" "")
+    endif()
+    string(REGEX REPLACE "${theory_expr}" "\\1" params "${match}")
+    string(REGEX REPLACE "${theory_expr}" "\\7" suite "${match}")
+    string(REGEX REPLACE "${theory_expr}" "\\8" test "${match}")
+    # Remove leading and trailing whitespace
+    string(STRIP "${params}" params)
+    string(STRIP "${suite}" suite)
+    string(STRIP "${test}" test)
+    # Convert parameters from a string to a list
+    string(REGEX REPLACE "${s}*,${s}*" ";" params "${params}")
+
+    # Extract fixtures that must be handled by CMake (.disabled and .timeout)
+    parse_cunit_fixtures("${match}" disabled timeout)
+    list(APPEND suites_wo_init_n_clean "${suite}")
+    list(APPEND theories "${suite}:${test}:${disabled}:${timeout}")
+
+    set(sep)
+    set(size "CU_TheoryDataPointsSize_${suite}_${test}(datapoints) (")
+    set(slice "CU_TheoryDataPointsSlice_${suite}_${test}(datapoints, index) (")
+    set(typedef "CU_TheoryDataPointsTypedef_${suite}_${test}() {")
+    foreach(param ${params})
+      string(
+        REGEX REPLACE "(${type_expr})${ident_expr}" "\\3" name "${param}")
+      string(
+        REGEX REPLACE "(${type_expr})${ident_expr}" "\\1" type "${param}")
+      string(STRIP "${name}" name)
+      string(STRIP "${type}" type)
+
+      set(slice "${slice}${sep} datapoints.${name}.p[index]")
+      if (NOT sep)
+        set(size "${size} datapoints.${name}.n")
+        set(sep ",")
+      endif()
+      set(typedef "${typedef} struct { size_t n; ${type} *p; } ${name};")
+    endforeach()
+    set(typedef "${typedef} }")
+    set(slice "${slice} )")
+    set(size "${size} )")
+
+    file(APPEND "${header}" "#define ${size}\n")
+    file(APPEND "${header}" "#define ${slice}\n")
+    file(APPEND "${header}" "#define ${typedef}\n")
+  endforeach()
+
+  # Propagate suites, tests and theories extracted from the source file.
+  if(suites_wo_init_n_clean)
+    list(REMOVE_DUPLICATES suites_wo_init_n_clean)
+    list(SORT suites_wo_init_n_clean)
+    foreach(suite ${suites_wo_init_n_clean})
+      set(init "FALSE")
+      set(clean "FALSE")
+      if(${suite} IN_LIST suites_w_init)
+        set(init "TRUE")
+      endif()
+      if(${suite} IN_LIST suites_w_deinit)
+        set(clean "TRUE")
+      endif()
+
+      list(APPEND suites "${suite}:${init}:${clean}")
+    endforeach()
+  endif()
+
+  if(theories)
+    set(${HEADER_FILE} "${header}" PARENT_SCOPE)
+  else()
+    unset(${HEADER_FILE} PARENT_SCOPE)
+  endif()
+  set(${SUITES} ${suites} PARENT_SCOPE)
+  set(${TESTS} ${tests};${theories} PARENT_SCOPE)
+endfunction()
+
+function(add_cunit_executable TARGET)
+  # Retrieve location of shared libary, which is need to extend the PATH
+  # environment variable on Microsoft Windows, so that the operating
+  # system can locate the .dll that it was linked against.
+  # On macOS, this mechanism is used to set the DYLD_LIBRARY_PATH.
+  get_target_property(CUNIT_LIBRARY_TYPE CUnit TYPE)
+  get_target_property(CUNIT_IMPORTED_LOCATION CUnit IMPORTED_LOCATION)
+  get_filename_component(CUNIT_LIBRARY_DIR "${CUNIT_IMPORTED_LOCATION}" PATH)
+
+  set(decls)
+  set(defns)
+  set(sources)
+
+  foreach(source ${ARGN})
+    if((EXISTS "${source}" OR EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${source}"))
+      unset(suites)
+      unset(tests)
+
+      process_cunit_source_file("${source}" header suites tests)
+      if(header)
+        set_property(
+          SOURCE "${source}"
+          PROPERTY COMPILE_DEFINITIONS CU_THEORY_INCLUDE_FILE=\"${header}\")
+      endif()
+
+      # Disable missing-field-initializers warnings as not having to specify
+      # every member, aka fixture, is intended behavior.
+      if(${CMAKE_C_COMPILER_ID} STREQUAL "Clang" OR
+         ${CMAKE_C_COMPILER_ID} STREQUAL "AppleClang" OR
+         ${CMAKE_C_COMPILER_ID} STREQUAL "GNU")
+        set_property(
+          SOURCE "${source}"
+          PROPERTY COMPILE_FLAGS -Wno-missing-field-initializers)
+      endif()
+
+      foreach(suite ${suites})
+        string(REPLACE ":" ";" suite ${suite})
+        list(GET suite 2 clean)
+        list(GET suite 1 init)
+        list(GET suite 0 suite)
+        set(init_func "NULL")
+        set(clean_func "NULL")
+        if(init)
+          set(decls "${decls}\nCU_InitDecl(${suite});")
+          set(init_func "CU_InitName(${suite})")
+        endif()
+        if(clean)
+          set(decls "${decls}\nCU_CleanDecl(${suite});")
+          set(clean_func "CU_CleanName(${suite})")
+        endif()
+        set(defns "${defns}\nADD_SUITE(${suite}, ${init_func}, ${clean_func});")
+      endforeach()
+
+      foreach(test ${tests})
+        string(REPLACE ":" ";" test ${test})
+        list(GET test 3 timeout)
+        list(GET test 2 disabled)
+        list(GET test 0 suite)
+        list(GET test 1 test)
+
+        set(enable "true")
+        if(disabled)
+          set(enable "false")
+        endif()
+        if(NOT timeout)
+          set(timeout 10)
+        endif()
+
+        set(decls "${decls}\nCU_TestDecl(${suite}, ${test});")
+        set(defns "${defns}\nADD_TEST(${suite}, ${test}, ${enable});")
+        set(ctest "CUnit_${suite}_${test}")
+
+        add_test(
+          NAME ${ctest}
+          COMMAND ${TARGET} -s ${suite} -t ${test})
+        set_property(TEST ${ctest} PROPERTY TIMEOUT ${timeout})
+        set_property(TEST ${ctest} PROPERTY DISABLED ${disabled})
+        if(APPLE)
+          set_property(
+            TEST ${ctest}
+            PROPERTY ENVIRONMENT
+              "DYLD_LIBRARY_PATH=${CUNIT_LIBRARY_DIR}:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:$ENV{DYLD_LIBRARY_PATH}")
+        elseif(WIN32 AND ${CUNIT_LIBRARY_TYPE} STREQUAL "SHARED_LIBRARY")
+          set_property(
+            TEST ${ctest}
+            PROPERTY ENVIRONMENT
+              "PATH=${CUNIT_LIBRARY_DIR};$ENV{PATH}")
+        else()
+          set_property(
+            TEST ${ctest}
+            PROPERTY ENVIRONMENT
+              "LD_LIBRARY_PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:$ENV{LD_LIBRARY_PATH}")
+        endif()
+      endforeach()
+
+      list(APPEND sources "${source}")
+    endif()
+  endforeach()
+
+  configure_file(
+    "${CUNIT_DIR}/src/main.c.in" "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.c" @ONLY)
+  if("2.1.3" VERSION_LESS_EQUAL
+       "${CUNIT_VERSION_MAJOR}.${CUNIT_VERSION_MINOR}.${CUNIT_VERSION_PATCH}")
+    set_property(
+      SOURCE "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.c"
+      PROPERTY COMPILE_DEFINITIONS HAVE_ENABLE_JUNIT_XML)
+  endif()
+
+  add_executable(
+    ${TARGET} "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.c" ${sources})
+  target_link_libraries(${TARGET} PRIVATE CUnit)
+  target_include_directories(${TARGET} PRIVATE "${CUNIT_DIR}/include")
+endfunction()
+

--- a/cmake/Modules/CUnit/include/CUnit/Test.h
+++ b/cmake/Modules/CUnit/include/CUnit/Test.h
@@ -1,0 +1,96 @@
+#ifndef CUNIT_TEST_H
+#define CUNIT_TEST_H
+
+#include <stdbool.h>
+#include <CUnit/CUnit.h>
+#include <CUnit/CUError.h>
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+typedef void(*cu_test_init_func_t)(void);
+typedef void(*cu_test_fini_func_t)(void);
+
+typedef struct {
+  cu_test_init_func_t init;
+  cu_test_fini_func_t fini;
+  int disabled; /* Parsed by CMake, used at test registration in main. */
+  int timeout; /* Parsed by CMake, used at test registration in CMake. */
+} cu_data_t;
+
+#define CU_InitName(suite) \
+  CU_Init_ ## suite
+#define CU_CleanName(suite) \
+  CU_Fini_ ## suite
+#define CU_TestName(suite, test) \
+  CU_Test_ ## suite ## _ ## test
+#define CU_TestProxyName(suite, test) \
+  CU_TestProxy_ ## suite ## _ ## test
+
+#define CU_InitDecl(suite) \
+  extern int CU_InitName(suite)(void)
+#define CU_Init(suite) \
+  CU_InitDecl(suite); \
+  int CU_InitName(suite)(void)
+
+#define CU_CleanDecl(suite) \
+  extern int CU_CleanName(suite)(void)
+#define CU_Clean(suite) \
+  CU_CleanDecl(suite); \
+  int CU_CleanName(suite)(void)
+
+/* CU_Test generates a wrapper function that takes care of per-test
+   initialization and deinitialization, if provided in the CU_Test
+   signature. */
+#define CU_Test(suite, test, ...)                          \
+  static void CU_TestName(suite, test)(void);              \
+  void CU_TestProxyName(suite, test)(void);                \
+                                                           \
+  void CU_TestProxyName(suite, test)(void) {               \
+    cu_data_t cu_data = CU_Fixture(__VA_ARGS__);           \
+                                                           \
+    if (cu_data.init != NULL) {                            \
+      cu_data.init();                                      \
+    }                                                      \
+                                                           \
+    CU_TestName(suite, test)();                            \
+                                                           \
+    if (cu_data.fini != NULL) {                            \
+      cu_data.fini();                                      \
+    }                                                      \
+  }                                                        \
+                                                           \
+  static void CU_TestName(suite, test)(void)
+
+#define CU_TestDecl(suite, test) \
+  extern void CU_TestProxyName(suite, test)(void)
+
+/* Microsoft Visual Studio does not like empty struct initializers, i.e.
+   no fixtures are specified. To work around that issue CU_Fixture inserts a
+   NULL initializer as fall back. */
+#define CU_Comma() ,
+#define CU_Reduce(one, ...) one
+
+#ifdef _WIN32
+/* Microsoft Visual Studio does not expand __VA_ARGS__ correctly. */
+#define CU_Fixture__(...) CU_Fixture____((__VA_ARGS__))
+#define CU_Fixture____(tuple) CU_Fixture___ tuple
+#else
+#define CU_Fixture__(...) CU_Fixture___(__VA_ARGS__)
+#endif /* _WIN32 */
+
+#define CU_Fixture___(throw, away, value, ...) value
+
+#define CU_Fixture(...) \
+  CU_Fixture_( CU_Comma CU_Reduce(__VA_ARGS__,) (), __VA_ARGS__ )
+
+#define CU_Fixture_(throwaway, ...) \
+  CU_Fixture__(throwaway, ((cu_data_t){ 0 }), ((cu_data_t){ __VA_ARGS__ }))
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif /* CUNIT_TEST_H */
+

--- a/cmake/Modules/CUnit/include/CUnit/Theory.h
+++ b/cmake/Modules/CUnit/include/CUnit/Theory.h
@@ -1,0 +1,73 @@
+#ifndef CUNIT_THEORY_H
+#define CUNIT_THEORY_H
+
+/* Function-style macros cannot be defined on the command line. */
+#ifdef CU_THEORY_INCLUDE_FILE
+#include CU_THEORY_INCLUDE_FILE
+#endif
+
+#include "CUnit/Test.h"
+
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+#define CU_TheoryDataPointsName(suite, test) \
+  CU_TheoryDataPoints_ ## suite ## _ ## test
+
+#define CU_TheoryDataPointsTypeName(suite, test) \
+  CU_TheoryDataPointsType_ ## suite ## _ ## test
+
+#define CU_TheoryDataPointsSize(suite, test) \
+  CU_TheoryDataPointsSize_ ## suite ## _ ## test ( \
+    CU_TheoryDataPointsName(suite, test))
+
+#define CU_TheoryDataPointsSlice(suite, test, index) \
+  CU_TheoryDataPointsSlice_ ## suite ## _ ## test ( \
+    CU_TheoryDataPointsName(suite, test), index)
+
+#define CU_TheoryDataPointsTypedef(suite, test) \
+  CU_TheoryDataPointsTypedef_ ## suite ## _ ## test()
+
+#define CU_TheoryDataPoints(suite, test) \
+  struct CU_TheoryDataPointsTypeName(suite, test) \
+    CU_TheoryDataPointsTypedef(suite, test) ; \
+   \
+  static struct CU_TheoryDataPointsTypeName(suite, test) \
+    CU_TheoryDataPointsName(suite, test)
+
+#define CU_DataPoints(type, ...) { \
+    .p = (type[]) { __VA_ARGS__ }, \
+    .n = (sizeof((type[]) { __VA_ARGS__ }) / sizeof(type)) \
+  }
+
+#define CU_Theory(signature, suite, test, ...)                            \
+  static void CU_TestName(suite, test) signature;                         \
+  void CU_TestProxyName(suite, test)(void);                               \
+                                                                          \
+  void CU_TestProxyName(suite, test)(void) {                              \
+    cu_data_t cu_data = CU_Fixture(__VA_ARGS__);                          \
+    size_t i, n;                                                          \
+                                                                          \
+    if (cu_data.init != NULL) {                                           \
+      cu_data.init();                                                     \
+    }                                                                     \
+                                                                          \
+    for (i = 0, n = CU_TheoryDataPointsSize(suite, test); i < n; i++) {   \
+      CU_TestName(suite, test) CU_TheoryDataPointsSlice(suite, test, i) ; \
+    }                                                                     \
+                                                                          \
+    if (cu_data.fini != NULL) {                                           \
+      cu_data.fini();                                                     \
+    }                                                                     \
+  }                                                                       \
+                                                                          \
+  static void CU_TestName(suite, test) signature
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif /* CUNIT_THEORY_H */
+

--- a/cmake/Modules/CUnit/src/main.c.in
+++ b/cmake/Modules/CUnit/src/main.c.in
@@ -1,0 +1,240 @@
+/*
+ * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define EX_USAGE (64)
+#define EX_SOFTWARE (70)
+
+#include <CUnit/Basic.h>
+#include <CUnit/Automated.h>
+#include "CUnit/Test.h"
+
+static struct {
+    bool print_help;
+    bool automated;
+    bool junit;
+    const char *results;
+    CU_BasicRunMode mode;
+    CU_ErrorAction error_action;
+    const char *suite;
+    const char *test;
+} opts = {
+    false,
+    false,
+    false,
+    NULL,
+    CU_BRM_NORMAL,
+    CUEA_IGNORE,
+    "*",
+    "*"
+};
+
+static int patmatch(const char *pat, const char *str)
+{
+    while (*pat) {
+        if (*pat == '?') {
+            /* any character will do */
+            if (*str++ == 0) {
+                return 0;
+            }
+            pat++;
+        } else if (*pat == '*') {
+            /* collapse a sequence of wildcards, requiring as many
+               characters in str as there are ?s in the sequence */
+            while (*pat == '*' || *pat == '?') {
+                if (*pat == '?' && *str++ == 0) {
+                    return 0;
+                }
+                pat++;
+            }
+            /* try matching on all positions where str matches pat */
+            while (*str) {
+                if (*str == *pat && patmatch(pat+1, str+1)) {
+                    return 1;
+                }
+                str++;
+            }
+            return *pat == 0;
+        } else {
+            /* only an exact match */
+            if (*str++ != *pat++) {
+                return 0;
+            }
+        }
+    }
+
+    return *str == 0;
+}
+
+static void usage(const char *name)
+{
+    fprintf(stderr, "Usage: %s OPTIONS\n", name);
+    fprintf(stderr, "Try '%s -h' for more information\n", name);
+}
+
+static void help(const char *name)
+{
+    printf("Usage: %s [OPTIONS]\n", name);
+    printf("\n");
+    printf("Possible options:\n");
+    printf("  -a           run in automated mode\n");
+    printf("  -f           fail fast\n");
+    printf("  -h           display this help and exit\n");
+    printf("  -j           junit format results \n");
+    printf("  -r FILENAME  results file for automated run\n");
+    printf("  -s PATTERN   run only tests in suites matching pattern\n");
+    printf("  -t PATTERN   run only test matching pattern\n");
+    printf("\n");
+    printf("Exit codes:\n");
+    printf("  %-2d  Successful termination\n", EXIT_SUCCESS);
+    printf("  %-2d  One or more failing test cases\n", EXIT_FAILURE);
+    printf("  %-2d  Command line usage error\n", EX_USAGE);
+    printf("  %-2d  Internal software error\n", EX_SOFTWARE);
+}
+
+static int parse_options(int argc, char *argv[])
+{
+    int err = 0;
+
+    for (int i = 1; err == 0 && i < argc; i++) {
+        switch ((argv[i][0] == '-') ? argv[i][1] : 0) {
+            case 'a':
+                opts.automated = true;
+                break;
+            case 'f':
+                opts.error_action = CUEA_FAIL;
+                break;
+            case 'h':
+                opts.print_help = true;
+                break;
+            case 'j':
+                opts.junit = true;
+                break;
+            case 'r':
+                if((i+1) < argc){
+                    opts.results = argv[++i];
+                    break;
+                }
+                /* FALLS THROUGH */
+            case 's':
+                if ((i+1) < argc) {
+                    opts.suite = argv[++i];
+                    break;
+                }
+                /* FALLS THROUGH */
+            case 't':
+                if ((i+1) < argc) {
+                    opts.test = argv[++i];
+                    break;
+                }
+                /* FALLS THROUGH */
+            default:
+                err = 1;
+                break;
+        }
+    }
+
+    return err;
+}
+
+static void
+add_suite(
+    const char *suite,
+    CU_InitializeFunc pInitFunc,
+    CU_CleanupFunc pCleanFunc)
+{
+    CU_pSuite pSuite;
+
+    pSuite = CU_get_suite(suite);
+    if (pSuite == NULL) {
+        pSuite = CU_add_suite(suite, pInitFunc, pCleanFunc);
+        CU_set_suite_active(pSuite, patmatch(opts.suite, suite));
+    }
+}
+
+#define ADD_SUITE(suite, init, clean) \
+  add_suite(#suite, init, clean)
+
+static void
+add_test(
+    const char *suite,
+    const char *test,
+    CU_TestFunc pTestFunc,
+    bool enable)
+{
+    CU_pSuite pSuite;
+    CU_pTest pTest;
+
+    pSuite = CU_get_suite(suite);
+    pTest = CU_add_test(pSuite, test, pTestFunc);
+    CU_set_test_active(pTest, enable && patmatch(opts.test, test));
+}
+
+#define ADD_TEST(suite, test, enable) \
+  add_test(#suite, #test, CU_TestProxyName(suite, test), enable)
+
+/* CMake will expand the macro below to declare generated functions. */
+@decls@
+
+int main(int argc, char *argv[])
+{
+    int ret = EXIT_SUCCESS;
+
+    if (parse_options(argc, argv) != 0) {
+        usage(argv[0]);
+        return EX_USAGE;
+    } else if (opts.print_help) {
+        help(argv[0]);
+        return ret;
+    } else if (CU_initialize_registry() != CUE_SUCCESS) {
+        fprintf(stderr, "CU_initialize_registry: %s\n", CU_get_error_msg());
+        return EX_SOFTWARE;
+    }
+
+/* CMake will expand the macro below to register all suites and tests. */
+@defns@
+
+    CU_set_error_action(opts.error_action);
+
+    if (opts.automated) {
+        if (opts.results != NULL) {
+            CU_set_output_filename(opts.results);
+        }
+
+#if defined(HAVE_ENABLE_JUNIT_XML)
+        if (opts.junit) {
+            CU_automated_enable_junit_xml(CU_TRUE);
+        } else
+#endif
+        {
+            CU_list_tests_to_file();
+        }
+        CU_automated_run_tests();
+    } else {
+        CU_set_fail_on_inactive(0);
+        CU_basic_set_mode(opts.mode);
+        CU_basic_run_tests();
+    }
+
+    if (CU_get_error() != CUE_SUCCESS) {
+        ret = EX_SOFTWARE;
+    } else if (CU_get_number_of_failures() != 0) {
+        ret = EXIT_FAILURE;
+    }
+
+    CU_cleanup_registry();
+
+    return ret;
+}
+

--- a/cmake/Modules/FindCUnit.cmake
+++ b/cmake/Modules/FindCUnit.cmake
@@ -1,0 +1,96 @@
+#
+# Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+find_package(CUnit CONFIG QUIET)
+if(CUnit_FOUND)
+  message(STATUS "Found CUnit via Config file: ${CUnit_DIR}")
+  set(CUNIT_FOUND ${CUnit_FOUND})
+else()
+  set(CUNIT_HEADER "CUnit/CUnit.h")
+
+  if(CONAN_INCLUDE_DIRS)
+    find_path(CUNIT_INCLUDE_DIR ${CUNIT_HEADER} HINTS ${CONAN_INCLUDE_DIRS})
+  else()
+    find_path(CUNIT_INCLUDE_DIR ${CUNIT_HEADER})
+  endif()
+
+  mark_as_advanced(CUNIT_INCLUDE_DIR)
+
+  if(CUNIT_INCLUDE_DIR AND EXISTS "${CUNIT_INCLUDE_DIR}/${CUNIT_HEADER}")
+    set(PATTERN "^#define CU_VERSION \"([0-9]+)\\.([0-9]+)\\-([0-9]+)\"$")
+    file(STRINGS "${CUNIT_INCLUDE_DIR}/${CUNIT_HEADER}" CUNIT_H REGEX "${PATTERN}")
+
+    string(REGEX REPLACE "${PATTERN}" "\\1" CUNIT_VERSION_MAJOR "${CUNIT_H}")
+    string(REGEX REPLACE "${PATTERN}" "\\2" CUNIT_VERSION_MINOR "${CUNIT_H}")
+    string(REGEX REPLACE "${PATTERN}" "\\3" CUNIT_VERSION_PATCH "${CUNIT_H}")
+
+    set(CUNIT_VERSION "${CUNIT_VERSION_MAJOR}.${CUNIT_VERSION_MINOR}-${CUNIT_VERSION_PATCH}")
+  endif()
+
+  if(CONAN_LIB_DIRS)
+    find_library(CUNIT_LIBRARY cunit HINTS ${CONAN_LIB_DIRS})
+  else()
+    find_library(CUNIT_LIBRARY cunit)
+  endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  CUnit
+  REQUIRED_VARS
+    CUNIT_LIBRARY CUNIT_INCLUDE_DIR
+  VERSION_VAR
+    CUNIT_VERSION)
+
+if(CUNIT_FOUND)
+  set(CUNIT_INCLUDE_DIRS ${CUNIT_INCLUDE_DIR})
+  set(CUNIT_LIBRARIES ${CUNIT_LIBRARY})
+
+  if(WIN32)
+    get_filename_component(CUNIT_LIBRARY_DIR "${CUNIT_LIBRARY}}" PATH)
+    get_filename_component(CUNIT_BASENAME "${CUNIT_LIBRARY}}" NAME_WE)
+    get_filename_component(CUNIT_PREFIX "${CUNIT_LIBRARY_DIR}" PATH)
+
+    find_program(
+      CUNIT_DLL
+        "${CMAKE_SHARED_LIBRARY_PREFIX}${CUNIT_BASENAME}${CMAKE_SHARED_LIBRARY_SUFFIX}"
+      HINTS
+        ${CUNIT_PREFIX}
+      PATH_SUFFIXES
+        bin
+      NO_DEFAULT_PATH)
+    mark_as_advanced(CUNIT_DLL)
+
+    # IMPORTANT:
+    # Providing a .dll file as the value for IMPORTED_LOCATION can only be
+    # done for "SHARED" libraries, otherwise the location of the .dll will be
+    # passed to linker, causing it to fail.
+    if(CUNIT_DLL)
+      add_library(CUnit SHARED IMPORTED)
+      set_target_properties(
+        CUnit PROPERTIES IMPORTED_IMPLIB "${CUNIT_LIBRARY}")
+      set_target_properties(
+        CUnit PROPERTIES IMPORTED_LOCATION "${CUNIT_DLL}")
+    else()
+      add_library(CUnit STATIC IMPORTED)
+      set_target_properties(
+        CUnit PROPERTIES IMPORTED_LOCATION "${CUNIT_LIBRARY}")
+    endif()
+  else()
+    add_library(CUnit UNKNOWN IMPORTED)
+    set_target_properties(
+      CUnit PROPERTIES IMPORTED_LOCATION "${CUNIT_LIBRARY}")
+  endif()
+
+  set_target_properties(
+    CUnit PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${CUNIT_INCLUDE_DIR}")
+endif()
+

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,5 @@
+[requires]
+cunit/2.1-3@bincrafters/stable
+
+[generators]
+cmake

--- a/src/ddscxx/CMakeLists.txt
+++ b/src/ddscxx/CMakeLists.txt
@@ -11,8 +11,6 @@
 #
 include(GenerateExportHeader)
 
-find_package(CycloneDDS REQUIRED)
-
 set(sources
     src/dds/core/Duration.cpp
     src/dds/core/Exception.cpp
@@ -107,10 +105,6 @@ install(
             "${CMAKE_CURRENT_SOURCE_DIR}/include/org"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ddscxx"
   COMPONENT dev)
-
-if(BUILD_TESTING)
-  add_subdirectory(tests)
-endif()
 
 # Preprocess headers to make the documentation more readable. The steps
 # involved have been converted from a Python script into CMake logic. This is

--- a/src/idlcxx/CMakeLists.txt
+++ b/src/idlcxx/CMakeLists.txt
@@ -23,3 +23,7 @@ target_include_directories(
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
 
 target_link_libraries(idlcxx PUBLIC CycloneDDS::idl)
+
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/src/idlcxx/CMakeLists.txt
+++ b/src/idlcxx/CMakeLists.txt
@@ -24,6 +24,21 @@ target_include_directories(
 
 target_link_libraries(idlcxx PUBLIC CycloneDDS::idl)
 
+include(GenerateExportHeader)
+
+generate_export_header(
+  idlcxx
+  BASE_NAME IDLCXX_EXPORT
+  EXPORT_MACRO_NAME IDLCXX_EXPORT
+  EXPORT_FILE_NAME "include/idlcxx/export.h")
+
+install(
+  TARGETS idlcxx
+  EXPORT "${CMAKE_PROJECT_NAME}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT lib
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib)
+
 if(BUILD_TESTING)
   add_subdirectory(tests)
 endif()

--- a/src/idlcxx/CMakeLists.txt
+++ b/src/idlcxx/CMakeLists.txt
@@ -9,5 +9,17 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-add_subdirectory(ddscxx)
-add_subdirectory(idlcxx)
+
+add_library(
+  idlcxx SHARED
+    src/backendCpp11.c
+    src/streamer_generator.c)
+
+target_include_directories(
+  idlcxx
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
+
+target_link_libraries(idlcxx PUBLIC CycloneDDS::idl)

--- a/src/idlcxx/CMakeLists.txt
+++ b/src/idlcxx/CMakeLists.txt
@@ -13,7 +13,8 @@
 add_library(
   idlcxx SHARED
     src/backendCpp11.c
-    src/streamer_generator.c)
+    src/streamer_generator.c
+    src/idl_ostream.c)
 
 target_include_directories(
   idlcxx

--- a/src/idlcxx/include/idlcxx/cpp11backend.h
+++ b/src/idlcxx/include/idlcxx/cpp11backend.h
@@ -13,9 +13,7 @@
 #ifndef IDL_CPP11BACKEND_H
 #define IDL_CPP11BACKEND_H
 
-#include "idl/export.h"
-
-IDL_EXPORT char *get_cpp_name(
+char *get_cpp_name(
   const char* name);
 
 #endif /* IDL_CPP11BACKEND_H */

--- a/src/idlcxx/include/idlcxx/cpp11backend.h
+++ b/src/idlcxx/include/idlcxx/cpp11backend.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright(c) 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#ifndef IDL_CPP11BACKEND_H
+#define IDL_CPP11BACKEND_H
+
+#include "idl/export.h"
+
+IDL_EXPORT char *get_cpp_name(
+  const char* name);
+
+#endif /* IDL_CPP11BACKEND_H */

--- a/src/idlcxx/include/idlcxx/idl_ostream.h
+++ b/src/idlcxx/include/idlcxx/idl_ostream.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright(c) 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef IDL_OSTREAM_H
+#define IDL_OSTREAM_H
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+
+#include "idlcxx/export.h"
+
+typedef struct idl_ostream idl_ostream_t;
+
+#define IDL_OSTREAM_BUFFER_INCR 4096
+
+IDLCXX_EXPORT idl_ostream_t* create_idl_ostream(FILE* file);
+
+IDLCXX_EXPORT char* get_ostream_buffer(const idl_ostream_t* str);
+
+IDLCXX_EXPORT size_t get_ostream_buffer_size(const idl_ostream_t* str);
+
+IDLCXX_EXPORT size_t get_ostream_buffer_position(const idl_ostream_t* str);
+
+IDLCXX_EXPORT FILE* get_ostream_file(idl_ostream_t* str);
+
+IDLCXX_EXPORT void destruct_idl_ostream(idl_ostream_t* ostr);
+
+IDLCXX_EXPORT void format_ostream(idl_ostream_t* ostr, const char* fmt, ...);
+
+IDLCXX_EXPORT size_t transfer_ostream_buffer(idl_ostream_t* from, idl_ostream_t* to);
+
+IDLCXX_EXPORT size_t flush_ostream(idl_ostream_t* str);
+
+#endif /* IDL_OSTREAM_H */

--- a/src/idlcxx/include/idlcxx/streamer_generator.h
+++ b/src/idlcxx/include/idlcxx/streamer_generator.h
@@ -18,17 +18,18 @@
 #include "idl/tree.h"
 #include "idl/retcode.h"
 #include "idl/idl_ostream.h"
+#include "idlcxx/export.h"
 
 typedef struct idl_streamer_output idl_streamer_output_t;
 
-IDL_EXPORT idl_streamer_output_t* create_idl_streamer_output(void);
+IDLCXX_EXPORT idl_streamer_output_t* create_idl_streamer_output(void);
 
-IDL_EXPORT idl_ostream_t* get_idl_streamer_impl_buf(const idl_streamer_output_t* str);
+IDLCXX_EXPORT idl_ostream_t* get_idl_streamer_impl_buf(const idl_streamer_output_t* str);
 
-IDL_EXPORT idl_ostream_t* get_idl_streamer_header_buf(const idl_streamer_output_t* str);
+IDLCXX_EXPORT idl_ostream_t* get_idl_streamer_header_buf(const idl_streamer_output_t* str);
 
-IDL_EXPORT void destruct_idl_streamer_output(idl_streamer_output_t* str);
+IDLCXX_EXPORT void destruct_idl_streamer_output(idl_streamer_output_t* str);
 
-IDL_EXPORT void idl_streamers_generate(idl_tree_t* tree, idl_streamer_output_t* str);
+IDLCXX_EXPORT void idl_streamers_generate(idl_tree_t* tree, idl_streamer_output_t* str);
 
 #endif

--- a/src/idlcxx/include/idlcxx/streamer_generator.h
+++ b/src/idlcxx/include/idlcxx/streamer_generator.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright(c) 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef IDL_STREAMER_GENERATOR_H
+#define IDL_STREAMER_GENERATOR_H
+
+#include <stdarg.h>
+#include <stdio.h>
+
+#include "idl/tree.h"
+#include "idl/retcode.h"
+#include "idl/idl_ostream.h"
+
+typedef struct idl_streamer_output idl_streamer_output_t;
+
+IDL_EXPORT idl_streamer_output_t* create_idl_streamer_output(void);
+
+IDL_EXPORT idl_ostream_t* get_idl_streamer_impl_buf(const idl_streamer_output_t* str);
+
+IDL_EXPORT idl_ostream_t* get_idl_streamer_header_buf(const idl_streamer_output_t* str);
+
+IDL_EXPORT void destruct_idl_streamer_output(idl_streamer_output_t* str);
+
+IDL_EXPORT void idl_streamers_generate(idl_tree_t* tree, idl_streamer_output_t* str);
+
+#endif

--- a/src/idlcxx/include/idlcxx/streamer_generator.h
+++ b/src/idlcxx/include/idlcxx/streamer_generator.h
@@ -17,7 +17,7 @@
 
 #include "idl/tree.h"
 #include "idl/retcode.h"
-#include "idl/idl_ostream.h"
+#include "idlcxx/idl_ostream.h"
 #include "idlcxx/export.h"
 
 typedef struct idl_streamer_output idl_streamer_output_t;

--- a/src/idlcxx/include/idlcxx/version.h.in
+++ b/src/idlcxx/include/idlcxx/version.h.in
@@ -1,0 +1,21 @@
+/*
+ * Copyright(c) 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef IDL_VERSION_H
+#define IDL_VERSION_H
+
+#define IDL_VERSION "@CycloneDDS_VERSION@"
+#define IDL_VERSION_MAJOR @CycloneDDS_VERSION_MAJOR@
+#define IDL_VERSION_MINOR @CycloneDDS_VERSION_MINOR@
+#define IDL_VERSION_PATCH @CycloneDDS_VERSION_PATCH@
+#define IDL_VERSION_TWEAK @CycloneDDS_VERSION_TWEAK@
+
+#endif /* IDL_VERSION_H */

--- a/src/idlcxx/src/backendCpp11.c
+++ b/src/idlcxx/src/backendCpp11.c
@@ -14,6 +14,8 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include "strdup.h"
+
 /* Specify a list of all C++11 keywords */
 static const char* cpp11_keywords[] =
 {
@@ -54,6 +56,6 @@ get_cpp_name(const char* name)
     }
   }
   /* No match with a keyword is found, thus return the identifier itself */
-  cpp11Name = strdup(name);
+  cpp11Name = idl_strdup(name);
   return cpp11Name;
 }

--- a/src/idlcxx/src/backendCpp11.c
+++ b/src/idlcxx/src/backendCpp11.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright(c) 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+/* Specify a list of all C++11 keywords */
+static const char* cpp11_keywords[] =
+{
+  /* QAC EXPECT 5007; Bypass qactools error */
+  "alignas", "alignof", "and", "and_eq", "asm", "auto", "bitand",
+  "bitor", "bool", "break", "case", "catch", "char", "char16_t",
+  "char32_t", "class", "compl", "concept", "const", "constexpr",
+  "const_cast", "continue", "decltype", "default", "delete",
+  "do", "double", "dynamic_cast", "else", "enum", "explicit",
+  "export", "extern", "false", "float", "for", "friend",
+  "goto", "if", "inline", "int", "long", "mutable",
+  "namespace", "new", "noexcept", "not", "not_eq", "nullptr", "operator", "or",
+  "or_eq", "private", "protected", "public", "register", "reinterpret_cast",
+  "requires", "return", "short", "signed", "sizeof", "static", "static_assert",
+  "static_cast", "struct", "switch", "template", "this", "thread_local", "throw",
+  "true", "try", "typedef", "typeid", "typename", "union", "unsigned",
+  "using", "virtual", "void", "volatile", "wchar_t", "while",
+  "xor", "xor_eq",
+  "int16_t", "int32_t", "int64_t",
+  "uint8_t", "uint16_t", "uint32_t", "uint64_t",
+};
+
+char*
+get_cpp_name(const char* name)
+{
+  char* cpp11Name;
+  size_t i;
+
+  /* search through the C++ keyword list */
+  for (i = 0; i < sizeof(cpp11_keywords) / sizeof(char*); i++) {
+    if (strcmp(cpp11_keywords[i], name) == 0) {
+      /* If a keyword matches the specified identifier, prepend _cxx_ */
+      /* QAC EXPECT 5007; will not use wrapper */
+      size_t cpp11NameLen = strlen(name) + 5 + 1;
+      cpp11Name = malloc(cpp11NameLen);
+      snprintf(cpp11Name, cpp11NameLen, "_cxx_%s", name);
+      return cpp11Name;
+    }
+  }
+  /* No match with a keyword is found, thus return the identifier itself */
+  cpp11Name = strdup(name);
+  return cpp11Name;
+}

--- a/src/idlcxx/src/idl_ostream.c
+++ b/src/idlcxx/src/idl_ostream.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright(c) 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#include "idlcxx/idl_ostream.h"
+#include "idl/processor.h"
+
+#include <string.h>
+#include <stdarg.h>
+
+struct idl_ostream
+{
+  FILE* _file;
+  idl_buffer_t _buf;
+};
+
+idl_ostream_t* create_idl_ostream(FILE* file)
+{
+  idl_ostream_t* ptr = malloc(sizeof(idl_ostream_t));
+
+  ptr->_buf.data = malloc(IDL_OSTREAM_BUFFER_INCR);
+  memset(ptr->_buf.data, 0x0, IDL_OSTREAM_BUFFER_INCR);
+  ptr->_buf.size = IDL_OSTREAM_BUFFER_INCR;
+  ptr->_buf.used = 0;
+  ptr->_file = file;
+
+  return ptr;
+}
+
+char* get_ostream_buffer(const idl_ostream_t* str)
+{
+  return str->_buf.data;
+}
+
+size_t get_ostream_buffer_size(const idl_ostream_t* str)
+{
+  return str->_buf.size;
+}
+
+size_t get_ostream_buffer_position(const idl_ostream_t* str)
+{
+  return str->_buf.used;
+}
+
+FILE* get_ostream_file(idl_ostream_t* str)
+{
+  return str->_file;
+}
+
+void destruct_idl_ostream(idl_ostream_t* ostr)
+{
+  if (ostr)
+  {
+    if (ostr->_buf.data)
+      free(ostr->_buf.data);
+    free(ostr);
+  }
+}
+
+void format_ostream(idl_ostream_t* ostr, const char* fmt, ...)
+{
+  va_list args;
+  va_start(args, fmt);
+
+  size_t space = ostr->_buf.size - ostr->_buf.used;
+  int wb = vsnprintf(ostr->_buf.data + ostr->_buf.used,
+                      space,
+                      fmt,
+                      args);
+  if (wb < 0)
+  {
+    fprintf(stderr, "a formatting error occurred during format_ostream\n");
+    return;
+  }
+  size_t writtenbytes = (size_t)wb;
+  if (writtenbytes < space)
+  {
+    ostr->_buf.used += writtenbytes;
+  }
+  else
+  {
+    size_t newsize = ostr->_buf.size + writtenbytes + IDL_OSTREAM_BUFFER_INCR;
+    char *temp = realloc(ostr->_buf.data, newsize);
+    if (temp)
+    {
+      ostr->_buf.data = temp;
+      ostr->_buf.size = newsize;
+      space = ostr->_buf.size - ostr->_buf.used;
+      wb = vsnprintf(ostr->_buf.data + ostr->_buf.used,
+                      space,
+                      fmt,
+                      args);
+
+      if (wb < 0)
+        fprintf(stderr, "a formatting error occurred during format_ostream\n");
+      else
+        ostr->_buf.used += (unsigned int)wb;
+    }
+    else
+    {
+      ostr->_buf.size = 0;
+      ostr->_buf.used = 0;
+      fprintf(stderr,"format_ostream out of memory error\n");
+    }
+  }
+
+  va_end(args);
+}
+
+size_t transfer_ostream_buffer(idl_ostream_t* from, idl_ostream_t* to)
+{
+  if (from == NULL || to == NULL)
+    return 0;
+
+  format_ostream(to, from->_buf.data);
+
+  size_t returnval = from->_buf.used;
+  from->_buf.data[0] = 0x0;
+  from->_buf.used = 0;
+
+  return returnval;
+}
+
+size_t flush_ostream(idl_ostream_t* str)
+{
+  if (str->_file)
+    fprintf(str->_file, "%s", str->_buf.data);
+
+  size_t returnval = str->_buf.used;
+  str->_buf.used = 0;
+
+  return returnval;
+}

--- a/src/idlcxx/src/strdup.h
+++ b/src/idlcxx/src/strdup.h
@@ -9,13 +9,15 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-#ifndef IDL_VERSION_H
-#define IDL_VERSION_H
+#ifndef IDL_STRDUP_H
+#define IDL_STRDUP_H
 
-#define IDL_VERSION "@CycloneDDS_VERSION@"
-#define IDL_VERSION_MAJOR @CycloneDDS_VERSION_MAJOR@
-#define IDL_VERSION_MINOR @CycloneDDS_VERSION_MINOR@
-#define IDL_VERSION_PATCH @CycloneDDS_VERSION_PATCH@
-#define IDL_VERSION_TWEAK @CycloneDDS_VERSION_TWEAK@
+#include <string.h>
 
-#endif /* IDL_VERSION_H */
+#if _WIN32
+# define idl_strdup(s) _strdup(s)
+#else
+# define idl_strdup(s) strdup(s)
+#endif
+
+#endif /* IDL_STRDUP_H */

--- a/src/idlcxx/src/streamer_generator.c
+++ b/src/idlcxx/src/streamer_generator.c
@@ -811,7 +811,7 @@ idl_retcode_t process_case(context_t* ctx, idl_case_t* _case)
   else if ((_case->type_spec->mask & IDL_TEMPL_TYPE) == IDL_TEMPL_TYPE)
     process_template(ctx, _case->declarator, _case->type_spec);
   else
-    return IDL_RETCODE_PARSE_ERROR;
+    return IDL_RETCODE_INVALID_PARSETREE;
 
   ctx->depth--;
   format_write_stream(1, ctx, "  }\n");
@@ -844,7 +844,7 @@ idl_retcode_t process_case_label(context_t* ctx, idl_case_label_t* label)
     {
       int n = snprintf(buffer, 0, "%lu", *((uint64_t*)ptr));
       if (n < 0)
-        return IDL_RETCODE_PARSE_ERROR;
+        return IDL_RETCODE_SYNTAX_ERROR;
       buffer = calloc((size_t)n + 1,1);
       snprintf(buffer, (size_t)n + 1, "%lu", *((uint64_t*)ptr));
     }
@@ -860,7 +860,7 @@ idl_retcode_t process_case_label(context_t* ctx, idl_case_label_t* label)
     }
   }
   else 
-    return IDL_RETCODE_PARSE_ERROR;
+    return IDL_RETCODE_INVALID_PARSETREE;
 
   if (buffer)
   {

--- a/src/idlcxx/src/streamer_generator.c
+++ b/src/idlcxx/src/streamer_generator.c
@@ -431,7 +431,7 @@ idl_retcode_t process_known_width(context_t* ctx, const char* name, idl_kind_t k
     cast_fmt = int8_cast;
     break;
   case IDL_UINT8:
-  //case IDL_OCTET:
+  case IDL_OCTET:
     cast_fmt = uint8_cast;
     break;
   case IDL_INT16:

--- a/src/idlcxx/src/streamer_generator.c
+++ b/src/idlcxx/src/streamer_generator.c
@@ -1,0 +1,679 @@
+/*
+ * Copyright(c) 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "idlcxx/streamer_generator.h"
+#include "idlcxx/cpp11backend.h"
+#include "idl/tree.h"
+
+#ifndef _WIN32
+#define strcpy_s(ptr, len, str) strcpy(ptr, str)
+#define sprintf_s(ptr, len, str, ...) sprintf(ptr, str, __VA_ARGS__)
+#define strcat_s(ptr, len, str) strcat(ptr, str)
+#endif
+
+#define format_ostream_indented(depth,ostr,str,...) \
+if (depth > 0) format_ostream(ostr, "%*c", depth, ' '); \
+format_ostream(ostr, str, ##__VA_ARGS__);
+
+static const char* struct_write_func_fmt = "size_t write_struct(const %s &obj, void *data, size_t position)";
+static const char* primitive_calc_alignment_modulo_fmt = "(%d - position%%%d)%%%d;";
+static const char* primitive_calc_alignment_shift_fmt = "(%d - position&%#x)&%#x;";
+static const char* primitive_incr_fmt = "  position += ";
+static const char* primitive_incr_alignment_fmt = "  position += alignmentbytes;";
+static const char* primitive_write_func_padding_fmt = "  memset(data+position,0x0,%d);  //setting padding bytes to 0x0\n";
+static const char* primitive_write_func_alignment_fmt = "  memset(data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n";
+static const char* primitive_write_func_write_fmt = "  memcpy(data+position,&obj.%s(),%d%s);  //bytes for member: %s\n";
+static const char* incr_comment = "  //moving position indicator\n";
+static const char* align_comment = "  //alignment\n";
+static const char* padding_comment = "  //padding bytes\n";
+static const char* instance_write_func_fmt = "  position = write_struct(obj.%s(), data, position);\n";
+static const char* namespace_declaration_fmt = "namespace %s\n";
+static const char* struct_write_size_func_fmt = "size_t write_size(const %s &obj, size_t offset)";
+static const char* primitive_incr_pos = "  position += %d;";
+static const char* instance_size_func_calc_fmt = "  position += write_size(obj.%s(), position);\n";
+static const char* struct_read_func_fmt = "size_t read_struct(%s &obj, void *data, size_t position)";
+static const char* primitive_read_func_read_fmt = "  memcpy(&obj.%s(), data+position, %d);  //bytes for member: %s\n";
+static const char* primitive_read_func_seq_fmt = "  memcpy(&sequenceentries, data+position, %d);  //number of entries in the sequence\n";
+static const char* instance_read_func_fmt = "  position = read_struct(obj.%s(), data, position);\n";
+static const char* seq_size_fmt = "%s().size";
+static const char* seq_read_reserve_fmt = "  obj.%s().reserve(sequenceentries);\n";
+static const char* seq_structured_write_fmt = "  for (const auto &%s:obj.%s()) position = write_struct(%s,data,position);\n";
+static const char* seq_structured_write_size_fmt = "  for (const auto &%s:obj.%s()) position += write_size(%s, position);\n";
+static const char* seq_structured_read_copy_fmt = "  for (size_t %s = 0; %s < sequenceentries; %s++) position = read_struct(obj.%s()[%s], data, position);\n";
+static const char* seq_primitive_write_fmt = "  memcpy(data+position,obj.%s().data(),sequenceentries*%d);  //contents for %s\n";
+static const char* seq_primitive_read_fmt = "  memcpy(obj.%s().data(),data+position,sequenceentries*%d);\n";
+static const char* seq_incr_fmt = "  position += sequenceentries*%d;\n";
+
+#if 0
+static const char* fixed_pt_write_digits = "    long long int digits = ((long double)obj.%s()/pow(10.0,obj.%s().fixed_scale()));\n";
+static const char* fixed_pt_write_byte = "    int byte = (obj.%s().fixed_digits())/2;\n";
+static const char* fixed_pt_write_fill[] = {
+"    if (digits < 0)\n",
+"    {\n",
+"      digits *= -1;\n",
+"      data[position + byte] = (digits % 10 << 4) | 0x0d;\n",
+"    }\n",
+"    else\n",
+"    {\n",
+"      data[position + byte] = (digits % 10 << 4) | 0x0c;\n",
+"    }\n",
+"    while (byte && digits)\n",
+"    {\n",
+"      byte--;\n",
+"      digits /= 10;\n",
+"      data[position + byte] = ((unsigned char)digits) % 10;\n",
+"      digits /= 10;\n",
+"      data[position + byte] |= ((unsigned char)digits) % 10 * 16;\n",
+"    }\n",
+"    memset(data + position,0x0,byte);\n"
+};
+static const char* fixed_pt_write_position = "  position += (obj.%s().fixed_digits()/2) + 1;\n";
+
+static const char* fixed_pt_read_byte = "    int byte = obj.%s().fixed_digits()/2;\n";
+static const char* fixed_pt_read_fill[] = {
+"    long long int digits = ((unsigned_char)data[byte] & 0xf0) >> 4;\n",
+"    if (data[byte] & 0x0d == 0x0d)\n",
+"      digits *= -1;\n",
+"    while (byte >= 0)\n",
+"    {\n",
+"      unsigned char temp = *((usigned char*)(data + position + byte));\n",
+"      digits *= 10;\n",
+"      digits *= 10;\n",
+"      byte--;\n",
+"    }\n"
+};
+static const char* fixed_pt_read_assign = "    obj.%s() = (pow((long double)0.1, obj.%s().fixed_scale()) * digits);\n";
+static const char* fixed_pt_read_position = "    position += (obj.%s().fixed_digits()/2) + 1;\n";
+#endif
+
+struct idl_streamer_output
+{
+  size_t indent;
+  idl_ostream_t* header_stream;
+  idl_ostream_t* impl_stream;
+};
+
+typedef struct context context_t;
+
+struct context
+{
+  idl_streamer_output_t* str;
+  char* context;
+  idl_ostream_t* header_stream;
+  idl_ostream_t* write_size_stream;
+  idl_ostream_t* write_stream;
+  idl_ostream_t* read_stream;
+  size_t depth;
+  int currentalignment;
+  int accumulatedalignment;
+  int alignmentpresent;
+  int sequenceentriespresent;
+  context_t* parent;
+};
+
+
+static idl_retcode_t process_node(context_t* ctx, idl_node_t* node);
+static idl_retcode_t process_instance(context_t* ctx, idl_node_t* node);
+static idl_retcode_t process_base(context_t* ctx, idl_member_t* member);
+static idl_retcode_t process_template(context_t* ctx, idl_member_t* member);
+static idl_retcode_t process_known_width(context_t* ctx, const char* name, int bytewidth, int sequence, const char* seqappend);
+static int determine_byte_width(const idl_type_spec_t* typespec);
+static idl_retcode_t add_alignment(context_t* ctx, int bytewidth);
+static idl_retcode_t process_member(context_t* ctx, idl_member_t* member);
+static idl_retcode_t process_module(context_t* ctx, idl_module_t* module);
+static idl_retcode_t process_constructed(context_t* ctx, idl_node_t* node);
+static context_t* create_context(idl_streamer_output_t* str, const char* ctx);
+static void flush_streams(context_t* ctx);
+static void close_context(context_t* ctx);
+
+static char* generatealignment(int alignto)
+{
+  char* returnval = NULL;
+  if (alignto < 2)
+  {
+    size_t len = strlen("0;") + 1;
+    returnval = malloc(len);
+    strcpy_s(returnval, len, "0;");
+  }
+  else if (alignto == 2)
+  {
+    size_t len = strlen("position&0x1;") + 1;
+    returnval = malloc(len);
+    strcpy_s(returnval, len, "position&0x1;");
+  }
+  else
+  {
+    int mask = 0xFFFFFF;
+    while (mask != 0)
+    {
+      if (alignto == mask + 1)
+      {
+        size_t len = strlen(primitive_calc_alignment_shift_fmt) - 2 + 30 + 1;
+        returnval = malloc(len);
+        sprintf_s(returnval, len, primitive_calc_alignment_shift_fmt, alignto, mask, mask);
+        return returnval;
+      }
+      mask >>= 1;
+    }
+
+    size_t len = strlen(primitive_calc_alignment_modulo_fmt) - 10 + 5 + 1;
+    returnval = malloc(len);
+    sprintf_s(returnval, len, primitive_calc_alignment_modulo_fmt, alignto, alignto, alignto);
+  }
+  return returnval;
+}
+
+int determine_byte_width(const idl_type_spec_t* typespec)
+{
+  if ((typespec->kind & IDL_ENUM_TYPE) == IDL_ENUM_TYPE)
+    return 4;
+
+  switch (typespec->kind)
+  {
+  case IDL_INT8:
+  case IDL_UINT8:
+  case IDL_CHAR:
+  case IDL_WCHAR:
+  case IDL_BOOL:
+  case IDL_OCTET:
+    return 1;
+  case IDL_INT16: // is equal to IDL_SHORT
+  case IDL_UINT16: // is equal to IDL_USHORT
+    return 2;
+  case IDL_INT32: //is equal to IDL_LONG
+  case IDL_UINT32: //is equal to IDL_ULONG
+  case IDL_FLOAT:
+    return 4;
+  case IDL_INT64: //is equal to IDL_LLONG
+  case IDL_UINT64: //is equal to IDL_ULLONG
+  case IDL_DOUBLE:
+  case IDL_LDOUBLE:
+    return 8;
+  }
+
+  return -1;
+}
+
+idl_streamer_output_t* create_idl_streamer_output()
+{
+  idl_streamer_output_t* ptr = malloc(sizeof(idl_streamer_output_t));
+  if (NULL != ptr)
+  {
+    ptr->indent = 0;
+    ptr->header_stream = create_idl_ostream(NULL);
+    ptr->impl_stream = create_idl_ostream(NULL);
+  }
+  return ptr;
+}
+
+void destruct_idl_streamer_output(idl_streamer_output_t* str)
+{
+  if (NULL == str)
+    return;
+
+  if (str->header_stream != NULL)
+    destruct_idl_ostream(str->header_stream);
+  if (str->impl_stream != NULL)
+    destruct_idl_ostream(str->impl_stream);
+  free(str);
+}
+
+idl_ostream_t* get_idl_streamer_impl_buf(const idl_streamer_output_t* str)
+{
+  return str->impl_stream;
+}
+
+idl_ostream_t* get_idl_streamer_header_buf(const idl_streamer_output_t* str)
+{
+  return str->header_stream;
+}
+
+context_t* create_context(idl_streamer_output_t* str, const char* ctx)
+{
+  context_t* ptr = malloc(sizeof(context_t));
+  if (NULL != ptr)
+  {
+    ptr->str = str;
+    ptr->depth = 0;
+    size_t len = strlen(ctx) + 1;
+    ptr->context = malloc(len);
+    ptr->context[strlen(ctx)] = 0x0;
+    strcpy_s(ptr->context, len, ctx);
+    ptr->currentalignment = -1;
+    ptr->accumulatedalignment = 0;
+    ptr->alignmentpresent = 0;
+    ptr->sequenceentriespresent = 0;
+    ptr->header_stream = create_idl_ostream(NULL);
+    ptr->write_size_stream = create_idl_ostream(NULL);
+    ptr->write_stream = create_idl_ostream(NULL);
+    ptr->read_stream = create_idl_ostream(NULL);
+  }
+  //printf("new context generated: %s\n", ctx);
+  return ptr;
+}
+
+void flush_streams(context_t* ctx)
+{
+  transfer_ostream_buffer(ctx->header_stream, ctx->str->header_stream);
+  transfer_ostream_buffer(ctx->write_stream, ctx->str->impl_stream);
+  transfer_ostream_buffer(ctx->write_size_stream, ctx->str->impl_stream);
+  transfer_ostream_buffer(ctx->read_stream, ctx->str->impl_stream);
+}
+
+void close_context(context_t* ctx)
+{
+  //add closing statements to buffers?
+  flush_streams(ctx);
+
+  destruct_idl_ostream(ctx->header_stream);
+  destruct_idl_ostream(ctx->write_stream);
+  destruct_idl_ostream(ctx->write_size_stream);
+  destruct_idl_ostream(ctx->read_stream);
+
+  free(ctx->context);
+}
+
+idl_retcode_t process_node(context_t* ctx, idl_node_t* node)
+{
+  if (idl_is_member(node))
+    process_member(ctx, (idl_member_t*)node);
+  else if (idl_is_module(node))
+    process_module(ctx, (idl_module_t*)node);
+  else if (idl_is_constructed_type(node))
+    process_constructed(ctx, node);
+
+  if (node->next)
+    process_node(ctx, node->next);
+
+  return IDL_RETCODE_OK;
+}
+
+idl_retcode_t process_member(context_t* ctx, idl_member_t* member)
+{
+  if (NULL == ctx || NULL == member)
+    return IDL_RETCODE_INVALID_PARSETREE;
+  if (member->type_spec->kind & IDL_BASE_TYPE)
+    process_base(ctx, member);
+  else if (member->type_spec->kind & IDL_SCOPED_NAME)
+    process_instance(ctx, &member->node);
+  else if (member->type_spec->kind & IDL_TEMPL_TYPE)
+    process_template(ctx, member);
+
+  return IDL_RETCODE_OK;
+}
+
+idl_retcode_t process_instance(context_t* ctx, idl_node_t* node)
+{
+  if (NULL == ctx || NULL == node)
+    return IDL_RETCODE_INVALID_PARSETREE;
+  idl_member_t* member = (idl_member_t*)node;
+  // FIXME: this probably needs to loop?
+  char* cpp11name = get_cpp_name(member->declarators->identifier);
+  format_ostream_indented(ctx->depth * 2, ctx->write_stream, instance_write_func_fmt, cpp11name);
+  format_ostream_indented(ctx->depth * 2, ctx->read_stream, instance_read_func_fmt, cpp11name);
+  format_ostream_indented(ctx->depth * 2, ctx->write_size_stream, instance_size_func_calc_fmt, cpp11name);
+
+  ctx->accumulatedalignment = 0;
+  ctx->currentalignment = -1;
+
+  free(cpp11name);
+  return IDL_RETCODE_OK;
+}
+
+idl_retcode_t add_alignment(context_t* ctx, int bytewidth)
+{
+  if (NULL == ctx)
+    return IDL_RETCODE_INVALID_PARSETREE;
+
+  //printf("current alignment: %d, byte width: %d, acc: %d\n", ctx->currentalignment, bytewidth, ctx->accumulatedalignment);
+  if ((0 > ctx->currentalignment || bytewidth > ctx->currentalignment) && bytewidth != 1)
+  {
+    if (0 == ctx->alignmentpresent)
+    {
+      format_ostream_indented(ctx->depth * 2, ctx->write_stream, "  size_t alignmentbytes = ");
+      format_ostream_indented(ctx->depth * 2, ctx->read_stream, "  size_t alignmentbytes = ");
+      ctx->alignmentpresent = 1;
+    }
+    else
+    {
+      format_ostream_indented(ctx->depth * 2, ctx->write_stream, "  alignmentbytes = ");
+      format_ostream_indented(ctx->depth * 2, ctx->read_stream, "  alignmentbytes = ");
+    }
+
+
+    char* buffer = generatealignment(bytewidth);
+    format_ostream_indented(0, ctx->write_stream, buffer);
+    format_ostream_indented(0, ctx->write_stream, align_comment);
+    format_ostream_indented(ctx->depth * 2, ctx->write_stream, primitive_write_func_alignment_fmt);
+    format_ostream_indented(ctx->depth * 2, ctx->write_stream, primitive_incr_alignment_fmt);
+    format_ostream_indented(0, ctx->write_stream, incr_comment);
+
+    format_ostream_indented(0, ctx->read_stream, buffer);
+    format_ostream_indented(0, ctx->read_stream, align_comment);
+    format_ostream_indented(ctx->depth * 2, ctx->read_stream, primitive_incr_alignment_fmt);
+    format_ostream_indented(0, ctx->read_stream, incr_comment);
+
+    format_ostream_indented(ctx->depth * 2, ctx->write_size_stream, primitive_incr_fmt);
+    format_ostream_indented(0, ctx->write_size_stream, buffer);
+    format_ostream_indented(0, ctx->write_size_stream, align_comment);
+
+    ctx->accumulatedalignment = 0;
+    ctx->currentalignment = bytewidth;
+
+    if (buffer)
+      free(buffer);
+  }
+  else
+  {
+    int missingbytes = (bytewidth - (ctx->accumulatedalignment % bytewidth)) % bytewidth;
+    if (0 != missingbytes)
+    {
+      format_ostream_indented(ctx->depth * 2, ctx->write_stream, primitive_write_func_padding_fmt, missingbytes);
+      format_ostream_indented(ctx->depth * 2, ctx->write_size_stream, primitive_incr_pos, missingbytes);
+      format_ostream_indented(0, ctx->write_size_stream, padding_comment);
+      format_ostream_indented(ctx->depth * 2, ctx->read_stream, primitive_incr_pos, missingbytes);
+      format_ostream_indented(0, ctx->read_stream, padding_comment);
+      format_ostream_indented(ctx->depth * 2, ctx->write_stream, primitive_incr_pos, missingbytes);
+      format_ostream_indented(0, ctx->write_stream, incr_comment);
+
+      ctx->accumulatedalignment = 0;
+    }
+  }
+
+  return IDL_RETCODE_OK;
+}
+
+idl_retcode_t process_known_width(context_t* ctx, const char* name, int bytewidth, int sequence, const char* seqappend)
+{
+  if (NULL == ctx || NULL == name)
+    return IDL_RETCODE_INVALID_PARSETREE;
+
+  if (ctx->currentalignment != bytewidth)
+    add_alignment(ctx, bytewidth);
+  format_ostream_indented(ctx->depth * 2, ctx->write_stream, primitive_write_func_write_fmt, name, bytewidth, seqappend ? seqappend : "", name);
+
+  ctx->accumulatedalignment += bytewidth;
+
+  if (0 == sequence)
+  {
+    format_ostream_indented(ctx->depth * 2, ctx->read_stream, primitive_read_func_read_fmt, name, bytewidth, name);
+  }
+  else
+  {
+    if (0 == ctx->sequenceentriespresent)
+    {
+      format_ostream_indented(ctx->depth * 2, ctx->read_stream, "  uint32_t sequenceentries;");
+      ctx->sequenceentriespresent = 1;
+    }
+    format_ostream_indented(ctx->depth * 2, ctx->read_stream, primitive_read_func_seq_fmt, bytewidth);
+  }
+
+  format_ostream_indented(ctx->depth * 2, ctx->write_size_stream, primitive_incr_pos, bytewidth);
+  format_ostream_indented(0, ctx->write_size_stream, "  //bytes for member: ");
+  format_ostream_indented(0, ctx->write_size_stream, name);
+  format_ostream_indented(0, ctx->write_size_stream, "\n");
+
+  format_ostream_indented(ctx->depth * 2, ctx->write_stream, primitive_incr_pos, bytewidth);
+  format_ostream_indented(0, ctx->write_stream, incr_comment);
+
+  format_ostream_indented(ctx->depth * 2, ctx->read_stream, primitive_incr_pos, bytewidth);
+  format_ostream_indented(0, ctx->read_stream, incr_comment);
+
+  return IDL_RETCODE_OK;
+}
+
+idl_retcode_t process_template(context_t* ctx, idl_member_t* member)
+{
+  if (NULL == ctx || NULL == member)
+    return IDL_RETCODE_INVALID_PARSETREE;
+
+  char* cpp11name = NULL;
+  idl_type_spec_t* type_spec = member->type_spec;
+
+  if ((type_spec->kind & IDL_SEQUENCE_TYPE) == IDL_SEQUENCE_TYPE)
+  {
+    // FIXME: loop!?
+    cpp11name = get_cpp_name(member->declarators->identifier);
+
+    size_t cpp11len = strlen(cpp11name);
+    size_t bufsize = cpp11len + strlen(seq_size_fmt) - 2 + 1;
+    char* buffer = malloc(bufsize);
+    sprintf_s(buffer, bufsize, seq_size_fmt, cpp11name);
+    process_known_width(ctx, buffer, 4, 1, NULL);
+
+    if (buffer)
+      free(buffer);
+
+    //TODO!!! determine whether the templated type is a base type or no
+    bool is_base_type = false;
+    if (is_base_type)
+    {
+      int bytewidth = determine_byte_width(type_spec);  //determine byte width of base type?
+
+      if (bytewidth > 4)
+        add_alignment(ctx, bytewidth);
+
+      format_ostream_indented(ctx->depth * 2, ctx->write_stream, seq_primitive_write_fmt, cpp11name, bytewidth, cpp11name);
+      format_ostream_indented(ctx->depth * 2, ctx->read_stream, seq_read_reserve_fmt, cpp11name);
+      format_ostream_indented(ctx->depth * 2, ctx->read_stream, seq_primitive_read_fmt, cpp11name, bytewidth);
+      format_ostream_indented(ctx->depth * 2, ctx->write_stream, seq_incr_fmt, bytewidth);
+      format_ostream_indented(ctx->depth * 2, ctx->write_size_stream, seq_incr_fmt, bytewidth);
+      format_ostream_indented(ctx->depth * 2, ctx->read_stream, seq_incr_fmt, bytewidth);
+    }
+    else
+    {
+      char* iterated_name = NULL;
+      size_t iterated_name_size = 0;
+
+      if (strcmp(cpp11name, "_1"))
+      {
+        iterated_name_size = strlen("_1") + 1;
+        iterated_name = malloc(iterated_name_size);
+        strcpy_s(iterated_name, iterated_name_size, "_1");
+      }
+      else
+      {
+        iterated_name_size = strlen("_2") + 1;
+        iterated_name = malloc(iterated_name_size);
+        strcpy_s(iterated_name, iterated_name_size, "_2");
+      }
+
+      format_ostream_indented(ctx->depth * 2, ctx->write_stream, seq_structured_write_fmt, iterated_name, cpp11name, iterated_name);
+      format_ostream_indented(ctx->depth * 2, ctx->write_size_stream, seq_structured_write_size_fmt, iterated_name, cpp11name, iterated_name);
+      format_ostream_indented(ctx->depth * 2, ctx->read_stream, seq_read_reserve_fmt, cpp11name);
+      format_ostream_indented(ctx->depth * 2, ctx->read_stream, seq_structured_read_copy_fmt, iterated_name, iterated_name, iterated_name, cpp11name, iterated_name);
+
+      if (NULL != iterated_name)
+        free(iterated_name);
+    }
+
+    ctx->accumulatedalignment = 0;
+    ctx->currentalignment = -1;
+  }
+  else if ((type_spec->kind & IDL_STRING_TYPE) == IDL_STRING_TYPE ||
+    (type_spec->kind & IDL_WSTRING_TYPE) == IDL_WSTRING_TYPE)
+  {
+    // FIXME: loop!?
+    cpp11name = get_cpp_name(member->declarators->identifier);
+    size_t cpp11len = strlen(cpp11name);
+    size_t bufsize = cpp11len + strlen(seq_size_fmt) - 2 + 1;
+    char* buffer = malloc(bufsize);
+    sprintf_s(buffer, bufsize, seq_size_fmt, cpp11name);
+    process_known_width(ctx, buffer, 4, 1, "+1");
+
+    if (buffer)
+      free(buffer);
+
+    format_ostream_indented(ctx->depth * 2, ctx->write_stream, seq_primitive_write_fmt, cpp11name, 1, cpp11name);
+    format_ostream_indented(ctx->depth * 2, ctx->read_stream, seq_read_reserve_fmt, cpp11name);
+    format_ostream_indented(ctx->depth * 2, ctx->read_stream, seq_primitive_read_fmt, cpp11name, 1);
+    format_ostream_indented(ctx->depth * 2, ctx->write_stream, seq_incr_fmt, 1);
+    format_ostream_indented(ctx->depth * 2, ctx->write_size_stream, seq_incr_fmt, 1);
+    format_ostream_indented(ctx->depth * 2, ctx->read_stream, seq_incr_fmt, 1);
+
+    ctx->accumulatedalignment = 0;
+    ctx->currentalignment = -1;
+  }
+#if 0
+  else if ((type_spec->kind & IDL_FIXED_PT_TYPE) == IDL_FIXED_PT_TYPE)
+  {
+    //fputs("fixed point type template classes not supported at this time", stderr);
+
+    format_ostream_indented(ctx->depth * 2, ctx->write_stream, "  {\n");
+    format_ostream_indented(ctx->depth * 2, ctx->write_stream, fixed_pt_write_digits, cpp11name, cpp11name);
+    format_ostream_indented(ctx->depth * 2, ctx->write_stream, fixed_pt_write_byte, cpp11name);
+
+    for (size_t i = 0; i < sizeof(fixed_pt_write_fill) / sizeof(const char*); i++)
+      format_ostream_indented(ctx->depth * 2, ctx->write_stream, fixed_pt_write_fill[i]);
+    format_ostream_indented(ctx->depth * 2, ctx->write_stream, fixed_pt_write_position, cpp11name);
+    format_ostream_indented(ctx->depth * 2, ctx->write_size_stream, "  ");
+    format_ostream_indented(0, ctx->write_size_stream, fixed_pt_write_position, cpp11name);
+    format_ostream_indented(ctx->depth * 2, ctx->write_stream, "  }\n");
+    format_ostream_indented(ctx->depth * 2, ctx->read_stream, "  {\n");
+    format_ostream_indented(ctx->depth * 2, ctx->read_stream, fixed_pt_read_byte, cpp11name);
+
+    for (size_t i = 0; i < sizeof(fixed_pt_read_fill) / sizeof(const char*); i++)
+      format_ostream_indented(ctx->depth * 2, ctx->read_stream, fixed_pt_read_fill[i]);
+
+    format_ostream_indented(ctx->depth * 2, ctx->read_stream, fixed_pt_read_assign, cpp11name, cpp11name);
+    format_ostream_indented(ctx->depth * 2, ctx->read_stream, fixed_pt_read_position, cpp11name);
+    format_ostream_indented(ctx->depth * 2, ctx->read_stream, "  }\n");
+
+    ctx->accumulatedalignment = 0;
+    ctx->currentalignment = -1;
+  }
+#endif
+
+  if (cpp11name)
+    free(cpp11name);
+  return IDL_RETCODE_OK;
+}
+
+idl_retcode_t process_module(context_t* ctx, idl_module_t* module)
+{
+  if (NULL == ctx || NULL == module)
+    return IDL_RETCODE_INVALID_PARSETREE;
+
+  if (module->definitions)
+  {
+    char* cpp11name = get_cpp_name(module->identifier);
+    format_ostream_indented(ctx->depth * 2, ctx->str->header_stream, namespace_declaration_fmt, cpp11name);
+    format_ostream_indented(ctx->depth * 2, ctx->str->header_stream, "{\n\n");
+    format_ostream_indented(ctx->depth * 2, ctx->str->impl_stream, namespace_declaration_fmt, cpp11name);
+    format_ostream_indented(ctx->depth * 2, ctx->str->impl_stream, "{\n\n");
+
+    context_t* newctx = create_context(ctx->str, cpp11name);
+    newctx->depth = ctx->depth + 1;
+
+    process_node(newctx, (idl_node_t*)module->definitions);
+
+    close_context(newctx);
+
+    free(newctx);
+
+    format_ostream_indented(ctx->depth * 2, ctx->str->header_stream, "}\n\n");
+    format_ostream_indented(ctx->depth * 2, ctx->str->impl_stream, "}\n\n");
+
+    free(cpp11name);
+  }
+
+  return IDL_RETCODE_OK;
+}
+
+idl_retcode_t process_constructed(context_t* ctx, idl_node_t* node)
+{
+  if (NULL == ctx || NULL == node)
+    return IDL_RETCODE_INVALID_PARSETREE;
+
+  char* cpp11name = NULL;
+
+  if (idl_is_struct(node))
+  {
+    idl_struct_type_t* _struct = (idl_struct_type_t*)node;
+    if (_struct->members)
+    {
+      cpp11name = get_cpp_name(_struct->identifier);
+      format_ostream_indented(ctx->depth * 2, ctx->header_stream, struct_write_func_fmt, cpp11name);
+      format_ostream_indented(0, ctx->header_stream, ";\n\n");
+      format_ostream_indented(ctx->depth * 2, ctx->write_stream, struct_write_func_fmt, cpp11name);
+      format_ostream_indented(0, ctx->write_stream, "\n");
+      format_ostream_indented(ctx->depth * 2, ctx->write_stream, "{\n");
+
+      format_ostream_indented(ctx->depth * 2, ctx->header_stream, struct_write_size_func_fmt, cpp11name);
+      format_ostream_indented(0, ctx->header_stream, ";\n\n");
+      format_ostream_indented(ctx->depth * 2, ctx->write_size_stream, struct_write_size_func_fmt, cpp11name);
+      format_ostream_indented(0, ctx->write_size_stream, "\n");
+      format_ostream_indented(ctx->depth * 2, ctx->write_size_stream, "{\n");
+      format_ostream_indented(ctx->depth * 2, ctx->write_size_stream, "  size_t position = offset;\n");
+
+      format_ostream_indented(ctx->depth * 2, ctx->header_stream, struct_read_func_fmt, cpp11name);
+      format_ostream_indented(0, ctx->header_stream, ";\n\n");
+      format_ostream_indented(ctx->depth * 2, ctx->read_stream, struct_read_func_fmt, cpp11name);
+      format_ostream_indented(0, ctx->read_stream, "\n");
+      format_ostream_indented(ctx->depth * 2, ctx->read_stream, "{\n");
+
+      ctx->currentalignment = -1;
+      ctx->alignmentpresent = 0;
+      ctx->sequenceentriespresent = 0;
+      ctx->accumulatedalignment = 0;
+
+      process_node(ctx, (idl_node_t*)_struct->members);
+
+      format_ostream_indented(ctx->depth * 2, ctx->write_size_stream, "  return position-offset;\n");
+      format_ostream_indented(ctx->depth * 2, ctx->write_size_stream, "}\n\n");
+      format_ostream_indented(ctx->depth * 2, ctx->write_stream, "  return position;\n");
+      format_ostream_indented(ctx->depth * 2, ctx->write_stream, "}\n\n");
+      format_ostream_indented(ctx->depth * 2, ctx->read_stream, "  return position;\n");
+      format_ostream_indented(ctx->depth * 2, ctx->read_stream, "}\n\n");
+
+      //flush_streams(ctx);
+    }
+  }
+  else if (idl_is_union(node))
+  {
+    fputs("union constructed types not supported at this time", stderr);
+  }
+  else if (idl_is_enum(node))
+  {
+    fputs("enum constructed types not supported at this time", stderr);
+  }
+
+  if (cpp11name)
+    free(cpp11name);
+  return IDL_RETCODE_OK;
+}
+
+idl_retcode_t process_base(context_t* ctx, idl_member_t* member)
+{
+  if (NULL == ctx || NULL == member)
+    return IDL_RETCODE_INVALID_PARSETREE;
+
+  char* cpp11name = get_cpp_name(member->declarators->identifier);
+  int bytewidth = determine_byte_width(member->type_spec);
+  if (1 > bytewidth)
+    return IDL_RETCODE_PARSE_ERROR;
+
+  process_known_width(ctx, cpp11name, bytewidth, 0, NULL);
+
+  free(cpp11name);
+  return IDL_RETCODE_OK;
+}
+
+void idl_streamers_generate(idl_tree_t* tree, idl_streamer_output_t* str)
+{
+  context_t* ctx = create_context(str, "");
+  process_node(ctx, tree->root);
+  close_context(ctx);
+}

--- a/src/idlcxx/src/streamer_generator.c
+++ b/src/idlcxx/src/streamer_generator.c
@@ -21,6 +21,7 @@
 #define strcpy_s(ptr, len, str) strcpy(ptr, str)
 #define sprintf_s(ptr, len, str, ...) sprintf(ptr, str, __VA_ARGS__)
 #define strcat_s(ptr, len, str) strcat(ptr, str)
+#define _strdup(str) strdup(str)
 #endif
 
 #define format_ostream_indented(depth,ostr,str,...) \
@@ -563,10 +564,10 @@ idl_retcode_t process_template(context_t* ctx, idl_member_t* member)
     }
     else
     {
-      char* iterated_name = strdup("_1");
+      char* iterated_name = _strdup("_1");
 
       if (0 == strcmp(cpp11name, iterated_name))
-        iterated_name = strdup("_2");
+        iterated_name = _strdup("_2");
 
       format_ostream_indented(ctx->depth * 2, ctx->write_stream, seq_structured_write_fmt, iterated_name, cpp11name, iterated_name);
       format_ostream_indented(ctx->depth * 2, ctx->write_size_stream, seq_structured_write_size_fmt, iterated_name, cpp11name, iterated_name);
@@ -593,7 +594,9 @@ idl_retcode_t process_template(context_t* ctx, idl_member_t* member)
     format_ostream_indented(ctx->depth * 2, ctx->write_stream, fixed_pt_write_byte, cpp11name);
 
     for (size_t i = 0; i < sizeof(fixed_pt_write_fill) / sizeof(const char*); i++)
+    {
       format_ostream_indented(ctx->depth * 2, ctx->write_stream, fixed_pt_write_fill[i]);
+    }
     format_ostream_indented(ctx->depth * 2, ctx->write_stream, fixed_pt_write_position, cpp11name);
     format_ostream_indented(ctx->depth * 2, ctx->write_size_stream, "  ");
     format_ostream_indented(0, ctx->write_size_stream, fixed_pt_write_position, cpp11name);
@@ -602,7 +605,9 @@ idl_retcode_t process_template(context_t* ctx, idl_member_t* member)
     format_ostream_indented(ctx->depth * 2, ctx->read_stream, fixed_pt_read_byte, cpp11name);
 
     for (size_t i = 0; i < sizeof(fixed_pt_read_fill) / sizeof(const char*); i++)
+    {
       format_ostream_indented(ctx->depth * 2, ctx->read_stream, fixed_pt_read_fill[i]);
+    }
 
     format_ostream_indented(ctx->depth * 2, ctx->read_stream, fixed_pt_read_assign, cpp11name, cpp11name);
     format_ostream_indented(ctx->depth * 2, ctx->read_stream, fixed_pt_read_position, cpp11name);

--- a/src/idlcxx/src/streamer_generator.c
+++ b/src/idlcxx/src/streamer_generator.c
@@ -341,7 +341,8 @@ idl_retcode_t process_member(context_t* ctx, idl_member_t* member)
 {
   if (NULL == ctx || NULL == member)
     return IDL_RETCODE_INVALID_PARSETREE;
-  if ((member->type_spec->mask & IDL_BASE_TYPE) == IDL_BASE_TYPE)
+  if ((member->type_spec->mask & IDL_BASE_TYPE) == IDL_BASE_TYPE ||
+      (member->type_spec->mask & IDL_ENUM) == IDL_ENUM)
     // FIXME: this probably needs to loop to find the correct declarator?
     process_base(ctx, member->declarators, member->type_spec);
   else if ((member->type_spec->mask & IDL_STRUCT) == IDL_STRUCT)
@@ -783,10 +784,6 @@ idl_retcode_t process_constructed(context_t* ctx, idl_node_t* node)
     format_write_stream(1, ctx, "}\n\n");
     format_read_stream(1, ctx, "  return position;\n");
     format_read_stream(1, ctx, "}\n\n");
-  }
-  else if (idl_is_enum(node))
-  {
-    fputs("enum constructed types not supported at this time", stderr);
   }
 
   if (cpp11name)

--- a/src/idlcxx/src/streamer_generator.c
+++ b/src/idlcxx/src/streamer_generator.c
@@ -216,8 +216,7 @@ static char* generatealignment(int alignto)
 
 int determine_byte_width(idl_mask_t mask)
 {
-  mask %= IDL_BASE_TYPE * 2;
-  switch (mask)
+  switch (mask % (IDL_BASE_TYPE*2))
   {
   case IDL_INT8:
   case IDL_UINT8:
@@ -570,7 +569,7 @@ idl_retcode_t process_template(context_t* ctx, idl_declarator_t* decl, idl_type_
     size_t bufsize = strlen(cpp11name) + strlen(seq_size_fmt) - 2 + 1;
     char* buffer = calloc(bufsize,1);
     sprintf_s(buffer, bufsize, seq_size_fmt, cpp11name);
-    process_known_width(ctx, buffer, IDL_UINT32, 1, member_mask == IDL_STRING ? "+1":"");
+    process_known_width(ctx, buffer, IDL_UINT32, 1, (member_mask & IDL_STRING) == IDL_STRING ? "+1":"");
 
     if (buffer)
       free(buffer);
@@ -580,7 +579,7 @@ idl_retcode_t process_template(context_t* ctx, idl_declarator_t* decl, idl_type_
       return IDL_RETCODE_INVALID_PARSETREE;
     }
     else if ((member_mask & IDL_BASE_TYPE) == IDL_BASE_TYPE ||
-              member_mask == IDL_STRING)
+             (member_mask & IDL_STRING) == IDL_STRING)
     {
       int bytewidth = 1;
 
@@ -843,11 +842,11 @@ idl_retcode_t process_case_label(context_t* ctx, idl_case_label_t* label)
     void* ptr = &(lit->value);
     if ((ce->mask & IDL_INTEGER_LITERAL) == IDL_INTEGER_LITERAL)
     {
-      int n = snprintf(buffer, 0, "%llu", *((uint64_t*)ptr));
+      int n = snprintf(buffer, 0, "%lu", *((uint64_t*)ptr));
       if (n < 0)
         return IDL_RETCODE_PARSE_ERROR;
       buffer = calloc((size_t)n + 1,1);
-      snprintf(buffer, (size_t)n + 1, "%llu", *((uint64_t*)ptr));
+      snprintf(buffer, (size_t)n + 1, "%lu", *((uint64_t*)ptr));
     }
     else if ((ce->mask & IDL_BOOLEAN_LITERAL) == IDL_BOOLEAN_LITERAL)
     {

--- a/src/idlcxx/src/streamer_generator.c
+++ b/src/idlcxx/src/streamer_generator.c
@@ -332,6 +332,7 @@ void close_context(context_t* ctx)
   destruct_idl_ostream(ctx->read_stream);
 
   free(ctx->context);
+  free(ctx);
 }
 
 bool idl_is_base_type(idl_node_t* node)
@@ -899,7 +900,6 @@ idl_retcode_t process_module(context_t* ctx, idl_module_t* module)
     process_node(newctx, (idl_node_t*)module->definitions);
 
     close_context(newctx);
-    free(newctx);
 
     format_header_stream(1, ctx, namespace_closure_fmt, cpp11name);
     format_read_stream(1, ctx, namespace_closure_fmt, cpp11name);

--- a/src/idlcxx/src/streamer_generator.c
+++ b/src/idlcxx/src/streamer_generator.c
@@ -715,12 +715,14 @@ idl_retcode_t process_known_width_array(context_t* ctx, const char *name, uint64
   if (0 > bytewidth)
     return IDL_RETCODE_INVALID_PARSETREE;
 
-  size_t bytesinarray = bytewidth * entries;
+  unsigned int bw = (unsigned int)bytewidth;
+
+  size_t bytesinarray = bw * entries;
 
   if (ctx->currentalignment != bytewidth)
     add_alignment(ctx, bytewidth);
 
-  ctx->accumulatedalignment += bytewidth*entries;
+  ctx->accumulatedalignment += (int)(bw*entries);
   format_write_stream(1, ctx, primitive_write_func_array_fmt, name, bytesinarray, name);
   format_read_stream(1, ctx, primitive_read_func_array_fmt, name, bytesinarray, name);
 

--- a/src/idlcxx/tests/CMakeLists.txt
+++ b/src/idlcxx/tests/CMakeLists.txt
@@ -11,5 +11,8 @@
 #
 include(CUnit)
 
-add_cunit_executable(cunit_idlcxx cpp11Backend.c streamer_generator.c)
+set(idlcxx_test_sources
+    "streamer_generator.c")
+
+add_cunit_executable(cunit_idlcxx ${idlcxx_test_sources})
 target_link_libraries(cunit_idlcxx PRIVATE idlcxx)

--- a/src/idlcxx/tests/CMakeLists.txt
+++ b/src/idlcxx/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020 ADLINK Technology Limited and others
+# Copyright(c) 2006 to 2019 ADLINK Technology Limited and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -9,5 +9,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-add_subdirectory(ddscxx)
-add_subdirectory(idlcxx)
+include(CUnit)
+
+add_cunit_executable(cunit_idlcxx cpp11Backend.c streamer_generator.c)
+target_link_libraries(cunit_idlcxx PRIVATE idlcxx)

--- a/src/idlcxx/tests/CMakeLists.txt
+++ b/src/idlcxx/tests/CMakeLists.txt
@@ -12,7 +12,8 @@
 include(CUnit)
 
 set(idlcxx_test_sources
-    "streamer_generator.c")
+    "streamer_generator.c"
+    "idl_ostream.c")
 
 add_cunit_executable(cunit_idlcxx ${idlcxx_test_sources})
 target_link_libraries(cunit_idlcxx PRIVATE idlcxx)

--- a/src/idlcxx/tests/idl_ostream.c
+++ b/src/idlcxx/tests/idl_ostream.c
@@ -1,0 +1,86 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "idlcxx/idl_ostream.h"
+
+#include "CUnit/Test.h"
+
+CU_Init(idl_ostream)
+{
+  return 0;
+}
+
+CU_Clean(idl_ostream)
+{
+  return 0;
+}
+
+CU_Test(idl_ostream, creation_destruction)
+{
+  //!!!WARNING!!! need to use a real file here? to prevent undefined behaviour when the ostream might
+  //do something on destruction with the file pointer (writing to it or something)
+  FILE* f = (FILE*)0x12345678;
+  idl_ostream_t* ostr = create_idl_ostream(f);
+
+  CU_ASSERT_PTR_NOT_NULL_FATAL(ostr);
+
+  CU_ASSERT_PTR_NOT_NULL(get_ostream_buffer(ostr));
+
+  CU_ASSERT_EQUAL(get_ostream_buffer_size(ostr), IDL_OSTREAM_BUFFER_INCR);
+
+  CU_ASSERT_EQUAL(get_ostream_buffer_position(ostr), 0);
+
+  CU_ASSERT_PTR_EQUAL(get_ostream_file(ostr),f);
+
+  destruct_idl_ostream(ostr);
+}
+
+#if 0
+CU__Test(idl_ostream, write_transfer_buffer)
+{
+  idl_ostream_t* ostr = create_idl_ostream(NULL),
+               * ostr2 = create_idl_ostream(NULL);
+
+  char buffer[IDL_OSTREAM_BUFFER_INCR + 1];
+  for (int i = 0; i < IDL_OSTREAM_BUFFER_INCR; i++)
+    snprintf(buffer + i, IDL_OSTREAM_BUFFER_INCR + 1, "%d", i % 10);
+
+  const int iterations = 5;
+  const int transfers = 5;
+  for (int transfer = 0; transfer < transfers; transfer++)
+  {
+    for (int iteration = 0; iteration < iterations; iteration++)
+    {
+      for (int i = 0; i < IDL_OSTREAM_BUFFER_INCR; i++)
+      {
+        format_ostream(ostr, "%d", i % 10);
+        CU_ASSERT_EQUAL(get_ostream_buffer_position(ostr), iteration* IDL_OSTREAM_BUFFER_INCR+i+1);
+      }
+
+      if (transfer == 0)
+      {
+        CU_ASSERT_EQUAL(get_ostream_buffer_size(ostr), (iteration + 2) * IDL_OSTREAM_BUFFER_INCR);
+      }
+      else
+      {
+        CU_ASSERT_EQUAL(get_ostream_buffer_size(ostr), (iterations + 1) * IDL_OSTREAM_BUFFER_INCR);
+      }
+
+      for (int i = 0; i <= iteration; i++)
+        CU_ASSERT_EQUAL(0, memcmp(get_ostream_buffer(ostr) + IDL_OSTREAM_BUFFER_INCR * i, buffer, IDL_OSTREAM_BUFFER_INCR));
+    }
+
+    transfer_ostream_buffer(ostr, ostr2);
+    CU_ASSERT_STRING_EQUAL("", get_ostream_buffer(ostr));
+
+    for (int i = 0; i < transfer * iterations; i++)
+      CU_ASSERT_EQUAL(0, memcmp(get_ostream_buffer(ostr2) + i * IDL_OSTREAM_BUFFER_INCR, buffer, IDL_OSTREAM_BUFFER_INCR));
+  }
+
+  destruct_idl_ostream(ostr);
+  destruct_idl_ostream(ostr2);
+}
+#endif

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -24,7 +24,7 @@
 
 #include "CUnit/Theory.h"
 
-static const idl_kind_t idl_type[] = {
+static const idl_mask_t idl_type[] = {
   IDL_CHAR,
   IDL_OCTET,
   IDL_BOOL,
@@ -52,7 +52,7 @@ static const char* cxx_type[] = {
   "double"
 };
 
-static int cxx_width[] = {
+static size_t cxx_width[] = {
   1,
   1,
   1,
@@ -75,10 +75,10 @@ static uint64_t union_switch_int_case_labels[] = {
   4,5
 };
 
-static idl_kind_t union_switch_int_case_types[] = {
+static idl_mask_t union_switch_int_case_types[] = {
   IDL_OCTET,
   IDL_LONG,
-  IDL_STRING_TYPE
+  IDL_STRING
 };
 
 static const char* union_switch_int_case_names[] = {
@@ -87,13 +87,15 @@ static const char* union_switch_int_case_names[] = {
   "_str"
 };
 
-
 #define format_ostream_indented(depth,ostr,str,...) \
 if (depth > 0) format_ostream(ostr, "%*c", depth, ' '); \
 format_ostream(ostr, str, ##__VA_ARGS__);
 
-void create_funcs_base_width_1(idl_ostream_t *ostr, const char *tn, bool ns)
+void create_funcs_base(idl_ostream_t * ostr, size_t n, bool ns)
 {
+  const char* tn = cxx_type[n];
+  size_t width = cxx_width[n];
+
   if (ns)
   {
     format_ostream_indented(0, ostr, "namespace N\n{\n\n");
@@ -101,145 +103,63 @@ void create_funcs_base_width_1(idl_ostream_t *ostr, const char *tn, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  *((%s*)((char*)data+position)) = obj.mem();  //writing bytes for member: mem\n",tn);
-  format_ostream_indented(ns * 2, ostr, "  position += 1;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  return position;\n");
-  format_ostream_indented(ns * 2, ostr, "}\n\n");
-
-  format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
-  format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
-  format_ostream_indented(ns * 2, ostr, "  position += 1;  //bytes for member: mem\n");
-  format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
-  format_ostream_indented(ns * 2, ostr, "}\n\n");
-
-  format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
-  format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  obj.mem(*((%s*)((char*)data+position)));  //reading bytes for member: mem\n", tn);
-  format_ostream_indented(ns * 2, ostr, "  position += 1;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  return position;\n");
-  format_ostream_indented(ns * 2, ostr, "}\n\n");
-
-  if (ns)
+  if (width > 1)
   {
-    format_ostream_indented(0, ostr, "}\n\n");
+    if (width == 2)
+    {
+      format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = position&0x1;  //alignment\n");
+    }
+    else
+    {
+      format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (%d - position&%#x)&%#x;  //alignment\n",width,width-1,width-1);
+    }
+    format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
+    format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
   }
-}
-
-void create_funcs_base_width_2(idl_ostream_t* ostr, const char* tn, bool ns)
-{
-  if (ns)
-  {
-    format_ostream_indented(0, ostr, "namespace N\n{\n\n");
-  }
-
-  format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
-  format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = position&0x1;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
-  format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  *((%s*)((char*)data+position)) = obj.mem();  //writing bytes for member: mem\n", tn);
-  format_ostream_indented(ns * 2, ostr, "  position += 2;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  position += %d;  //moving position indicator\n", width);
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
   format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
-  format_ostream_indented(ns * 2, ostr, "  position += position&0x1;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  position += 2;  //bytes for member: mem\n");
+  if (width > 1)
+  {
+    if (width == 2)
+    {
+      format_ostream_indented(ns * 2, ostr, "  position += position&0x1;  //alignment\n");
+    }
+    else
+    {
+      format_ostream_indented(ns * 2, ostr, "  position += (%d - position&%#x)&%#x;  //alignment\n",width,width-1,width-1);
+    }
+  }
+  format_ostream_indented(ns * 2, ostr, "  position += %d;  //bytes for member: mem\n", width);
   format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
   format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position += position&0x1;  //alignment\n");
+  if (width > 1)
+  {
+    if (width == 2)
+    {
+      format_ostream_indented(ns * 2, ostr, "  position += position&0x1;  //alignment\n");
+    }
+    else
+    {
+      format_ostream_indented(ns * 2, ostr, "  position += (%d - position&%#x)&%#x;  //alignment\n", width, width - 1, width - 1);
+    }
+  }
   format_ostream_indented(ns * 2, ostr, "  obj.mem(*((%s*)((char*)data+position)));  //reading bytes for member: mem\n", tn);
-  format_ostream_indented(ns * 2, ostr, "  position += 2;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  position += %d;  //moving position indicator\n", width);
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
   if (ns)
   {
-    format_ostream_indented(0, ostr, "}\n\n");
-  }
-}
-
-void create_funcs_base_width_4(idl_ostream_t* ostr, const char* tn, bool ns)
-{
-  if (ns)
-  {
-    format_ostream_indented(0, ostr, "namespace N\n{\n\n");
-  }
-
-  format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
-  format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
-  format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  *((%s*)((char*)data+position)) = obj.mem();  //writing bytes for member: mem\n", tn);
-  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  return position;\n");
-  format_ostream_indented(ns * 2, ostr, "}\n\n");
-
-  format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
-  format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: mem\n");
-  format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
-  format_ostream_indented(ns * 2, ostr, "}\n\n");
-
-  format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
-  format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  obj.mem(*((%s*)((char*)data+position)));  //reading bytes for member: mem\n", tn);
-  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  return position;\n");
-  format_ostream_indented(ns * 2, ostr, "}\n\n");
-
-  if (ns)
-  {
-    format_ostream_indented(0, ostr, "}\n\n");
-  }
-}
-
-void create_funcs_base_width_8(idl_ostream_t* ostr, const char* tn, bool ns)
-{
-  if (ns)
-  {
-    format_ostream_indented(0, ostr, "namespace N\n{\n\n");
-  }
-
-  format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
-  format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (8 - position&0x7)&0x7;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
-  format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  *((%s*)((char*)data+position)) = obj.mem();  //writing bytes for member: mem\n", tn);
-  format_ostream_indented(ns * 2, ostr, "  position += 8;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  return position;\n");
-  format_ostream_indented(ns * 2, ostr, "}\n\n");
-
-  format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
-  format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (8 - position&0x7)&0x7;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  position += 8;  //bytes for member: mem\n");
-  format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
-  format_ostream_indented(ns * 2, ostr, "}\n\n");
-
-  format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
-  format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (8 - position&0x7)&0x7;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  obj.mem(*((%s*)((char*)data+position)));  //reading bytes for member: mem\n", tn);
-  format_ostream_indented(ns * 2, ostr, "  position += 8;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  return position;\n");
-  format_ostream_indented(ns * 2, ostr, "}\n\n");
-
-  if (ns)
-  {
-    format_ostream_indented(0, ostr, "}\n\n");
+    format_ostream_indented(0, ostr, "} //end namespace N\n\n");
   }
 }
 
@@ -271,24 +191,25 @@ void create_funcs_instance(idl_ostream_t* ostr, const char* in, bool ns)
 
   if (ns)
   {
-    format_ostream_indented(0, ostr, "}\n\n");
+    format_ostream_indented(0, ostr, "} //end namespace N\n\n");
   }
 
 }
 
-void create_funcs_sequence_width_1(idl_ostream_t* ostr, const char* in, bool ns)
+void create_funcs_string(idl_ostream_t* ostr, const char* in, bool ns)
 {
   if (ns)
   {
     format_ostream_indented(0, ostr, "namespace N\n{\n\n");
   }
 
+
   format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
   format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = obj.%s().size();  //number of entries in the sequence\n", in);
+  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = obj.%s().size()+1;  //number of entries in the sequence\n", in);
   format_ostream_indented(ns * 2, ostr, "  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing bytes for member: %s().size\n", in);
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  memcpy((char*)data+position,obj.%s().data(),sequenceentries*1);  //contents for %s\n", in, in);
@@ -301,7 +222,7 @@ void create_funcs_sequence_width_1(idl_ostream_t* ostr, const char* in, bool ns)
   format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
   format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: %s().size\n", in);
-  format_ostream_indented(ns * 2, ostr, "  position += (obj.%s().size())*1;  //entries of sequence\n", in);
+  format_ostream_indented(ns * 2, ostr, "  position += (obj.%s().size()+1)*1;  //entries of sequence\n", in);
   format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -310,19 +231,23 @@ void create_funcs_sequence_width_1(idl_ostream_t* ostr, const char* in, bool ns)
   format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n");
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  obj.%s().assign((char*)data+position,(char*)data+position+sequenceentries*1);  //putting data into container\n", in);
+  format_ostream_indented(ns * 2, ostr, "  obj.%s().assign((char*)((char*)data+position),(char*)((char*)data+position)+sequenceentries);  //putting data into container\n", in);
   format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*1;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
+
   if (ns)
   {
-    format_ostream_indented(0, ostr, "}\n\n");
+    format_ostream_indented(0, ostr, "} //end namespace N\n\n");
   }
 }
 
-void create_funcs_sequence_width_2(idl_ostream_t* ostr, const char* in, bool ns)
+void create_funcs_sequence(idl_ostream_t* ostr, const char* seq_name, size_t n, bool ns)
 {
+  size_t width = cxx_width[n];
+  const char* cxx_type_name = cxx_type[n];
+
   if (ns)
   {
     format_ostream_indented(0, ostr, "namespace N\n{\n\n");
@@ -333,11 +258,17 @@ void create_funcs_sequence_width_2(idl_ostream_t* ostr, const char* in, bool ns)
   format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
   format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = obj.%s().size();  //number of entries in the sequence\n", in);
-  format_ostream_indented(ns * 2, ostr, "  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing bytes for member: %s().size\n", in);
+  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = obj.%s().size();  //number of entries in the sequence\n", seq_name);
+  format_ostream_indented(ns * 2, ostr, "  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing bytes for member: %s().size\n", seq_name);
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  memcpy((char*)data+position,obj.%s().data(),sequenceentries*2);  //contents for %s\n", in, in);
-  format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*2;  //moving position indicator\n");
+  if (width > 4)
+  {
+    format_ostream_indented(ns * 2, ostr, "  alignmentbytes = (%d - position&%#x)&%#x;  //alignment\n", width, width-1, width-1);
+    format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
+    format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
+  }
+  format_ostream_indented(ns * 2, ostr, "  memcpy((char*)data+position,obj.%s().data(),sequenceentries*%d);  //contents for %s\n", seq_name, width, seq_name);
+  format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*%d;  //moving position indicator\n", width);
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -345,8 +276,12 @@ void create_funcs_sequence_width_2(idl_ostream_t* ostr, const char* in, bool ns)
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
   format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: %s().size\n", in);
-  format_ostream_indented(ns * 2, ostr, "  position += (obj.%s().size())*2;  //entries of sequence\n", in);
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: %s().size\n", seq_name);
+  if (width > 4)
+  {
+    format_ostream_indented(ns * 2, ostr, "  position += (%d - position&%#x)&%#x;  //alignment\n", width, width - 1, width - 1);
+  }
+  format_ostream_indented(ns * 2, ostr, "  position += (obj.%s().size())*%d;  //entries of sequence\n", seq_name, width);
   format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -355,109 +290,19 @@ void create_funcs_sequence_width_2(idl_ostream_t* ostr, const char* in, bool ns)
   format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n");
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  obj.%s().assign((char*)data+position,(char*)data+position+sequenceentries*2);  //putting data into container\n", in);
-  format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*2;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  return position;\n");
-  format_ostream_indented(ns * 2, ostr, "}\n\n");
-
-  if (ns)
+  if (width > 4)
   {
-    format_ostream_indented(0, ostr, "}\n\n");
+    format_ostream_indented(ns * 2, ostr, "  position += (%d - position&%#x)&%#x;  //alignment\n", width, width - 1, width - 1);
   }
-}
-
-void create_funcs_sequence_width_4(idl_ostream_t* ostr, const char* in, bool ns)
-{
-  if (ns)
-  {
-    format_ostream_indented(0, ostr, "namespace N\n{\n\n");
-  }
-
-  format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
-  format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
-  format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = obj.%s().size();  //number of entries in the sequence\n", in);
-  format_ostream_indented(ns * 2, ostr, "  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing bytes for member: %s().size\n", in);
-  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  memcpy((char*)data+position,obj.%s().data(),sequenceentries*4);  //contents for %s\n", in, in);
-  format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  obj.%s().assign((%s*)((char*)data+position),(%s*)((char*)data+position)+sequenceentries);  //putting data into container\n", seq_name, cxx_type_name, cxx_type_name);
+  format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*%d;  //moving position indicator\n",width);
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
-  format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
-  format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: %s().size\n", in);
-  format_ostream_indented(ns * 2, ostr, "  position += (obj.%s().size())*4;  //entries of sequence\n", in);
-  format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
-  format_ostream_indented(ns * 2, ostr, "}\n\n");
-
-  format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
-  format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n");
-  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  obj.%s().assign((char*)data+position,(char*)data+position+sequenceentries*4);  //putting data into container\n", in);
-  format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*4;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  return position;\n");
-  format_ostream_indented(ns * 2, ostr, "}\n\n");
 
   if (ns)
   {
-    format_ostream_indented(0, ostr, "}\n\n");
-  }
-}
-
-void create_funcs_sequence_width_8(idl_ostream_t* ostr, const char* in, bool ns)
-{
-  if (ns)
-  {
-    format_ostream_indented(0, ostr, "namespace N\n{\n\n");
-  }
-
-  format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
-  format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
-  format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = obj.%s().size();  //number of entries in the sequence\n", in);
-  format_ostream_indented(ns * 2, ostr, "  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing bytes for member: %s().size\n", in);
-  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  alignmentbytes = (8 - position&0x7)&0x7;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
-  format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  memcpy((char*)data+position,obj.%s().data(),sequenceentries*8);  //contents for %s\n", in, in);
-  format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*8;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  return position;\n");
-  format_ostream_indented(ns * 2, ostr, "}\n\n");
-
-  format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
-  format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: %s().size\n", in);
-  format_ostream_indented(ns * 2, ostr, "  position += (8 - position&0x7)&0x7;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (obj.%s().size())*8;  //entries of sequence\n", in);
-  format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
-  format_ostream_indented(ns * 2, ostr, "}\n\n");
-
-  format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
-  format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n");
-  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (8 - position&0x7)&0x7;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  obj.%s().assign((char*)data+position,(char*)data+position+sequenceentries*8);  //putting data into container\n", in);
-  format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*8;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  return position;\n");
-  format_ostream_indented(ns * 2, ostr, "}\n\n");
-
-  if (ns)
-  {
-    format_ostream_indented(0, ostr, "}\n\n");
+    format_ostream_indented(0, ostr, "} //end namespace N\n\n");
   }
 }
 
@@ -469,7 +314,7 @@ void create_funcs_sequence_width_8(idl_ostream_t* ostr, const char* in, bool ns)
 "  size_t write_struct(const s &obj, void *data, size_t position);\n\n"\
 "  size_t write_size(const s &obj, size_t offset);\n\n"\
 "  size_t read_struct(s &obj, void *data, size_t position);\n\n"\
-"}\n\n"
+"} //end namespace N\n\n"
 
 void generate_union_funcs(idl_ostream_t* ostr, bool ns)
 {
@@ -586,11 +431,11 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
 
   if (ns)
   {
-    format_ostream_indented(0, ostr, "}\n\n");
+    format_ostream_indented(0, ostr, "}  //end namespace N\n\n");
   }
 }
 
-idl_member_t* generate_member_base(idl_kind_t member_type, const char* member_name)
+idl_member_t* generate_member_base(idl_mask_t member_type, const char* member_name)
 {
   idl_member_t* returnval = idl_create_member();
 
@@ -601,7 +446,7 @@ idl_member_t* generate_member_base(idl_kind_t member_type, const char* member_na
   returnval->declarators->identifier = _strdup(member_name);
 
   returnval->type_spec = calloc(sizeof(idl_type_spec_t),1);
-  returnval->type_spec->kind = member_type;
+  returnval->type_spec->mask = member_type;
 
   return returnval;
 }
@@ -617,12 +462,12 @@ idl_member_t* generate_member_instance(const char* member_type, const char* memb
   returnval->declarators->identifier = _strdup(member_name);
 
   returnval->type_spec = calloc(sizeof(idl_type_spec_t),1);
-  returnval->type_spec->kind = IDL_SCOPED_NAME;
+  returnval->type_spec->mask = IDL_STRUCT;
 
   return returnval;
 }
 
-idl_member_t* generate_sequence_instance(idl_kind_t sequenced_type, const char* member_name)
+idl_member_t* generate_sequence_instance(idl_mask_t sequenced_type, const char* member_name)
 {
   idl_member_t* returnval = idl_create_member();
 
@@ -632,17 +477,18 @@ idl_member_t* generate_sequence_instance(idl_kind_t sequenced_type, const char* 
   returnval->declarators->node.next = NULL;
   returnval->declarators->identifier = _strdup(member_name);
 
-  returnval->type_spec = calloc(sizeof(idl_type_spec_t),1);
-  returnval->type_spec->kind = IDL_SEQUENCE_TYPE;
-  returnval->type_spec->sequence_type.type_spec = calloc(sizeof(idl_simple_type_spec_t),1);
-  returnval->type_spec->sequence_type.type_spec->kind = sequenced_type;
+  idl_sequence_t *seq = calloc(sizeof(idl_sequence_t), 1);
+  returnval->type_spec = (idl_type_spec_t*)seq;
+  returnval->type_spec->mask = IDL_SEQUENCE;
+  seq->type_spec = calloc(sizeof(idl_type_spec_t), 1);
+  seq->type_spec->mask = sequenced_type;
 
   return returnval;
 }
 
-idl_struct_type_t* generate_struct_base(const char* name, const idl_kind_t* member_types, const char** member_names, size_t nmembers)
+idl_struct_t* generate_struct_base(const char* name, const idl_mask_t* member_types, const char** member_names, size_t nmembers)
 {
-  idl_struct_type_t* returnval = idl_create_struct();
+  idl_struct_t* returnval = idl_create_struct();
   returnval->identifier = _strdup(name);
 
   idl_node_t* prevmem = NULL;
@@ -664,9 +510,9 @@ idl_struct_type_t* generate_struct_base(const char* name, const idl_kind_t* memb
   return returnval;
 }
 
-idl_struct_type_t* generate_struct_instance(const char* name, const char** instance_types, const char** member_names, size_t nmembers)
+idl_struct_t* generate_struct_instance(const char* name, const char** instance_types, const char** member_names, size_t nmembers)
 {
-  idl_struct_type_t* returnval = idl_create_struct();
+  idl_struct_t* returnval = idl_create_struct();
   returnval->identifier = _strdup(name);
 
   idl_node_t* prevmem = NULL;
@@ -688,9 +534,24 @@ idl_struct_type_t* generate_struct_instance(const char* name, const char** insta
   return returnval;
 }
 
-idl_struct_type_t* generate_struct_sequence(const char* name, const idl_kind_t* sequence_types, const char** member_names, size_t nmembers)
+idl_struct_t* generate_struct_string(const char* name)
 {
-  idl_struct_type_t* returnval = idl_create_struct();
+  idl_struct_t* returnval = idl_create_struct();
+  returnval->identifier = _strdup(name);
+
+  idl_member_t* mem = generate_member_base(IDL_STRING, "str");
+
+  idl_node_t* currentnode = (idl_node_t*)mem;
+  currentnode->parent = (idl_node_t*)returnval;
+
+  returnval->members = mem;
+
+  return returnval;
+}
+
+idl_struct_t* generate_struct_sequence(const char* name, const idl_mask_t* sequence_types, const char** member_names, size_t nmembers)
+{
+  idl_struct_t* returnval = idl_create_struct();
   returnval->identifier = _strdup(name);
 
   idl_node_t* prevmem = NULL;
@@ -722,7 +583,7 @@ idl_case_label_t* generate_union_case_int_label(uint64_t _case)
   return returnval;
 }
 
-idl_case_t* generate_union_int_switch_case(const uint64_t* labels, const idl_kind_t case_type, const char* case_name)
+idl_case_t* generate_union_int_switch_case(const uint64_t* labels, const idl_mask_t case_type, const char* case_name)
 {
   idl_case_t* returnval = idl_create_case();
 
@@ -743,7 +604,7 @@ idl_case_t* generate_union_int_switch_case(const uint64_t* labels, const idl_kin
   }
 
   returnval->type_spec = calloc(sizeof(idl_type_spec_t),1);
-  returnval->type_spec->kind = case_type;
+  returnval->type_spec->mask = case_type;
   returnval->declarator = idl_create_declarator();
   returnval->declarator->node.parent = (idl_node_t*)returnval;
   returnval->declarator->identifier = _strdup(case_name);
@@ -751,14 +612,14 @@ idl_case_t* generate_union_int_switch_case(const uint64_t* labels, const idl_kin
   return returnval;
 }
 
-idl_union_type_t* generate_union_int_switch(const char* name, const uint64_t* cases, const idl_kind_t* case_types, const char** case_names)
+idl_union_t* generate_union_int_switch(const char* name, const uint64_t* cases, const idl_mask_t* case_types, const char** case_names)
 {
-  idl_union_type_t* returnval = idl_create_union();
+  idl_union_t* returnval = idl_create_union();
 
   returnval->identifier = _strdup(name);
 
   returnval->switch_type_spec = calloc(sizeof(idl_switch_type_spec_t), 1);
-  returnval->switch_type_spec->kind = IDL_ULONG;
+  returnval->switch_type_spec->mask = IDL_ULONG;
 
   idl_node_t* prevcase = NULL;
   for (size_t _case = 0; _case < ncases; _case++)
@@ -783,10 +644,10 @@ void test_base(size_t n, bool ns)
 {
   idl_tree_t* tree = calloc(sizeof(idl_tree_t),1);
 
-  idl_kind_t kinds[1] = { idl_type[n] };
+  idl_mask_t masks[1] = { idl_type[n] };
   const char* names[1] = { "mem" };
 
-  idl_struct_type_t* str = generate_struct_base("s", kinds, names, 1);
+  idl_struct_t* str = generate_struct_base("s", masks, names, 1);
   if (ns)
   {
     idl_module_t* mod = idl_create_module();
@@ -809,23 +670,7 @@ void test_base(size_t n, bool ns)
 
   idl_ostream_t* impl = create_idl_ostream(NULL);
 
-  switch (cxx_width[n])
-  {
-  case 1:
-    create_funcs_base_width_1(impl,cxx_type[n],ns);
-    break;
-  case 2:
-    create_funcs_base_width_2(impl, cxx_type[n], ns);
-    break;
-  case 4:
-    create_funcs_base_width_4(impl, cxx_type[n], ns);
-    break;
-  case 8:
-    create_funcs_base_width_8(impl, cxx_type[n], ns);
-      break;
-  default:
-    CU_ASSERT_FATAL(0);
-  }
+  create_funcs_base(impl, n, ns);
 
   CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
@@ -842,7 +687,7 @@ void test_instance(bool ns)
   const char* types[1] = { "I" };
   const char* names[1] = { "mem" };
 
-  idl_struct_type_t* str = generate_struct_instance("s", types, names, 1);
+  idl_struct_t* str = generate_struct_instance("s", types, names, 1);
   if (ns)
   {
     idl_module_t* mod = idl_create_module();
@@ -876,10 +721,10 @@ void test_sequence(size_t n, bool ns)
 {
   idl_tree_t* tree = calloc(sizeof(idl_tree_t),1);
 
-  const idl_kind_t types[1] = { idl_type[n] };
+  const idl_mask_t types[1] = { idl_type[n] };
   const char* names[1] = { "mem" };
 
-  idl_struct_type_t* str = generate_struct_sequence("s", types, names, 1);
+  idl_struct_t* str = generate_struct_sequence("s", types, names, 1);
   if (ns)
   {
     idl_module_t* mod = idl_create_module();
@@ -902,23 +747,41 @@ void test_sequence(size_t n, bool ns)
 
   idl_ostream_t* impl = create_idl_ostream(NULL);
 
-  switch (cxx_width[n])
+  create_funcs_sequence(impl, names[0], n, ns);
+
+  CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
+
+  CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+}
+
+void test_string(bool ns)
+{
+  idl_tree_t* tree = calloc(sizeof(idl_tree_t), 1);
+
+  idl_struct_t* str = generate_struct_string("s");
+  if (ns)
   {
-  case 1:
-    create_funcs_sequence_width_1(impl, names[0], ns);
-    break;
-  case 2:
-    create_funcs_sequence_width_2(impl, names[0], ns);
-    break;
-  case 4:
-    create_funcs_sequence_width_4(impl, names[0], ns);
-    break;
-  case 8:
-    create_funcs_sequence_width_8(impl, names[0], ns);
-    break;
-  default:
-    CU_ASSERT_FATAL(0);
+    idl_module_t* mod = idl_create_module();
+    mod->definitions = calloc(sizeof(idl_definition_t), 1);
+    mod->definitions = (idl_definition_t*)str;
+    mod->identifier = _strdup("N");
+
+    tree->root = (idl_node_t*)mod;
+    str->node.parent = (idl_node_t*)mod;
+    mod->node.parent = (idl_node_t*)tree;
   }
+  else
+  {
+    tree->root = (idl_node_t*)str;
+    str->node.parent = (idl_node_t*)tree;
+  }
+
+  idl_streamer_output_t* generated = create_idl_streamer_output();
+  idl_streamers_generate(tree, generated);
+
+  idl_ostream_t* impl = create_idl_ostream(NULL);
+
+  create_funcs_string(impl, "str", ns);
 
   CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
 
@@ -927,7 +790,7 @@ void test_sequence(size_t n, bool ns)
 
 void test_union(bool ns)
 {
-  idl_union_type_t* _union = generate_union_int_switch("s", union_switch_int_case_labels, union_switch_int_case_types, union_switch_int_case_names);
+  idl_union_t* _union = generate_union_int_switch("s", union_switch_int_case_labels, union_switch_int_case_types, union_switch_int_case_names);
   idl_tree_t* tree = calloc(sizeof(idl_tree_t),1);
 
   if (ns)
@@ -964,13 +827,13 @@ void test_union(bool ns)
 
 CU_Test(streamer_generator, base_types_namespace_absent)
 {
-  for (size_t i = 0; i < sizeof(idl_type) / sizeof(idl_kind_t); i++)
+  for (size_t i = 0; i < sizeof(idl_type) / sizeof(idl_mask_t); i++)
     test_base(i, false);
 }
 
 CU_Test(streamer_generator, base_types_namespace_present)
 {
-  for (size_t i = 0; i < sizeof(idl_type) / sizeof(idl_kind_t); i++)
+  for (size_t i = 0; i < sizeof(idl_type) / sizeof(idl_mask_t); i++)
     test_base(i, true);
 }
 
@@ -984,15 +847,25 @@ CU_Test(streamer_generator, instance_namespace_present)
   test_instance(true);
 }
 
+CU_Test(streamer_generator, string_namespace_absent)
+{
+  test_string(false);
+}
+
+CU_Test(streamer_generator, string_namespace_present)
+{
+  test_string(true);
+}
+
 CU_Test(streamer_generator, sequence_namespace_absent)
 {
-  for (size_t i = 0; i < sizeof(idl_type) / sizeof(idl_kind_t); i++)
-    test_sequence(i,false);
+  for (size_t i = 0; i < sizeof(idl_type) / sizeof(idl_mask_t); i++)
+    test_sequence(i, false);
 }
 
 CU_Test(streamer_generator, sequence_namespace_present)
 {
-  for (size_t i = 0; i < sizeof(idl_type) / sizeof(idl_kind_t); i++)
+  for (size_t i = 0; i < sizeof(idl_type) / sizeof(idl_mask_t); i++)
     test_sequence(i, true);
 }
 

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -762,8 +762,8 @@ void test_base(size_t n, bool ns)
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
 
   destruct_idl_ostream(impl);
-
   destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_instance(bool ns)
@@ -802,8 +802,11 @@ void test_instance(bool ns)
   create_funcs_instance(impl, "mem", ns);
 
   CU_ASSERT_STRING_EQUAL(ns ? HNPI : HNAI, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
-
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_ostream(impl);
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_sequence(size_t n, bool ns)
@@ -838,8 +841,11 @@ void test_sequence(size_t n, bool ns)
   create_funcs_sequence(impl, "mem", n, ns);
 
   CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
-
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_ostream(impl);
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_string(bool ns)
@@ -872,8 +878,11 @@ void test_string(bool ns)
   create_funcs_string(impl, "str", ns);
 
   CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
-
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_ostream(impl);
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_union(bool ns)
@@ -918,6 +927,10 @@ void test_union(bool ns)
 
   CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_ostream(impl);
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_enum(bool ns)
@@ -952,6 +965,10 @@ void test_enum(bool ns)
 
   CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_ostream(impl);
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_array_base(bool ns)
@@ -985,6 +1002,10 @@ void test_array_base(bool ns)
 
   CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_ostream(impl);
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_array_instance(bool ns)
@@ -1024,6 +1045,10 @@ void test_array_instance(bool ns)
 
   CU_ASSERT_STRING_EQUAL(ns ? HNPI : HNAI, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_ostream(impl);
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_namespace_cross_call()
@@ -1039,6 +1064,9 @@ void test_namespace_cross_call()
 
   CU_ASSERT_STRING_EQUAL(CCFH, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
   CU_ASSERT_STRING_EQUAL(CCFI, get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_struct_inheritance()
@@ -1058,6 +1086,9 @@ void test_struct_inheritance()
 
   CU_ASSERT_STRING_EQUAL(HNAI, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
   CU_ASSERT_STRING_EQUAL(IFI, get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 void test_bounded_sequence()
@@ -1075,6 +1106,9 @@ void test_bounded_sequence()
 
   CU_ASSERT_STRING_EQUAL(HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
   CU_ASSERT_STRING_EQUAL(BSI, get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
 }
 
 CU_Test(streamer_generator, base_types_namespace_absent)

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -15,6 +15,8 @@
 #include <stdbool.h>
 #ifdef _WIN32
 #include <Windows.h>
+#else
+#define _strdup(str) strdup(str)
 #endif
 
 #include "idlcxx/streamer_generator.h"
@@ -22,18 +24,18 @@
 
 #include "CUnit/Theory.h"
 
-static const char* idl_type[] = {
-  "char",
-  "octet",
-  "boolean",
-  "short",
-  "long",
-  "long long",
-  "unsigned short",
-  "unsigned long",
-  "unsigned long long",
-  "float",
-  "double"
+static const idl_kind_t idl_type[] = {
+  IDL_CHAR,
+  IDL_OCTET,
+  IDL_BOOL,
+  IDL_SHORT,
+  IDL_LONG,
+  IDL_LLONG,
+  IDL_USHORT,
+  IDL_ULONG,
+  IDL_ULLONG,
+  IDL_FLOAT,
+  IDL_DOUBLE
 };
 
 static const char* cxx_type[] = {
@@ -64,123 +66,530 @@ static int cxx_width[] = {
   8
 };
 
+#define format_ostream_indented(depth,ostr,str,...) \
+if (depth > 0) format_ostream(ostr, "%*c", depth, ' '); \
+format_ostream(ostr, str, ##__VA_ARGS__);
 
-static const char* struct_fmt =
-"struct s { %s mem;\n};\n";
+void create_funcs_base_width_1(idl_ostream_t *ostr, const char *tn, bool ns)
+{
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "namespace N\n{\n\n");
+  }
 
-static const char* cxx_write_func_fmt_1 =
-"size_t write_struct(const s &obj, void *data, size_t position)\n{\n"\
-"  *((%s*)((char*)data+position)) = obj.mem();  //writing bytes for member: mem\n"\
-"  position += 1;  //moving position indicator\n"\
-"  return position;\n"\
-"}\n\n";
-static const char* cxx_write_size_func_fmt_1 =
-"size_t write_size(const s &obj, size_t offset)\n"\
-"{\n"\
-"  size_t position = offset;\n"\
-"  position += 1;  //bytes for member: mem\n"\
-"  return position-offset;\n"\
-"}\n\n";
-static const char* cxx_read_func_fmt_1 =
-"size_t read_struct(s &obj, void *data, size_t position)\n"\
-"{\n"\
-"  obj.mem() = *((%s*)((char*)data+position));  //reading bytes for member: mem\n"\
-"  position += 1;  //moving position indicator\n"\
-"  return position;\n"\
-"}\n\n";
+  format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  *((%s*)((char*)data+position)) = obj.mem();  //writing bytes for member: mem\n",tn);
+  format_ostream_indented(ns * 2, ostr, "  position += 1;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
 
-static const char* cxx_write_func_fmt_2 =
-"size_t write_struct(const s &obj, void *data, size_t position)\n"\
-"{\n"\
-"  size_t alignmentbytes = position&0x1;  //alignment\n"\
-"  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
-"  position += alignmentbytes;  //moving position indicator\n"\
-"  *((%s*)((char*)data+position)) = obj.mem();  //writing bytes for member: mem\n"\
-"  position += 2;  //moving position indicator\n"\
-"  return position;\n"\
-"}\n\n";
-static const char* cxx_write_size_func_fmt_2 =
-"size_t write_size(const s &obj, size_t offset)\n"\
-"{\n"\
-"  size_t position = offset;\n"\
-"  position += position&0x1;  //alignment\n"\
-"  position += 2;  //bytes for member: mem\n"\
-"  return position-offset;\n"\
-"}\n\n";
-static const char* cxx_read_func_fmt_2 =
-"size_t read_struct(s &obj, void *data, size_t position)\n"\
-"{\n"\
-"  position += position&0x1;  //alignment\n"\
-"  obj.mem() = *((%s*)((char*)data+position));  //reading bytes for member: mem\n"\
-"  position += 2;  //moving position indicator\n"\
-"  return position;\n"\
-"}\n\n";
+  format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 1;  //bytes for member: mem\n");
+  format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
 
-static const char* cxx_write_func_fmt_4 =
-"size_t write_struct(const s &obj, void *data, size_t position)\n"\
-"{\n"\
-"  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
-"  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
-"  position += alignmentbytes;  //moving position indicator\n"\
-"  *((%s*)((char*)data+position)) = obj.mem();  //writing bytes for member: mem\n"\
-"  position += 4;  //moving position indicator\n"\
-"  return position;\n"\
-"}\n\n";
-static const char* cxx_write_size_func_fmt_4 =
-"size_t write_size(const s &obj, size_t offset)\n"\
-"{\n"\
-"  size_t position = offset;\n"\
-"  position += (4 - position&0x3)&0x3;  //alignment\n"\
-"  position += 4;  //bytes for member: mem\n"\
-"  return position-offset;\n"\
-"}\n\n";
-static const char* cxx_read_func_fmt_4 =
-"size_t read_struct(s &obj, void *data, size_t position)\n"\
-"{\n"\
-"  position += (4 - position&0x3)&0x3;  //alignment\n"\
-"  obj.mem() = *((%s*)((char*)data+position));  //reading bytes for member: mem\n"\
-"  position += 4;  //moving position indicator\n"\
-"  return position;\n"\
-"}\n\n";
+  format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  obj.mem() = *((%s*)((char*)data+position));  //reading bytes for member: mem\n", tn);
+  format_ostream_indented(ns * 2, ostr, "  position += 1;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
 
-static const char* cxx_write_func_fmt_8 =
-"size_t write_struct(const s &obj, void *data, size_t position)\n"\
-"{\n"\
-"  size_t alignmentbytes = (8 - position&0x7)&0x7;  //alignment\n"\
-"  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
-"  position += alignmentbytes;  //moving position indicator\n"\
-"  *((%s*)((char*)data+position)) = obj.mem();  //writing bytes for member: mem\n"\
-"  position += 8;  //moving position indicator\n"\
-"  return position;\n"\
-"}\n\n";
-static const char* cxx_write_size_func_fmt_8 =
-"size_t write_size(const s &obj, size_t offset)\n"\
-"{\n"\
-"  size_t position = offset;\n"\
-"  position += (8 - position&0x7)&0x7;  //alignment\n"\
-"  position += 8;  //bytes for member: mem\n"\
-"  return position-offset;\n"\
-"}\n\n";
-static const char* cxx_read_func_fmt_8 =
-"size_t read_struct(s &obj, void *data, size_t position)\n"\
-"{\n"\
-"  position += (8 - position&0x7)&0x7;  //alignment\n"\
-"  obj.mem() = *((%s*)((char*)data+position));  //reading bytes for member: mem\n"\
-"  position += 8;  //moving position indicator\n"\
-"  return position;\n"\
-"}\n\n";
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "}\n\n");
+  }
+}
 
-#define HNS "size_t write_struct(const s &obj, void *data, size_t position);\n\n"\
+void create_funcs_base_width_2(idl_ostream_t* ostr, const char* tn, bool ns)
+{
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "namespace N\n{\n\n");
+  }
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = position&0x1;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
+  format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  *((%s*)((char*)data+position)) = obj.mem();  //writing bytes for member: mem\n", tn);
+  format_ostream_indented(ns * 2, ostr, "  position += 2;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
+  format_ostream_indented(ns * 2, ostr, "  position += position&0x1;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 2;  //bytes for member: mem\n");
+  format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position += position&0x1;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  obj.mem() = *((%s*)((char*)data+position));  //reading bytes for member: mem\n", tn);
+  format_ostream_indented(ns * 2, ostr, "  position += 2;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "}\n\n");
+  }
+}
+
+void create_funcs_base_width_4(idl_ostream_t* ostr, const char* tn, bool ns)
+{
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "namespace N\n{\n\n");
+  }
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
+  format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  *((%s*)((char*)data+position)) = obj.mem();  //writing bytes for member: mem\n", tn);
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: mem\n");
+  format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  obj.mem() = *((%s*)((char*)data+position));  //reading bytes for member: mem\n", tn);
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "}\n\n");
+  }
+}
+
+void create_funcs_base_width_8(idl_ostream_t* ostr, const char* tn, bool ns)
+{
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "namespace N\n{\n\n");
+  }
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (8 - position&0x7)&0x7;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
+  format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  *((%s*)((char*)data+position)) = obj.mem();  //writing bytes for member: mem\n", tn);
+  format_ostream_indented(ns * 2, ostr, "  position += 8;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (8 - position&0x7)&0x7;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 8;  //bytes for member: mem\n");
+  format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (8 - position&0x7)&0x7;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  obj.mem() = *((%s*)((char*)data+position));  //reading bytes for member: mem\n", tn);
+  format_ostream_indented(ns * 2, ostr, "  position += 8;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "}\n\n");
+  }
+}
+
+void create_funcs_instance(idl_ostream_t* ostr, const char* in, bool ns)
+{
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "namespace N\n{\n\n");
+  }
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position = write_struct(obj.%s(), data, position);\n", in);
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
+  format_ostream_indented(ns * 2, ostr, "  position += write_size(obj.%s(), position);\n", in);
+  format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position = read_struct(obj.%s(), data, position);\n", in);
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "}\n\n");
+  }
+
+}
+
+void create_funcs_sequence_width_1(idl_ostream_t* ostr, const char* in, bool ns)
+{
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "namespace N\n{\n\n");
+  }
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
+  format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = obj.%s().size();  //number of entries in the sequence\n", in);
+  format_ostream_indented(ns * 2, ostr, "  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing bytes for member: %s().size\n", in);
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  memcpy((char*)data+position,obj.%s().data(),sequenceentries*1);  //contents for %s\n", in, in);
+  format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*1;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: %s().size\n", in);
+  format_ostream_indented(ns * 2, ostr, "  position += (obj.%s().size())*1;  //entries of sequence\n", in);
+  format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  obj.%s().assign((char*)data+position,(char*)data+position+sequenceentries*1);  //putting data into container\n", in);
+  format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*1;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "}\n\n");
+  }
+}
+
+void create_funcs_sequence_width_2(idl_ostream_t* ostr, const char* in, bool ns)
+{
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "namespace N\n{\n\n");
+  }
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
+  format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = obj.%s().size();  //number of entries in the sequence\n", in);
+  format_ostream_indented(ns * 2, ostr, "  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing bytes for member: %s().size\n", in);
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  memcpy((char*)data+position,obj.%s().data(),sequenceentries*2);  //contents for %s\n", in, in);
+  format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*2;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: %s().size\n", in);
+  format_ostream_indented(ns * 2, ostr, "  position += (obj.%s().size())*2;  //entries of sequence\n", in);
+  format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  obj.%s().assign((char*)data+position,(char*)data+position+sequenceentries*2);  //putting data into container\n", in);
+  format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*2;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "}\n\n");
+  }
+}
+
+void create_funcs_sequence_width_4(idl_ostream_t* ostr, const char* in, bool ns)
+{
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "namespace N\n{\n\n");
+  }
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
+  format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = obj.%s().size();  //number of entries in the sequence\n", in);
+  format_ostream_indented(ns * 2, ostr, "  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing bytes for member: %s().size\n", in);
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  memcpy((char*)data+position,obj.%s().data(),sequenceentries*4);  //contents for %s\n", in, in);
+  format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: %s().size\n", in);
+  format_ostream_indented(ns * 2, ostr, "  position += (obj.%s().size())*4;  //entries of sequence\n", in);
+  format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  obj.%s().assign((char*)data+position,(char*)data+position+sequenceentries*4);  //putting data into container\n", in);
+  format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "}\n\n");
+  }
+}
+
+void create_funcs_sequence_width_8(idl_ostream_t* ostr, const char* in, bool ns)
+{
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "namespace N\n{\n\n");
+  }
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
+  format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = obj.%s().size();  //number of entries in the sequence\n", in);
+  format_ostream_indented(ns * 2, ostr, "  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing bytes for member: %s().size\n", in);
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  alignmentbytes = (8 - position&0x7)&0x7;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
+  format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  memcpy((char*)data+position,obj.%s().data(),sequenceentries*8);  //contents for %s\n", in, in);
+  format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*8;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: %s().size\n", in);
+  format_ostream_indented(ns * 2, ostr, "  position += (8 - position&0x7)&0x7;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (obj.%s().size())*8;  //entries of sequence\n", in);
+  format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (8 - position&0x7)&0x7;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  obj.%s().assign((char*)data+position,(char*)data+position+sequenceentries*8);  //putting data into container\n", in);
+  format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*8;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "}\n\n");
+  }
+}
+
+#define HNA "size_t write_struct(const s &obj, void *data, size_t position);\n\n"\
 "size_t write_size(const s &obj, size_t offset);\n\n"\
 "size_t read_struct(s &obj, void *data, size_t position);\n\n"
 
-void test_bare(int n)
-{
-  idl_tree_t* tree = 0x0;
+#define HNP "namespace N\n{\n\n"\
+"  size_t write_struct(const s &obj, void *data, size_t position);\n\n"\
+"  size_t write_size(const s &obj, size_t offset);\n\n"\
+"  size_t read_struct(s &obj, void *data, size_t position);\n\n"\
+"}\n\n"
 
-  char buffer[1024] = { 0x0 };
-  sprintf(buffer, struct_fmt, idl_type[n]);
-  idl_parse_string(buffer, 0x0, &tree);
+idl_member_t* generate_member_base(idl_kind_t member_type, const char* member_name)
+{
+  idl_member_t* returnval = idl_create_member();
+
+  returnval->declarators = idl_create_declarator();
+  returnval->declarators->node.parent = (idl_node_t*)returnval;
+  returnval->declarators->node.previous = NULL;
+  returnval->declarators->node.next = NULL;
+  returnval->declarators->identifier = _strdup(member_name);
+
+  returnval->type_spec = malloc(sizeof(idl_type_spec_t));
+  returnval->type_spec->kind = member_type;
+
+  return returnval;
+}
+
+idl_member_t* generate_member_instance(const char* member_type, const char* member_name)
+{
+  idl_member_t* returnval = idl_create_member();
+
+  returnval->declarators = idl_create_declarator();
+  returnval->declarators->node.parent = (idl_node_t*)returnval;
+  returnval->declarators->node.previous = NULL;
+  returnval->declarators->node.next = NULL;
+  returnval->declarators->identifier = _strdup(member_name);
+
+  returnval->type_spec = malloc(sizeof(idl_type_spec_t));
+  returnval->type_spec->kind = IDL_SCOPED_NAME;
+
+  return returnval;
+}
+
+idl_member_t* generate_sequence_instance(idl_kind_t sequenced_type, const char* member_name)
+{
+  idl_member_t* returnval = idl_create_member();
+
+  returnval->declarators = idl_create_declarator();
+  returnval->declarators->node.parent = (idl_node_t*)returnval;
+  returnval->declarators->node.previous = NULL;
+  returnval->declarators->node.next = NULL;
+  returnval->declarators->identifier = _strdup(member_name);
+
+  returnval->type_spec = malloc(sizeof(idl_type_spec_t));
+  returnval->type_spec->kind = IDL_SEQUENCE_TYPE;
+  returnval->type_spec->sequence_type.type_spec = malloc(sizeof(idl_simple_type_spec_t));
+  returnval->type_spec->sequence_type.type_spec->kind = sequenced_type;
+
+  return returnval;
+}
+
+idl_struct_type_t* generate_struct_base(const char* name, const idl_kind_t* member_types, const char** member_names, size_t nmembers)
+{
+  idl_struct_type_t* returnval = idl_create_struct();
+  returnval->identifier = _strdup(name);
+
+  idl_member_t *prevmem = NULL;
+  for (size_t i = 0; i < nmembers; i++)
+  {
+    idl_member_t* mem = generate_member_base(member_types[i],member_names[i]);
+    mem->node.previous = (idl_node_t*)prevmem;
+    mem->node.next = NULL;
+    if (NULL != prevmem)
+      prevmem->node.next = (idl_node_t*)mem;
+    prevmem = mem;
+
+    if (NULL == returnval->members)
+      returnval->members = mem;
+  }
+
+  return returnval;
+}
+
+idl_struct_type_t* generate_struct_instance(const char* name, const char** instance_types, const char** member_names, size_t nmembers)
+{
+  idl_struct_type_t* returnval = idl_create_struct();
+  returnval->identifier = _strdup(name);
+
+  idl_member_t* prevmem = NULL;
+  for (size_t i = 0; i < nmembers; i++)
+  {
+    idl_member_t* mem = generate_member_instance(instance_types[i], member_names[i]);
+    mem->node.previous = (idl_node_t*)prevmem;
+    mem->node.next = NULL;
+    if (NULL != prevmem)
+      prevmem->node.next = (idl_node_t*)mem;
+    prevmem = mem;
+
+    if (NULL == returnval->members)
+      returnval->members = mem;
+  }
+
+  return returnval;
+}
+
+idl_struct_type_t* generate_struct_sequence(const char* name, const idl_kind_t* sequence_types, const char** member_names, size_t nmembers)
+{
+  idl_struct_type_t* returnval = idl_create_struct();
+  returnval->identifier = _strdup(name);
+
+  idl_member_t* prevmem = NULL;
+  for (size_t i = 0; i < nmembers; i++)
+  {
+    idl_member_t* mem = generate_sequence_instance(sequence_types[i], member_names[i]);
+    mem->node.previous = (idl_node_t*)prevmem;
+    mem->node.next = NULL;
+    if (NULL != prevmem)
+      prevmem->node.next = (idl_node_t*)mem;
+    prevmem = mem;
+
+    if (NULL == returnval->members)
+      returnval->members = mem;
+  }
+
+  return returnval;
+}
+
+void test_base(size_t n, bool ns)
+{
+  idl_tree_t* tree = malloc(sizeof(idl_tree_t));
+  tree->files = NULL;
+
+  idl_kind_t kinds[1] = { idl_type[n] };
+  const char* names[1] = { "mem" };
+
+  idl_struct_type_t* str = generate_struct_base("s", kinds, names, 1);
+  if (ns)
+  {
+    idl_module_t* mod = idl_create_module();
+    mod->definitions = malloc(sizeof(idl_definition_t));
+    mod->definitions = (idl_definition_t*)str;
+    mod->identifier = _strdup("N");
+
+    tree->root = (idl_node_t*)mod;
+    str->node.parent = (idl_node_t*)mod;
+    mod->node.parent = (idl_node_t*)tree;
+  }
+  else
+  {
+    tree->root = (idl_node_t*)str;
+    str->node.parent = (idl_node_t*)tree;
+  }
 
   idl_streamer_output_t* generated = create_idl_streamer_output();
   idl_streamers_generate(tree, generated);
@@ -190,35 +599,29 @@ void test_bare(int n)
   switch (cxx_width[n])
   {
   case 1:
-    format_ostream(impl, cxx_write_func_fmt_1, cxx_type[n]);
-    format_ostream(impl, cxx_write_size_func_fmt_1);
-    format_ostream(impl, cxx_read_func_fmt_1, cxx_type[n]);
+    create_funcs_base_width_1(impl,cxx_type[n],ns);
     break;
   case 2:
-    format_ostream(impl, cxx_write_func_fmt_2, cxx_type[n]);
-    format_ostream(impl, cxx_write_size_func_fmt_2);
-    format_ostream(impl, cxx_read_func_fmt_2, cxx_type[n]);
+    create_funcs_base_width_2(impl, cxx_type[n], ns);
     break;
   case 4:
-    format_ostream(impl, cxx_write_func_fmt_4, cxx_type[n]);
-    format_ostream(impl, cxx_write_size_func_fmt_4);
-    format_ostream(impl, cxx_read_func_fmt_4, cxx_type[n]);
+    create_funcs_base_width_4(impl, cxx_type[n], ns);
     break;
   case 8:
-    format_ostream(impl, cxx_write_func_fmt_8, cxx_type[n]);
-    format_ostream(impl, cxx_write_size_func_fmt_8, cxx_type[n]);
-    format_ostream(impl, cxx_read_func_fmt_8, cxx_type[n]);
-    break;
+    create_funcs_base_width_8(impl, cxx_type[n], ns);
+      break;
   default:
     CU_ASSERT_FATAL(0);
   }
 
-  CU_ASSERT_STRING_EQUAL(HNS, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
+  CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
+
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
 
   /*
-  printf("=========generated============\n%s\n============================\n", get_idl_streamer_header_buf(generated));
+  printf("=========generated============\n%s\n============================\n", get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
   printf("=========tested============\n%s\n============================\n", get_ostream_buffer(impl));
+
   for (int i = 0; i < get_ostream_buffer(impl) && i < strlen(get_ostream_buffer(get_idl_streamer_impl_buf(generated))); i++)
   {
     char c1 = get_ostream_buffer(impl)[i], c2 = get_ostream_buffer(get_idl_streamer_impl_buf(generated))[i];
@@ -231,9 +634,128 @@ void test_bare(int n)
   destruct_idl_streamer_output(generated);
 }
 
-CU_Test(streamer_generator, base_types_no_namespace)
+void test_instance(bool ns)
 {
-  for (size_t i = 0; i < sizeof(idl_type) / sizeof(const char*); i++)
-    test_bare(i);
-  CU_PASS("base_types_no_namespace");
+  idl_tree_t* tree = malloc(sizeof(idl_tree_t));
+  tree->files = NULL;
+
+  const char* types[1] = { "I" };
+  const char* names[1] = { "mem" };
+
+  idl_struct_type_t* str = generate_struct_instance("s", types, names, 1);
+  if (ns)
+  {
+    idl_module_t* mod = idl_create_module();
+    mod->definitions = malloc(sizeof(idl_definition_t));
+    mod->definitions = (idl_definition_t*)str;
+    mod->identifier = _strdup("N");
+
+    tree->root = (idl_node_t*)mod;
+    str->node.parent = (idl_node_t*)mod;
+    mod->node.parent = (idl_node_t*)tree;
+  }
+  else
+  {
+    tree->root = (idl_node_t*)str;
+    str->node.parent = (idl_node_t*)tree;
+  }
+
+  idl_streamer_output_t* generated = create_idl_streamer_output();
+  idl_streamers_generate(tree, generated);
+
+  idl_ostream_t* impl = create_idl_ostream(NULL);
+
+  create_funcs_instance(impl, names[0], ns);
+
+  CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
+
+  CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+}
+
+void test_sequence(size_t n, bool ns)
+{
+  idl_tree_t* tree = malloc(sizeof(idl_tree_t));
+  tree->files = NULL;
+
+  const idl_kind_t types[1] = { idl_type[n] };
+  const char* names[1] = { "mem" };
+
+  idl_struct_type_t* str = generate_struct_sequence("s", types, names, 1);
+  if (ns)
+  {
+    idl_module_t* mod = idl_create_module();
+    mod->definitions = malloc(sizeof(idl_definition_t));
+    mod->definitions = (idl_definition_t*)str;
+    mod->identifier = _strdup("N");
+
+    tree->root = (idl_node_t*)mod;
+    str->node.parent = (idl_node_t*)mod;
+    mod->node.parent = (idl_node_t*)tree;
+  }
+  else
+  {
+    tree->root = (idl_node_t*)str;
+    str->node.parent = (idl_node_t*)tree;
+  }
+
+  idl_streamer_output_t* generated = create_idl_streamer_output();
+  idl_streamers_generate(tree, generated);
+
+  idl_ostream_t* impl = create_idl_ostream(NULL);
+
+  switch (cxx_width[n])
+  {
+  case 1:
+    create_funcs_sequence_width_1(impl, names[0], ns);
+    break;
+  case 2:
+    create_funcs_sequence_width_2(impl, names[0], ns);
+    break;
+  case 4:
+    create_funcs_sequence_width_4(impl, names[0], ns);
+    break;
+  case 8:
+    create_funcs_sequence_width_8(impl, names[0], ns);
+    break;
+  default:
+    CU_ASSERT_FATAL(0);
+  }
+
+  CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
+
+  CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+}
+
+CU_Test(streamer_generator, base_types_namespace_absent)
+{
+  for (size_t i = 0; i < sizeof(idl_type) / sizeof(idl_kind_t); i++)
+    test_base(i, false);
+}
+
+CU_Test(streamer_generator, base_types_namespace_present)
+{
+  for (size_t i = 0; i < sizeof(idl_type) / sizeof(idl_kind_t); i++)
+    test_base(i, true);
+}
+
+CU_Test(streamer_generator, instance_namespace_absent)
+{
+  test_instance(false);
+}
+
+CU_Test(streamer_generator, instance_namespace_present)
+{
+  test_instance(true);
+}
+
+CU_Test(streamer_generator, sequence_namespace_absent)
+{
+  for (size_t i = 0; i < sizeof(idl_type) / sizeof(idl_kind_t); i++)
+    test_sequence(i,false);
+}
+
+CU_Test(streamer_generator, sequence_namespace_present)
+{
+  for (size_t i = 0; i < sizeof(idl_type) / sizeof(idl_kind_t); i++)
+    test_sequence(i, true);
 }

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright(c) 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
+#include "idlcxx/streamer_generator.h"
+#include "idl/processor.h"
+
+#include "CUnit/Theory.h"
+
+static char* input = "module M\n"\
+"{\n"\
+"	struct E {\n"\
+"		long L;\n"\
+"   float f;\n"\
+"	};\n"\
+"	\n"\
+"	struct F {\n"\
+"   long double d;\n"\
+"		char c;\n"\
+"		E e;\n"\
+"	};\n"\
+" module N {\n"\
+"  struct G {\n"\
+"    char g_c;\n"\
+"  };\n"\
+" };\n"\
+"};\n"\
+" module O {\n"\
+"  struct H {\n"\
+"    unsigned long h_i;\n"\
+"  };\n"\
+" };\n";
+
+CU_Test(streamer_generator, streamer_1)
+{
+  idl_tree_t* tree = 0x0;
+  idl_parse_string(input, 0x0, &tree);
+
+  CU_PASS("streamer_1");
+}

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -22,34 +22,218 @@
 
 #include "CUnit/Theory.h"
 
-static char* input = "module M\n"\
-"{\n"\
-"	struct E {\n"\
-"		long L;\n"\
-"   float f;\n"\
-"	};\n"\
-"	\n"\
-"	struct F {\n"\
-"   long double d;\n"\
-"		char c;\n"\
-"		E e;\n"\
-"	};\n"\
-" module N {\n"\
-"  struct G {\n"\
-"    char g_c;\n"\
-"  };\n"\
-" };\n"\
-"};\n"\
-" module O {\n"\
-"  struct H {\n"\
-"    unsigned long h_i;\n"\
-"  };\n"\
-" };\n";
+static const char* idl_type[] = {
+  "char",
+  "octet",
+  "boolean",
+  "short",
+  "long",
+  "long long",
+  "unsigned short",
+  "unsigned long",
+  "unsigned long long",
+  "float",
+  "double"
+};
 
-CU_Test(streamer_generator, streamer_1)
+static const char* cxx_type[] = {
+  "char",
+  "uint8_t",
+  "bool",
+  "int16_t",
+  "int32_t",
+  "int64_t",
+  "uint16_t",
+  "uint32_t",
+  "uint64_t",
+  "float",
+  "double"
+};
+
+static int cxx_width[] = {
+  1,
+  1,
+  1,
+  2,
+  4,
+  8,
+  2,
+  4,
+  8,
+  4,
+  8
+};
+
+
+static const char* struct_fmt =
+"struct s { %s mem;\n};\n";
+
+static const char* cxx_write_func_fmt_1 =
+"size_t write_struct(const s &obj, void *data, size_t position)\n{\n"\
+"  *((%s*)((char*)data+position)) = obj.mem();  //writing bytes for member: mem\n"\
+"  position += 1;  //moving position indicator\n"\
+"  return position;\n"\
+"}\n\n";
+static const char* cxx_write_size_func_fmt_1 =
+"size_t write_size(const s &obj, size_t offset)\n"\
+"{\n"\
+"  size_t position = offset;\n"\
+"  position += 1;  //bytes for member: mem\n"\
+"  return position-offset;\n"\
+"}\n\n";
+static const char* cxx_read_func_fmt_1 =
+"size_t read_struct(s &obj, void *data, size_t position)\n"\
+"{\n"\
+"  obj.mem() = *((%s*)((char*)data+position));  //reading bytes for member: mem\n"\
+"  position += 1;  //moving position indicator\n"\
+"  return position;\n"\
+"}\n\n";
+
+static const char* cxx_write_func_fmt_2 =
+"size_t write_struct(const s &obj, void *data, size_t position)\n"\
+"{\n"\
+"  size_t alignmentbytes = position&0x1;  //alignment\n"\
+"  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
+"  position += alignmentbytes;  //moving position indicator\n"\
+"  *((%s*)((char*)data+position)) = obj.mem();  //writing bytes for member: mem\n"\
+"  position += 2;  //moving position indicator\n"\
+"  return position;\n"\
+"}\n\n";
+static const char* cxx_write_size_func_fmt_2 =
+"size_t write_size(const s &obj, size_t offset)\n"\
+"{\n"\
+"  size_t position = offset;\n"\
+"  position += position&0x1;  //alignment\n"\
+"  position += 2;  //bytes for member: mem\n"\
+"  return position-offset;\n"\
+"}\n\n";
+static const char* cxx_read_func_fmt_2 =
+"size_t read_struct(s &obj, void *data, size_t position)\n"\
+"{\n"\
+"  position += position&0x1;  //alignment\n"\
+"  obj.mem() = *((%s*)((char*)data+position));  //reading bytes for member: mem\n"\
+"  position += 2;  //moving position indicator\n"\
+"  return position;\n"\
+"}\n\n";
+
+static const char* cxx_write_func_fmt_4 =
+"size_t write_struct(const s &obj, void *data, size_t position)\n"\
+"{\n"\
+"  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+"  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
+"  position += alignmentbytes;  //moving position indicator\n"\
+"  *((%s*)((char*)data+position)) = obj.mem();  //writing bytes for member: mem\n"\
+"  position += 4;  //moving position indicator\n"\
+"  return position;\n"\
+"}\n\n";
+static const char* cxx_write_size_func_fmt_4 =
+"size_t write_size(const s &obj, size_t offset)\n"\
+"{\n"\
+"  size_t position = offset;\n"\
+"  position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  position += 4;  //bytes for member: mem\n"\
+"  return position-offset;\n"\
+"}\n\n";
+static const char* cxx_read_func_fmt_4 =
+"size_t read_struct(s &obj, void *data, size_t position)\n"\
+"{\n"\
+"  position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  obj.mem() = *((%s*)((char*)data+position));  //reading bytes for member: mem\n"\
+"  position += 4;  //moving position indicator\n"\
+"  return position;\n"\
+"}\n\n";
+
+static const char* cxx_write_func_fmt_8 =
+"size_t write_struct(const s &obj, void *data, size_t position)\n"\
+"{\n"\
+"  size_t alignmentbytes = (8 - position&0x7)&0x7;  //alignment\n"\
+"  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
+"  position += alignmentbytes;  //moving position indicator\n"\
+"  *((%s*)((char*)data+position)) = obj.mem();  //writing bytes for member: mem\n"\
+"  position += 8;  //moving position indicator\n"\
+"  return position;\n"\
+"}\n\n";
+static const char* cxx_write_size_func_fmt_8 =
+"size_t write_size(const s &obj, size_t offset)\n"\
+"{\n"\
+"  size_t position = offset;\n"\
+"  position += (8 - position&0x7)&0x7;  //alignment\n"\
+"  position += 8;  //bytes for member: mem\n"\
+"  return position-offset;\n"\
+"}\n\n";
+static const char* cxx_read_func_fmt_8 =
+"size_t read_struct(s &obj, void *data, size_t position)\n"\
+"{\n"\
+"  position += (8 - position&0x7)&0x7;  //alignment\n"\
+"  obj.mem() = *((%s*)((char*)data+position));  //reading bytes for member: mem\n"\
+"  position += 8;  //moving position indicator\n"\
+"  return position;\n"\
+"}\n\n";
+
+#define HNS "size_t write_struct(const s &obj, void *data, size_t position);\n\n"\
+"size_t write_size(const s &obj, size_t offset);\n\n"\
+"size_t read_struct(s &obj, void *data, size_t position);\n\n"
+
+void test_bare(int n)
 {
   idl_tree_t* tree = 0x0;
-  idl_parse_string(input, 0x0, &tree);
 
-  CU_PASS("streamer_1");
+  char buffer[1024] = { 0x0 };
+  sprintf(buffer, struct_fmt, idl_type[n]);
+  idl_parse_string(buffer, 0x0, &tree);
+
+  idl_streamer_output_t* generated = create_idl_streamer_output();
+  idl_streamers_generate(tree, generated);
+
+  idl_ostream_t* impl = create_idl_ostream(NULL);
+
+  switch (cxx_width[n])
+  {
+  case 1:
+    format_ostream(impl, cxx_write_func_fmt_1, cxx_type[n]);
+    format_ostream(impl, cxx_write_size_func_fmt_1);
+    format_ostream(impl, cxx_read_func_fmt_1, cxx_type[n]);
+    break;
+  case 2:
+    format_ostream(impl, cxx_write_func_fmt_2, cxx_type[n]);
+    format_ostream(impl, cxx_write_size_func_fmt_2);
+    format_ostream(impl, cxx_read_func_fmt_2, cxx_type[n]);
+    break;
+  case 4:
+    format_ostream(impl, cxx_write_func_fmt_4, cxx_type[n]);
+    format_ostream(impl, cxx_write_size_func_fmt_4);
+    format_ostream(impl, cxx_read_func_fmt_4, cxx_type[n]);
+    break;
+  case 8:
+    format_ostream(impl, cxx_write_func_fmt_8, cxx_type[n]);
+    format_ostream(impl, cxx_write_size_func_fmt_8, cxx_type[n]);
+    format_ostream(impl, cxx_read_func_fmt_8, cxx_type[n]);
+    break;
+  default:
+    CU_ASSERT_FATAL(0);
+  }
+
+  CU_ASSERT_STRING_EQUAL(HNS, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
+  CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+
+  /*
+  printf("=========generated============\n%s\n============================\n", get_idl_streamer_header_buf(generated));
+  printf("=========tested============\n%s\n============================\n", get_ostream_buffer(impl));
+  for (int i = 0; i < get_ostream_buffer(impl) && i < strlen(get_ostream_buffer(get_idl_streamer_impl_buf(generated))); i++)
+  {
+    char c1 = get_ostream_buffer(impl)[i], c2 = get_ostream_buffer(get_idl_streamer_impl_buf(generated))[i];
+    if (c1 != c2) printf("%d: %d: buf: '%c' (%.x) - tree: '%c' (%.x) => %s\n", n, i, c1, c1, c2, c2, c1 != c2 ? "X" : "O");
+  }
+  */
+
+  destruct_idl_ostream(impl);
+
+  destruct_idl_streamer_output(generated);
+}
+
+CU_Test(streamer_generator, base_types_no_namespace)
+{
+  for (size_t i = 0; i < sizeof(idl_type) / sizeof(const char*); i++)
+    test_bare(i);
+  CU_PASS("base_types_no_namespace");
 }

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -1056,7 +1056,7 @@ void test_struct_inheritance()
   "};\n";
 
   idl_tree_t* tree = NULL;
-  idl_parse_string(str, 0u, &tree);
+  idl_parse_string(str, IDL_FLAG_EXTENDED_DATA_TYPES, &tree);
 
   idl_streamer_output_t* generated = create_idl_streamer_output();
   idl_streamers_generate(tree, generated);

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -115,7 +115,7 @@ void create_funcs_base_width_1(idl_ostream_t *ostr, const char *tn, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  obj.mem() = *((%s*)((char*)data+position));  //reading bytes for member: mem\n", tn);
+  format_ostream_indented(ns * 2, ostr, "  obj.mem(*((%s*)((char*)data+position)));  //reading bytes for member: mem\n", tn);
   format_ostream_indented(ns * 2, ostr, "  position += 1;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
@@ -154,7 +154,7 @@ void create_funcs_base_width_2(idl_ostream_t* ostr, const char* tn, bool ns)
   format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  position += position&0x1;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  obj.mem() = *((%s*)((char*)data+position));  //reading bytes for member: mem\n", tn);
+  format_ostream_indented(ns * 2, ostr, "  obj.mem(*((%s*)((char*)data+position)));  //reading bytes for member: mem\n", tn);
   format_ostream_indented(ns * 2, ostr, "  position += 2;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
@@ -193,7 +193,7 @@ void create_funcs_base_width_4(idl_ostream_t* ostr, const char* tn, bool ns)
   format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  obj.mem() = *((%s*)((char*)data+position));  //reading bytes for member: mem\n", tn);
+  format_ostream_indented(ns * 2, ostr, "  obj.mem(*((%s*)((char*)data+position)));  //reading bytes for member: mem\n", tn);
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
@@ -232,7 +232,7 @@ void create_funcs_base_width_8(idl_ostream_t* ostr, const char* tn, bool ns)
   format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  position += (8 - position&0x7)&0x7;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "  obj.mem() = *((%s*)((char*)data+position));  //reading bytes for member: mem\n", tn);
+  format_ostream_indented(ns * 2, ostr, "  obj.mem(*((%s*)((char*)data+position)));  //reading bytes for member: mem\n", tn);
   format_ostream_indented(ns * 2, ostr, "  position += 8;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
@@ -480,6 +480,11 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
+  format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  *((uint32_t*)((char*)data+position)) = obj._d();  //writing bytes for member: _d\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  switch (obj._d())\n");
   format_ostream_indented(ns * 2, ostr, "  {\n");
   format_ostream_indented(ns * 2, ostr, "    case 0:\n");
@@ -516,6 +521,8 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: _d\n");
   format_ostream_indented(ns * 2, ostr, "  switch (obj._d())\n");
   format_ostream_indented(ns * 2, ostr, "  {\n");
   format_ostream_indented(ns * 2, ostr, "    case 0:\n");
@@ -544,12 +551,15 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(0, ostr, "\n");
   format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  obj._d(*((uint32_t*)((char*)data+position)));  //reading bytes for member: _d\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  switch (obj._d())\n");
   format_ostream_indented(ns * 2, ostr, "  {\n");
   format_ostream_indented(ns * 2, ostr, "    case 0:\n");
   format_ostream_indented(ns * 2, ostr, "    case 1:\n");
   format_ostream_indented(ns * 2, ostr, "    {\n");
-  format_ostream_indented(ns * 2, ostr, "      obj._oct() = *((uint8_t*)((char*)data+position));  //reading bytes for member: _oct\n");
+  format_ostream_indented(ns * 2, ostr, "      obj._oct(*((uint8_t*)((char*)data+position)));  //reading bytes for member: _oct\n");
   format_ostream_indented(ns * 2, ostr, "      position += 1;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "    }\n");
   format_ostream_indented(ns * 2, ostr, "    break;\n");
@@ -557,7 +567,7 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "    case 3:\n");
   format_ostream_indented(ns * 2, ostr, "    {\n");
   format_ostream_indented(ns * 2, ostr, "      position += (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "      obj._long() = *((int32_t*)((char*)data+position));  //reading bytes for member: _long\n");
+  format_ostream_indented(ns * 2, ostr, "      obj._long(*((int32_t*)((char*)data+position)));  //reading bytes for member: _long\n");
   format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "    }\n");
   format_ostream_indented(ns * 2, ostr, "    break;\n");
@@ -746,6 +756,9 @@ idl_union_type_t* generate_union_int_switch(const char* name, const uint64_t* ca
   idl_union_type_t* returnval = idl_create_union();
 
   returnval->identifier = _strdup(name);
+
+  returnval->switch_type_spec = calloc(sizeof(idl_switch_type_spec_t), 1);
+  returnval->switch_type_spec->kind = IDL_ULONG;
 
   idl_node_t* prevcase = NULL;
   for (size_t _case = 0; _case < ncases; _case++)

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -353,8 +353,8 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "    break;\n");
   format_ostream_indented(ns * 2, ostr, "  }\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
-  format_ostream_indented(ns * 2, ostr, "}\n");
-  format_ostream_indented(0, ostr, "\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
   format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
@@ -383,8 +383,8 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "    break;\n");
   format_ostream_indented(ns * 2, ostr, "  }\n");
   format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
-  format_ostream_indented(ns * 2, ostr, "}\n");
-  format_ostream_indented(0, ostr, "\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
   format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  obj.clear();\n");
@@ -429,6 +429,112 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
 void generate_enum_funcs(idl_ostream_t* ostr, bool ns)
 {
   create_funcs_base(ostr, 7, ns);
+}
+
+void generate_array_base_funcs(idl_ostream_t* ostr, bool ns)
+{
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "namespace N\n{\n\n");
+  }
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
+  format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  memcpy((char*)data+position,obj.mem().data(),24);  //writing bytes for member: mem\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 24;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  *((float*)((char*)data+position)) = obj.mem2();  //writing bytes for member: mem2\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 24;  //bytes for member: mem\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: mem2\n");
+  format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  memcpy(obj.mem().data(),(char*)data+position,24);  //reading bytes for member: mem\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 24;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  obj.mem2(*((float*)((char*)data+position)));  //reading bytes for member: mem2\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "} //end namespace N\n\n");
+  }
+}
+
+
+void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
+{
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "namespace N\n{\n\n");
+  }
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_struct(const I &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
+  format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  *((int32_t*)((char*)data+position)) = obj.l();  //writing bytes for member: l\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  for (size_t _i = 0; _i < 6; _i++) position = write_struct(obj.mem()[_i], data, position);\n");
+  format_ostream_indented(ns * 2, ostr, "  position = write_struct(obj.mem2(), data, position);\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_size(const I &obj, size_t offset)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: l\n");
+  format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
+  format_ostream_indented(ns * 2, ostr, "  for (size_t _i = 0; _i < 6; _i++) position += write_size(obj.mem()[_i], position);\n");
+  format_ostream_indented(ns * 2, ostr, "  position += write_size(obj.mem2(), position);\n");
+  format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t read_struct(I &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  obj.l(*((int32_t*)((char*)data+position)));  //reading bytes for member: l\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  for (size_t _i = 0; _i < 6; _i++) position = read_struct(obj.mem()[_i], data, position);\n");
+  format_ostream_indented(ns * 2, ostr, "  position = read_struct(obj.mem2(), data, position);\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "} //end namespace N\n\n");
+  }
 }
 
 #define HNA "size_t write_struct(const s &obj, void *data, size_t position);\n\n"\
@@ -693,6 +799,78 @@ void test_enum(bool ns)
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
 }
 
+void test_array_base(bool ns)
+{
+  char buffer[1024];
+  if (ns)
+  {
+    sprintf_s(buffer, 1024,
+      "module N {\n"\
+      "struct s {\n"\
+      "float mem[3][2], mem2;\n"\
+      "};\n"\
+      "};\n");
+  }
+  else
+  {
+    sprintf_s(buffer, 1024,
+      "struct s {\n"\
+      "float mem[3][2], mem2;\n"\
+      "};\n");
+  }
+
+  idl_tree_t* tree = NULL;
+  idl_parse_string(buffer, 0u, &tree);
+
+  idl_streamer_output_t* generated = create_idl_streamer_output();
+  idl_streamers_generate(tree, generated);
+
+  idl_ostream_t* impl = create_idl_ostream(NULL);
+  generate_array_base_funcs(impl, ns);
+
+  CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
+  CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+}
+
+void test_array_instance(bool ns)
+{
+  char buffer[1024];
+  if (ns)
+  {
+    sprintf_s(buffer, 1024,
+      "module N {\n"\
+      "struct I {\n"\
+      "long l;\n"\
+      "};\n"\
+      "struct s {\n"\
+      "I mem[3][2], mem2;\n"\
+      "};\n"\
+      "};\n");
+  }
+  else
+  {
+    sprintf_s(buffer, 1024,
+      "struct I {\n"\
+      "long l;\n"\
+      "};\n"\
+      "struct s {\n"\
+      "I mem[3][2], mem2;\n"\
+      "};\n");
+  }
+
+  idl_tree_t* tree = NULL;
+  idl_parse_string(buffer, 0u, &tree);
+
+  idl_streamer_output_t* generated = create_idl_streamer_output();
+  idl_streamers_generate(tree, generated);
+
+  idl_ostream_t* impl = create_idl_ostream(NULL);
+  generate_array_instance_funcs(impl, ns);
+
+  CU_ASSERT_STRING_EQUAL(ns ? HNPI : HNAI, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
+  CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+}
+
 CU_Test(streamer_generator, base_types_namespace_absent)
 {
   for (size_t i = 0; i < sizeof(cxx_width) / sizeof(size_t); i++)
@@ -755,4 +933,24 @@ CU_Test(streamer_generator, enumerator_namespace_absent)
 CU_Test(streamer_generator, enumerator_namespace_present)
 {
   test_enum(true);
+}
+
+CU_Test(streamer_generator, array_base_type_namespace_absent)
+{
+  test_array_base(false);
+}
+
+CU_Test(streamer_generator, array_base_type_namespace_present)
+{
+  test_array_base(true);
+}
+
+CU_Test(streamer_generator, array_instance_namespace_absent)
+{
+  test_array_instance(false);
+}
+
+CU_Test(streamer_generator, array_instance_namespace_present)
+{
+  test_array_instance(true);
 }

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -66,6 +66,28 @@ static int cxx_width[] = {
   8
 };
 
+static size_t ncases = 3;
+static size_t labelspercase = 2;
+
+static uint64_t union_switch_int_case_labels[] = {
+  0,1,
+  2,3,
+  4,5
+};
+
+static idl_kind_t union_switch_int_case_types[] = {
+  IDL_OCTET,
+  IDL_LONG,
+  IDL_STRING_TYPE
+};
+
+static const char* union_switch_int_case_names[] = {
+  "_oct",
+  "_long",
+  "_str"
+};
+
+
 #define format_ostream_indented(depth,ostr,str,...) \
 if (depth > 0) format_ostream(ostr, "%*c", depth, ' '); \
 format_ostream(ostr, str, ##__VA_ARGS__);
@@ -449,6 +471,115 @@ void create_funcs_sequence_width_8(idl_ostream_t* ostr, const char* in, bool ns)
 "  size_t read_struct(s &obj, void *data, size_t position);\n\n"\
 "}\n\n"
 
+void generate_union_funcs(idl_ostream_t* ostr, bool ns)
+{
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "namespace N\n{\n\n");
+  }
+
+  format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  switch (obj._d())\n");
+  format_ostream_indented(ns * 2, ostr, "  {\n");
+  format_ostream_indented(ns * 2, ostr, "    case 0:\n");
+  format_ostream_indented(ns * 2, ostr, "    case 1:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      *((uint8_t*)((char*)data+position)) = obj._oct();  //writing bytes for member: _oct\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 1;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "    case 2:\n");
+  format_ostream_indented(ns * 2, ostr, "    case 3:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "      memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
+  format_ostream_indented(ns * 2, ostr, "      position += alignmentbytes;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "      *((int32_t*)((char*)data+position)) = obj._long();  //writing bytes for member: _long\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "    case 4:\n");
+  format_ostream_indented(ns * 2, ostr, "    case 5:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      uint32_t sequenceentries = obj._str().size()+1;  //number of entries in the sequence\n");
+  format_ostream_indented(ns * 2, ostr, "      *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing bytes for member: _str().size\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "      memcpy((char*)data+position,obj._str().data(),sequenceentries*1);  //contents for _str\n");
+  format_ostream_indented(ns * 2, ostr, "      position += sequenceentries*1;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "  }\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n");
+  format_ostream_indented(0, ostr, "\n");
+  format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
+  format_ostream_indented(ns * 2, ostr, "  switch (obj._d())\n");
+  format_ostream_indented(ns * 2, ostr, "  {\n");
+  format_ostream_indented(ns * 2, ostr, "    case 0:\n");
+  format_ostream_indented(ns * 2, ostr, "    case 1:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 1;  //bytes for member: _oct\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "    case 2:\n");
+  format_ostream_indented(ns * 2, ostr, "    case 3:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 4;  //bytes for member: _long\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "    case 4:\n");
+  format_ostream_indented(ns * 2, ostr, "    case 5:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 4;  //bytes for member: _str().size\n");
+  format_ostream_indented(ns * 2, ostr, "      position += (obj._str().size()+1)*1;  //entries of sequence\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "  }\n");
+  format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n");
+  format_ostream_indented(0, ostr, "\n");
+  format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  switch (obj._d())\n");
+  format_ostream_indented(ns * 2, ostr, "  {\n");
+  format_ostream_indented(ns * 2, ostr, "    case 0:\n");
+  format_ostream_indented(ns * 2, ostr, "    case 1:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      obj._oct() = *((uint8_t*)((char*)data+position));  //reading bytes for member: _oct\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 1;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "    case 2:\n");
+  format_ostream_indented(ns * 2, ostr, "    case 3:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "      obj._long() = *((int32_t*)((char*)data+position));  //reading bytes for member: _long\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "    case 4:\n");
+  format_ostream_indented(ns * 2, ostr, "    case 5:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "      obj._str().assign((char*)data+position,(char*)data+position+sequenceentries*1);  //putting data into container\n");
+  format_ostream_indented(ns * 2, ostr, "      position += sequenceentries*1;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "  }\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "}\n\n");
+  }
+}
+
 idl_member_t* generate_member_base(idl_kind_t member_type, const char* member_name)
 {
   idl_member_t* returnval = idl_create_member();
@@ -459,7 +590,7 @@ idl_member_t* generate_member_base(idl_kind_t member_type, const char* member_na
   returnval->declarators->node.next = NULL;
   returnval->declarators->identifier = _strdup(member_name);
 
-  returnval->type_spec = malloc(sizeof(idl_type_spec_t));
+  returnval->type_spec = calloc(sizeof(idl_type_spec_t),1);
   returnval->type_spec->kind = member_type;
 
   return returnval;
@@ -475,7 +606,7 @@ idl_member_t* generate_member_instance(const char* member_type, const char* memb
   returnval->declarators->node.next = NULL;
   returnval->declarators->identifier = _strdup(member_name);
 
-  returnval->type_spec = malloc(sizeof(idl_type_spec_t));
+  returnval->type_spec = calloc(sizeof(idl_type_spec_t),1);
   returnval->type_spec->kind = IDL_SCOPED_NAME;
 
   return returnval;
@@ -491,9 +622,9 @@ idl_member_t* generate_sequence_instance(idl_kind_t sequenced_type, const char* 
   returnval->declarators->node.next = NULL;
   returnval->declarators->identifier = _strdup(member_name);
 
-  returnval->type_spec = malloc(sizeof(idl_type_spec_t));
+  returnval->type_spec = calloc(sizeof(idl_type_spec_t),1);
   returnval->type_spec->kind = IDL_SEQUENCE_TYPE;
-  returnval->type_spec->sequence_type.type_spec = malloc(sizeof(idl_simple_type_spec_t));
+  returnval->type_spec->sequence_type.type_spec = calloc(sizeof(idl_simple_type_spec_t),1);
   returnval->type_spec->sequence_type.type_spec->kind = sequenced_type;
 
   return returnval;
@@ -504,15 +635,17 @@ idl_struct_type_t* generate_struct_base(const char* name, const idl_kind_t* memb
   idl_struct_type_t* returnval = idl_create_struct();
   returnval->identifier = _strdup(name);
 
-  idl_member_t *prevmem = NULL;
+  idl_node_t* prevmem = NULL;
   for (size_t i = 0; i < nmembers; i++)
   {
     idl_member_t* mem = generate_member_base(member_types[i],member_names[i]);
-    mem->node.previous = (idl_node_t*)prevmem;
-    mem->node.next = NULL;
+
+    idl_node_t* currentnode = (idl_node_t*)mem;
+    currentnode->parent = (idl_node_t*)returnval;
+    currentnode->previous = prevmem;
     if (NULL != prevmem)
-      prevmem->node.next = (idl_node_t*)mem;
-    prevmem = mem;
+      prevmem->next = currentnode;
+    prevmem = currentnode;
 
     if (NULL == returnval->members)
       returnval->members = mem;
@@ -526,15 +659,17 @@ idl_struct_type_t* generate_struct_instance(const char* name, const char** insta
   idl_struct_type_t* returnval = idl_create_struct();
   returnval->identifier = _strdup(name);
 
-  idl_member_t* prevmem = NULL;
+  idl_node_t* prevmem = NULL;
   for (size_t i = 0; i < nmembers; i++)
   {
     idl_member_t* mem = generate_member_instance(instance_types[i], member_names[i]);
-    mem->node.previous = (idl_node_t*)prevmem;
-    mem->node.next = NULL;
+
+    idl_node_t* currentnode = (idl_node_t*)mem;
+    currentnode->parent = (idl_node_t*)returnval;
+    currentnode->previous = prevmem;
     if (NULL != prevmem)
-      prevmem->node.next = (idl_node_t*)mem;
-    prevmem = mem;
+      prevmem->next = currentnode;
+    prevmem = currentnode;
 
     if (NULL == returnval->members)
       returnval->members = mem;
@@ -548,15 +683,17 @@ idl_struct_type_t* generate_struct_sequence(const char* name, const idl_kind_t* 
   idl_struct_type_t* returnval = idl_create_struct();
   returnval->identifier = _strdup(name);
 
-  idl_member_t* prevmem = NULL;
+  idl_node_t* prevmem = NULL;
   for (size_t i = 0; i < nmembers; i++)
   {
     idl_member_t* mem = generate_sequence_instance(sequence_types[i], member_names[i]);
-    mem->node.previous = (idl_node_t*)prevmem;
-    mem->node.next = NULL;
+
+    idl_node_t* currentnode = (idl_node_t*)mem;
+    currentnode->parent = (idl_node_t*)returnval;
+    currentnode->previous = prevmem;
     if (NULL != prevmem)
-      prevmem->node.next = (idl_node_t*)mem;
-    prevmem = mem;
+      prevmem->next = currentnode;
+    prevmem = currentnode;
 
     if (NULL == returnval->members)
       returnval->members = mem;
@@ -565,10 +702,73 @@ idl_struct_type_t* generate_struct_sequence(const char* name, const idl_kind_t* 
   return returnval;
 }
 
+idl_case_label_t* generate_union_case_int_label(uint64_t _case)
+{
+  idl_case_label_t* returnval = idl_create_case_label();
+
+  returnval->const_expr = (idl_const_expr_t*)idl_create_integer_literal(_case);
+  ((idl_node_t*)returnval->const_expr)->parent = (idl_node_t*)returnval;
+
+  return returnval;
+}
+
+idl_case_t* generate_union_int_switch_case(const uint64_t* labels, const idl_kind_t case_type, const char* case_name)
+{
+  idl_case_t* returnval = idl_create_case();
+
+  idl_node_t* prevlabel = NULL;
+  for (size_t label = 0; label < labelspercase; label++)
+  {
+    idl_case_label_t* currentlabel = generate_union_case_int_label(labels[label]);
+
+    idl_node_t* currentnode = (idl_node_t*)currentlabel;
+    currentnode->parent = (idl_node_t*)returnval;
+    currentnode->previous = prevlabel;
+    if (NULL != prevlabel)
+      prevlabel->next = currentnode;
+    prevlabel = currentnode;
+
+    if (NULL == returnval->case_labels)
+      returnval->case_labels = currentlabel;
+  }
+
+  returnval->type_spec = calloc(sizeof(idl_type_spec_t),1);
+  returnval->type_spec->kind = case_type;
+  returnval->declarator = idl_create_declarator();
+  returnval->declarator->node.parent = (idl_node_t*)returnval;
+  returnval->declarator->identifier = _strdup(case_name);
+
+  return returnval;
+}
+
+idl_union_type_t* generate_union_int_switch(const char* name, const uint64_t* cases, const idl_kind_t* case_types, const char** case_names)
+{
+  idl_union_type_t* returnval = idl_create_union();
+
+  returnval->identifier = _strdup(name);
+
+  idl_node_t* prevcase = NULL;
+  for (size_t _case = 0; _case < ncases; _case++)
+  {
+    idl_case_t* currentcase = generate_union_int_switch_case(cases + _case*labelspercase, case_types[_case], case_names[_case]);
+
+    idl_node_t* currentnode = (idl_node_t*)currentcase;
+    currentnode->parent = (idl_node_t*)returnval;
+    currentnode->previous = prevcase;
+    if (NULL != prevcase)
+      prevcase->next = currentnode;
+    prevcase = currentnode;
+
+    if (NULL == returnval->cases)
+      returnval->cases = currentcase;
+  }
+
+  return returnval;
+}
+
 void test_base(size_t n, bool ns)
 {
-  idl_tree_t* tree = malloc(sizeof(idl_tree_t));
-  tree->files = NULL;
+  idl_tree_t* tree = calloc(sizeof(idl_tree_t),1);
 
   idl_kind_t kinds[1] = { idl_type[n] };
   const char* names[1] = { "mem" };
@@ -577,7 +777,7 @@ void test_base(size_t n, bool ns)
   if (ns)
   {
     idl_module_t* mod = idl_create_module();
-    mod->definitions = malloc(sizeof(idl_definition_t));
+    mod->definitions = calloc(sizeof(idl_definition_t),1);
     mod->definitions = (idl_definition_t*)str;
     mod->identifier = _strdup("N");
 
@@ -615,19 +815,7 @@ void test_base(size_t n, bool ns)
   }
 
   CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
-
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
-
-  /*
-  printf("=========generated============\n%s\n============================\n", get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
-  printf("=========tested============\n%s\n============================\n", get_ostream_buffer(impl));
-
-  for (int i = 0; i < get_ostream_buffer(impl) && i < strlen(get_ostream_buffer(get_idl_streamer_impl_buf(generated))); i++)
-  {
-    char c1 = get_ostream_buffer(impl)[i], c2 = get_ostream_buffer(get_idl_streamer_impl_buf(generated))[i];
-    if (c1 != c2) printf("%d: %d: buf: '%c' (%.x) - tree: '%c' (%.x) => %s\n", n, i, c1, c1, c2, c2, c1 != c2 ? "X" : "O");
-  }
-  */
 
   destruct_idl_ostream(impl);
 
@@ -636,8 +824,7 @@ void test_base(size_t n, bool ns)
 
 void test_instance(bool ns)
 {
-  idl_tree_t* tree = malloc(sizeof(idl_tree_t));
-  tree->files = NULL;
+  idl_tree_t* tree = calloc(sizeof(idl_tree_t),1);
 
   const char* types[1] = { "I" };
   const char* names[1] = { "mem" };
@@ -646,7 +833,7 @@ void test_instance(bool ns)
   if (ns)
   {
     idl_module_t* mod = idl_create_module();
-    mod->definitions = malloc(sizeof(idl_definition_t));
+    mod->definitions = calloc(sizeof(idl_definition_t),1);
     mod->definitions = (idl_definition_t*)str;
     mod->identifier = _strdup("N");
 
@@ -674,8 +861,7 @@ void test_instance(bool ns)
 
 void test_sequence(size_t n, bool ns)
 {
-  idl_tree_t* tree = malloc(sizeof(idl_tree_t));
-  tree->files = NULL;
+  idl_tree_t* tree = calloc(sizeof(idl_tree_t),1);
 
   const idl_kind_t types[1] = { idl_type[n] };
   const char* names[1] = { "mem" };
@@ -684,7 +870,7 @@ void test_sequence(size_t n, bool ns)
   if (ns)
   {
     idl_module_t* mod = idl_create_module();
-    mod->definitions = malloc(sizeof(idl_definition_t));
+    mod->definitions = calloc(sizeof(idl_definition_t),1);
     mod->definitions = (idl_definition_t*)str;
     mod->identifier = _strdup("N");
 
@@ -726,6 +912,43 @@ void test_sequence(size_t n, bool ns)
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
 }
 
+void test_union(bool ns)
+{
+  idl_union_type_t* _union = generate_union_int_switch("s", union_switch_int_case_labels, union_switch_int_case_types, union_switch_int_case_names);
+  idl_tree_t* tree = calloc(sizeof(idl_tree_t),1);
+
+  if (ns)
+  {
+    idl_module_t* mod = idl_create_module();
+    mod->definitions = calloc(sizeof(idl_definition_t), 1);
+    mod->definitions = (idl_definition_t*)_union;
+    mod->identifier = _strdup("N");
+
+    tree->root = (idl_node_t*)mod;
+    _union->node.parent = (idl_node_t*)mod;
+    mod->node.parent = (idl_node_t*)tree;
+  }
+  else
+  {
+    tree->root = (idl_node_t*)_union;
+    _union->node.parent = (idl_node_t*)tree;
+  }
+
+  idl_streamer_output_t* generated = create_idl_streamer_output();
+  idl_streamers_generate(tree, generated);
+
+  idl_ostream_t* impl = create_idl_ostream(NULL);
+  generate_union_funcs(impl, ns);
+
+  /*
+  printf("=========generated============\n%s\n============================\n", get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+  printf("=========tested============\n%s\n============================\n", get_ostream_buffer(impl));
+  */
+
+  CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
+  CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+}
+
 CU_Test(streamer_generator, base_types_namespace_absent)
 {
   for (size_t i = 0; i < sizeof(idl_type) / sizeof(idl_kind_t); i++)
@@ -758,4 +981,14 @@ CU_Test(streamer_generator, sequence_namespace_present)
 {
   for (size_t i = 0; i < sizeof(idl_type) / sizeof(idl_kind_t); i++)
     test_sequence(i, true);
+}
+
+CU_Test(streamer_generator, union_case_int_namespace_absent)
+{
+  test_union(false);
+}
+
+CU_Test(streamer_generator, union_case_int_namespace_present)
+{
+  test_union(true);
 }

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -13,11 +13,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
-#ifdef _WIN32
-#include <Windows.h>
-#else
-#define sprintf_s(ptr, len, str, ...) sprintf(ptr, str __VA_OPT__(,) __VA_ARGS__)
-#endif
 
 #include "idlcxx/streamer_generator.h"
 #include "idl/processor.h"
@@ -737,7 +732,7 @@ void test_base(size_t n, bool ns)
   char buffer[1024];
   if (ns)
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "module N {\n"\
       "struct s {\n"\
       "%s mem;\n"\
@@ -747,7 +742,7 @@ void test_base(size_t n, bool ns)
   }
   else
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "struct s {\n"\
       "%s mem;\n"\
       "};\n",
@@ -776,7 +771,7 @@ void test_instance(bool ns)
   char buffer[1024];
   if (ns)
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "module N {\n"\
       "struct I {\n"\
       "long l;\n"
@@ -788,7 +783,7 @@ void test_instance(bool ns)
   }
   else
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "struct I {\n"\
       "long l;\n"
       "};\n"
@@ -816,7 +811,7 @@ void test_sequence(size_t n, bool ns)
   char buffer[1024];
   if (ns)
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "module N {\n"\
       "struct s {\n"\
       "sequence<%s> mem;\n"\
@@ -826,7 +821,7 @@ void test_sequence(size_t n, bool ns)
   }
   else
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "struct s {\n"\
       "sequence<%s> mem;\n"\
       "};\n",
@@ -852,7 +847,7 @@ void test_string(bool ns)
   char buffer[1024];
   if (ns)
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "module N {\n"\
       "struct s {\n"\
       "string str;\n"\
@@ -861,7 +856,7 @@ void test_string(bool ns)
   }
   else
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "struct s {\n"\
       "string str;\n"\
       "};\n");
@@ -886,7 +881,7 @@ void test_union(bool ns)
   char buffer[1024];
   if (ns)
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "module N {\n"\
       "union s switch (long) {\n"\
       "case 0:\n"\
@@ -901,7 +896,7 @@ void test_union(bool ns)
   }
   else
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "union s switch (long) {\n"\
       "case 0:\n"\
       "case 1: octet o;\n"\
@@ -930,7 +925,7 @@ void test_enum(bool ns)
   char buffer[1024];
   if (ns)
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "module N {\n"\
       "enum E {e_0, e_1, e_2, e_3};\n"\
       "struct s {\n"\
@@ -940,7 +935,7 @@ void test_enum(bool ns)
   }
   else
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "enum E {e_0, e_1, e_2, e_3};\n"\
       "struct s {\n"\
       "E mem;\n"\
@@ -964,7 +959,7 @@ void test_array_base(bool ns)
   char buffer[1024];
   if (ns)
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "module N {\n"\
       "struct s {\n"\
       "float mem[3][2], mem2;\n"\
@@ -973,7 +968,7 @@ void test_array_base(bool ns)
   }
   else
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "struct s {\n"\
       "float mem[3][2], mem2;\n"\
       "};\n");
@@ -997,7 +992,7 @@ void test_array_instance(bool ns)
   char buffer[1024];
   if (ns)
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "module N {\n"\
       "struct I {\n"\
       "long l;\n"\
@@ -1009,7 +1004,7 @@ void test_array_instance(bool ns)
   }
   else
   {
-    sprintf_s(buffer, 1024,
+    snprintf(buffer, sizeof(buffer),
       "struct I {\n"\
       "long l;\n"\
       "};\n"\

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -342,9 +342,6 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "    case 2:\n");
   format_ostream_indented(ns * 2, ostr, "    case 3:\n");
   format_ostream_indented(ns * 2, ostr, "    {\n");
-  format_ostream_indented(ns * 2, ostr, "      size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(ns * 2, ostr, "      memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
-  format_ostream_indented(ns * 2, ostr, "      position += alignmentbytes;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "      *((int32_t*)((char*)data+position)) = obj._long();  //writing bytes for member: _long\n");
   format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "    }\n");
@@ -379,7 +376,6 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "    case 2:\n");
   format_ostream_indented(ns * 2, ostr, "    case 3:\n");
   format_ostream_indented(ns * 2, ostr, "    {\n");
-  format_ostream_indented(ns * 2, ostr, "      position += (4 - position&0x3)&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "      position += 4;  //bytes for member: _long\n");
   format_ostream_indented(ns * 2, ostr, "    }\n");
   format_ostream_indented(ns * 2, ostr, "    break;\n");
@@ -396,6 +392,7 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(0, ostr, "\n");
   format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  obj.clear();\n");
   format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  obj._d(*((uint32_t*)((char*)data+position)));  //reading bytes for member: _d\n");
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
@@ -411,7 +408,6 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "    case 2:\n");
   format_ostream_indented(ns * 2, ostr, "    case 3:\n");
   format_ostream_indented(ns * 2, ostr, "    {\n");
-  format_ostream_indented(ns * 2, ostr, "      position += (4 - position&0x3)&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "      obj._long(*((int32_t*)((char*)data+position)));  //reading bytes for member: _long\n");
   format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "    }\n");
@@ -421,7 +417,7 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "    {\n");
   format_ostream_indented(ns * 2, ostr, "      uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n");
   format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "      obj._str().assign((char*)data+position,(char*)data+position+sequenceentries*1);  //putting data into container\n");
+  format_ostream_indented(ns * 2, ostr, "      obj._str().assign((char*)((char*)data+position),(char*)((char*)data+position)+sequenceentries);  //putting data into container\n");
   format_ostream_indented(ns * 2, ostr, "      position += sequenceentries*1;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "    }\n");
   format_ostream_indented(ns * 2, ostr, "    break;\n");
@@ -431,7 +427,7 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
 
   if (ns)
   {
-    format_ostream_indented(0, ostr, "}  //end namespace N\n\n");
+    format_ostream_indented(0, ostr, "} //end namespace N\n\n");
   }
 }
 
@@ -612,11 +608,11 @@ idl_case_t* generate_union_int_switch_case(const uint64_t* labels, const idl_mas
   return returnval;
 }
 
-idl_union_t* generate_union_int_switch(const char* name, const uint64_t* cases, const idl_mask_t* case_types, const char** case_names)
+idl_union_t* generate_union_int_switch(const uint64_t* cases, const idl_mask_t* case_types, const char** case_names)
 {
   idl_union_t* returnval = idl_create_union();
 
-  returnval->identifier = _strdup(name);
+  returnval->identifier = _strdup("s");
 
   returnval->switch_type_spec = calloc(sizeof(idl_switch_type_spec_t), 1);
   returnval->switch_type_spec->mask = IDL_ULONG;
@@ -790,7 +786,7 @@ void test_string(bool ns)
 
 void test_union(bool ns)
 {
-  idl_union_t* _union = generate_union_int_switch("s", union_switch_int_case_labels, union_switch_int_case_types, union_switch_int_case_names);
+  idl_union_t* _union = generate_union_int_switch(union_switch_int_case_labels, union_switch_int_case_types, union_switch_int_case_names);
   idl_tree_t* tree = calloc(sizeof(idl_tree_t),1);
 
   if (ns)

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -161,7 +161,7 @@ void create_funcs_instance(idl_ostream_t* ostr, const char* in, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position = write_struct(obj.%s(), data, position);\n", in);
+  format_ostream_indented(ns * 2, ostr, "  position = %swrite_struct(obj.%s(), data, position);\n", ns ? "N::" : "", in);
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -176,7 +176,7 @@ void create_funcs_instance(idl_ostream_t* ostr, const char* in, bool ns)
   format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
-  format_ostream_indented(ns * 2, ostr, "  position += write_size(obj.%s(), position);\n", in);
+  format_ostream_indented(ns * 2, ostr, "  position += %swrite_size(obj.%s(), position);\n", ns ? "N::" : "", in);
   format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -190,7 +190,7 @@ void create_funcs_instance(idl_ostream_t* ostr, const char* in, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position = read_struct(obj.%s(), data, position);\n", in);
+  format_ostream_indented(ns * 2, ostr, "  position = %sread_struct(obj.%s(), data, position);\n", ns ? "N::" : "", in);
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -495,8 +495,8 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  for (size_t _i = 0; _i < 6; _i++) position = write_struct(obj.mem()[_i], data, position);\n");
-  format_ostream_indented(ns * 2, ostr, "  position = write_struct(obj.mem2(), data, position);\n");
+  format_ostream_indented(ns * 2, ostr, "  for (size_t _i = 0; _i < 6; _i++) position = %swrite_struct(obj.mem()[_i], data, position);\n", ns ? "N::" : "");
+  format_ostream_indented(ns * 2, ostr, "  position = %swrite_struct(obj.mem2(), data, position);\n", ns ? "N::" : "");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -511,8 +511,8 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "size_t write_size(const s &obj, size_t offset)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  size_t position = offset;\n");
-  format_ostream_indented(ns * 2, ostr, "  for (size_t _i = 0; _i < 6; _i++) position += write_size(obj.mem()[_i], position);\n");
-  format_ostream_indented(ns * 2, ostr, "  position += write_size(obj.mem2(), position);\n");
+  format_ostream_indented(ns * 2, ostr, "  for (size_t _i = 0; _i < 6; _i++) position += %swrite_size(obj.mem()[_i], position);\n", ns ? "N::" : "");
+  format_ostream_indented(ns * 2, ostr, "  position += %swrite_size(obj.mem2(), position);\n", ns ? "N::" : "");
   format_ostream_indented(ns * 2, ostr, "  return position-offset;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -526,8 +526,8 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  for (size_t _i = 0; _i < 6; _i++) position = read_struct(obj.mem()[_i], data, position);\n");
-  format_ostream_indented(ns * 2, ostr, "  position = read_struct(obj.mem2(), data, position);\n");
+  format_ostream_indented(ns * 2, ostr, "  for (size_t _i = 0; _i < 6; _i++) position = %sread_struct(obj.mem()[_i], data, position);\n", ns ? "N::" : "");
+  format_ostream_indented(ns * 2, ostr, "  position = %sread_struct(obj.mem2(), data, position);\n", ns ? "N::" : "");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -537,99 +537,157 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   }
 }
 
-void generate_inheritance_funcs(idl_ostream_t* ostr)
-{
-  format_ostream_indented(0, ostr, "size_t write_struct(const I &obj, void *data, size_t position)\n");
-  format_ostream_indented(0, ostr, "{\n");
-  format_ostream_indented(0, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(0, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
-  format_ostream_indented(0, ostr, "  position += alignmentbytes;  //moving position indicator\n");
-  format_ostream_indented(0, ostr, "  *((int32_t*)((char*)data+position)) = obj.inherited_member();  //writing bytes for member: inherited_member\n");
-  format_ostream_indented(0, ostr, "  position += 4;  //moving position indicator\n");
-  format_ostream_indented(0, ostr, "  return position;\n");
-  format_ostream_indented(0, ostr, "}\n\n");
+#define CCFI "namespace A_1\n"\
+  "{\n\n"\
+"  namespace A_2\n"\
+"  {\n\n"\
+"    size_t write_struct(const s_1 &obj, void *data, size_t position)\n"\
+"    {\n"\
+"      size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+"      memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
+"      position += alignmentbytes;  //moving position indicator\n"\
+"      *((int32_t*)((char*)data+position)) = obj.m_1();  //writing bytes for member: m_1\n"\
+"      position += 4;  //moving position indicator\n"\
+"      return position;\n"\
+"    }\n\n"\
+"    size_t write_size(const s_1 &obj, size_t offset)\n"\
+"    {\n"\
+"      size_t position = offset;\n"\
+"      position += (4 - position&0x3)&0x3;  //alignment\n"\
+"      position += 4;  //bytes for member: m_1\n"\
+"      return position-offset;\n"\
+"    }\n\n"\
+"    size_t read_struct(s_1 &obj, void *data, size_t position)\n"\
+"    {\n"\
+"      position += (4 - position&0x3)&0x3;  //alignment\n"\
+"      obj.m_1(*((int32_t*)((char*)data+position)));  //reading bytes for member: m_1\n"\
+"      position += 4;  //moving position indicator\n"\
+"      return position;\n"\
+"    }\n\n"\
+"  } //end namespace A_2\n\n"\
+"} //end namespace A_1\n\n"\
+"namespace B_1\n"\
+"{\n\n"\
+"  namespace B_2\n"\
+"  {\n\n"\
+"    size_t write_struct(const s_2 &obj, void *data, size_t position)\n"\
+"    {\n"\
+"      position = A_1::A_2::write_struct(obj.m_2(), data, position);\n"\
+"      return position;\n"\
+"    }\n\n"\
+"    size_t write_size(const s_2 &obj, size_t offset)\n"\
+"    {\n"\
+"      size_t position = offset;\n"\
+"      position += A_1::A_2::write_size(obj.m_2(), position);\n"\
+"      return position-offset;\n"\
+"    }\n\n"\
+"    size_t read_struct(s_2 &obj, void *data, size_t position)\n"\
+"    {\n"\
+"      position = A_1::A_2::read_struct(obj.m_2(), data, position);\n"\
+"      return position;\n"\
+"    }\n\n"\
+"  } //end namespace B_2\n\n"\
+"} //end namespace B_1\n\n"
 
-  format_ostream_indented(0, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
-  format_ostream_indented(0, ostr, "{\n");
-  format_ostream_indented(0, ostr, "  position = write_struct(dynamic_cast<I&>(obj), data, position);\n");
-  format_ostream_indented(0, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(0, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
-  format_ostream_indented(0, ostr, "  position += alignmentbytes;  //moving position indicator\n");
-  format_ostream_indented(0, ostr, "  *((int32_t*)((char*)data+position)) = obj.new_member();  //writing bytes for member: new_member\n");
-  format_ostream_indented(0, ostr, "  position += 4;  //moving position indicator\n");
-  format_ostream_indented(0, ostr, "  return position;\n");
-  format_ostream_indented(0, ostr, "}\n\n");
+#define CCFH "namespace A_1\n"\
+"{\n\n"\
+"  namespace A_2\n"\
+"  {\n\n"\
+"    size_t write_struct(const s_1 &obj, void *data, size_t position);\n\n"\
+"    size_t write_size(const s_1 &obj, size_t offset);\n\n"\
+"    size_t read_struct(s_1 &obj, void *data, size_t position);\n\n"\
+"  } //end namespace A_2\n\n"\
+"} //end namespace A_1\n\n"\
+"namespace B_1\n"\
+"{\n\n"\
+"  namespace B_2\n"\
+"  {\n\n"\
+"    size_t write_struct(const s_2 &obj, void *data, size_t position);\n\n"\
+"    size_t write_size(const s_2 &obj, size_t offset);\n\n"\
+"    size_t read_struct(s_2 &obj, void *data, size_t position);\n\n"\
+"  } //end namespace B_2\n\n"\
+"} //end namespace B_1\n\n"
 
-  format_ostream_indented(0, ostr, "size_t write_size(const I &obj, size_t offset)\n");
-  format_ostream_indented(0, ostr, "{\n");
-  format_ostream_indented(0, ostr, "  size_t position = offset;\n");
-  format_ostream_indented(0, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(0, ostr, "  position += 4;  //bytes for member: inherited_member\n");
-  format_ostream_indented(0, ostr, "  return position-offset;\n");
-  format_ostream_indented(0, ostr, "}\n\n");
+#define IFI "size_t write_struct(const I &obj, void *data, size_t position)\n"\
+  "{\n"\
+  "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+  "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
+  "  position += alignmentbytes;  //moving position indicator\n"\
+  "  *((int32_t*)((char*)data+position)) = obj.inherited_member();  //writing bytes for member: inherited_member\n"\
+  "  position += 4;  //moving position indicator\n"\
+  "  return position;\n"\
+  "}\n\n"\
+  "size_t write_struct(const s &obj, void *data, size_t position)\n"\
+  "{\n"\
+  "  position = write_struct(dynamic_cast<I&>(obj), data, position);\n"\
+  "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+  "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
+  "  position += alignmentbytes;  //moving position indicator\n"\
+  "  *((int32_t*)((char*)data+position)) = obj.new_member();  //writing bytes for member: new_member\n"\
+  "  position += 4;  //moving position indicator\n"\
+  "  return position;\n"\
+  "}\n\n"\
+  "size_t write_size(const I &obj, size_t offset)\n"\
+  "{\n"\
+  "  size_t position = offset;\n"\
+  "  position += (4 - position&0x3)&0x3;  //alignment\n"\
+  "  position += 4;  //bytes for member: inherited_member\n"\
+  "  return position-offset;\n"\
+  "}\n\n"\
+  "size_t write_size(const s &obj, size_t offset)\n"\
+  "{\n"\
+  "  size_t position = offset;\n"\
+  "  position += write_size(dynamic_cast<I&>(obj), position);\n"\
+  "  position += (4 - position&0x3)&0x3;  //alignment\n"\
+  "  position += 4;  //bytes for member: new_member\n"\
+  "  return position-offset;\n"\
+  "}\n\n"\
+  "size_t read_struct(I &obj, void *data, size_t position)\n"\
+  "{\n"\
+  "  position += (4 - position&0x3)&0x3;  //alignment\n"\
+  "  obj.inherited_member(*((int32_t*)((char*)data+position)));  //reading bytes for member: inherited_member\n"\
+  "  position += 4;  //moving position indicator\n"\
+  "  return position;\n"\
+  "}\n\n"\
+  "size_t read_struct(s &obj, void *data, size_t position)\n"\
+  "{\n"\
+  "  position = read_struct(dynamic_cast<I&>(obj), data, position);\n"\
+  "  position += (4 - position&0x3)&0x3;  //alignment\n"\
+  "  obj.new_member(*((int32_t*)((char*)data+position)));  //reading bytes for member: new_member\n"\
+  "  position += 4;  //moving position indicator\n"\
+  "  return position;\n"\
+  "}\n\n"
 
-  format_ostream_indented(0, ostr, "size_t write_size(const s &obj, size_t offset)\n");
-  format_ostream_indented(0, ostr, "{\n");
-  format_ostream_indented(0, ostr, "  size_t position = offset;\n");
-  format_ostream_indented(0, ostr, "  position += write_size(dynamic_cast<I&>(obj), position);\n");
-  format_ostream_indented(0, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(0, ostr, "  position += 4;  //bytes for member: new_member\n");
-  format_ostream_indented(0, ostr, "  return position-offset;\n");
-  format_ostream_indented(0, ostr, "}\n\n");
-
-  format_ostream_indented(0, ostr, "size_t read_struct(I &obj, void *data, size_t position)\n");
-  format_ostream_indented(0, ostr, "{\n");
-  format_ostream_indented(0, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(0, ostr, "  obj.inherited_member(*((int32_t*)((char*)data+position)));  //reading bytes for member: inherited_member\n");
-  format_ostream_indented(0, ostr, "  position += 4;  //moving position indicator\n");
-  format_ostream_indented(0, ostr, "  return position;\n");
-  format_ostream_indented(0, ostr, "}\n\n");
-
-  format_ostream_indented(0, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
-  format_ostream_indented(0, ostr, "{\n");
-  format_ostream_indented(0, ostr, "  position = read_struct(dynamic_cast<I&>(obj), data, position);\n");
-  format_ostream_indented(0, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(0, ostr, "  obj.new_member(*((int32_t*)((char*)data+position)));  //reading bytes for member: new_member\n");
-  format_ostream_indented(0, ostr, "  position += 4;  //moving position indicator\n");
-  format_ostream_indented(0, ostr, "  return position;\n");
-  format_ostream_indented(0, ostr, "}\n\n");
-}
-
-void generate_bounded_sequence_funcs(idl_ostream_t* ostr)
-{
-  format_ostream_indented(0, ostr, "size_t write_struct(const s &obj, void *data, size_t position)\n");
-  format_ostream_indented(0, ostr, "{\n");
-  format_ostream_indented(0, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(0, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
-  format_ostream_indented(0, ostr, "  position += alignmentbytes;  //moving position indicator\n");
-  format_ostream_indented(0, ostr, "  uint32_t sequenceentries = obj.mem().size();  //number of entries in the sequence\n");
-  format_ostream_indented(0, ostr, "  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing bytes for member: mem().size\n");
-  format_ostream_indented(0, ostr, "  position += 4;  //moving position indicator\n");
-  format_ostream_indented(0, ostr, "  if (sequenceentries > 20) throw dds::core::InvalidArgumentError(\"attempt to assign entries to bounded member mem in excess of maximum length 20\");\n");
-  format_ostream_indented(0, ostr, "  memcpy((char*)data+position,obj.mem().data(),sequenceentries*4);  //contents for mem\n");
-  format_ostream_indented(0, ostr, "  position += sequenceentries*4;  //moving position indicator\n");
-  format_ostream_indented(0, ostr, "  return position;\n");
-  format_ostream_indented(0, ostr, "}\n\n");
-
-  format_ostream_indented(0, ostr, "size_t write_size(const s &obj, size_t offset)\n");
-  format_ostream_indented(0, ostr, "{\n");
-  format_ostream_indented(0, ostr, "  size_t position = offset;\n");
-  format_ostream_indented(0, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(0, ostr, "  position += 4;  //bytes for member: mem().size\n");
-  format_ostream_indented(0, ostr, "  position += (obj.mem().size())*4;  //entries of sequence\n");
-  format_ostream_indented(0, ostr, "  return position-offset;\n");
-  format_ostream_indented(0, ostr, "}\n\n");
-
-  format_ostream_indented(0, ostr, "size_t read_struct(s &obj, void *data, size_t position)\n");
-  format_ostream_indented(0, ostr, "{\n");
-  format_ostream_indented(0, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
-  format_ostream_indented(0, ostr, "  uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n");
-  format_ostream_indented(0, ostr, "  position += 4;  //moving position indicator\n");
-  format_ostream_indented(0, ostr, "  obj.mem().assign((int32_t*)((char*)data+position),(int32_t*)((char*)data+position)+sequenceentries);  //putting data into container\n");
-  format_ostream_indented(0, ostr, "  position += sequenceentries*4;  //moving position indicator\n");
-  format_ostream_indented(0, ostr, "  return position;\n");
-  format_ostream_indented(0, ostr, "}\n\n");
-}
+#define BSI "size_t write_struct(const s &obj, void *data, size_t position)\n"\
+  "{\n"\
+  "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+  "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
+  "  position += alignmentbytes;  //moving position indicator\n"\
+  "  uint32_t sequenceentries = obj.mem().size();  //number of entries in the sequence\n"\
+  "  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing bytes for member: mem().size\n"\
+  "  position += 4;  //moving position indicator\n"\
+  "  if (sequenceentries > 20) throw dds::core::InvalidArgumentError(\"attempt to assign entries to bounded member mem in excess of maximum length 20\");\n"\
+  "  memcpy((char*)data+position,obj.mem().data(),sequenceentries*4);  //contents for mem\n"\
+  "  position += sequenceentries*4;  //moving position indicator\n"\
+  "  return position;\n"\
+  "}\n\n"\
+  "size_t write_size(const s &obj, size_t offset)\n"\
+  "{\n"\
+  "  size_t position = offset;\n"\
+  "  position += (4 - position&0x3)&0x3;  //alignment\n"\
+  "  position += 4;  //bytes for member: mem().size\n"\
+  "  position += (obj.mem().size())*4;  //entries of sequence\n"\
+  "  return position-offset;\n"\
+  "}\n\n"\
+  "size_t read_struct(s &obj, void *data, size_t position)\n"\
+  "{\n"\
+  "  position += (4 - position&0x3)&0x3;  //alignment\n"\
+  "  uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n"\
+  "  position += 4;  //moving position indicator\n"\
+  "  obj.mem().assign((int32_t*)((char*)data+position),(int32_t*)((char*)data+position)+sequenceentries);  //putting data into container\n"\
+  "  position += sequenceentries*4;  //moving position indicator\n"\
+  "  return position;\n"\
+  "}\n\n"
 
 #define HNA "size_t write_struct(const s &obj, void *data, size_t position);\n\n"\
 "size_t write_size(const s &obj, size_t offset);\n\n"\
@@ -965,6 +1023,21 @@ void test_array_instance(bool ns)
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
 }
 
+void test_namespace_cross_call()
+{
+  char* str = "module A_1 { module A_2 { struct s_1 { long m_1; }; }; };\n"\
+              "module B_1 { module B_2 { struct s_2 { A_1::A_2::s_1 m_2; }; }; };\n";
+
+  idl_tree_t* tree = NULL;
+  idl_parse_string(str, 0u, &tree);
+
+  idl_streamer_output_t* generated = create_idl_streamer_output();
+  idl_streamers_generate(tree, generated);
+
+  CU_ASSERT_STRING_EQUAL(CCFH, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
+  CU_ASSERT_STRING_EQUAL(CCFI, get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+}
+
 void test_struct_inheritance()
 {
   const char* str = "struct I {\n"\
@@ -980,11 +1053,8 @@ void test_struct_inheritance()
   idl_streamer_output_t* generated = create_idl_streamer_output();
   idl_streamers_generate(tree, generated);
 
-  idl_ostream_t* impl = create_idl_ostream(NULL);
-  generate_inheritance_funcs(impl);
-
   CU_ASSERT_STRING_EQUAL(HNAI, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
-  CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+  CU_ASSERT_STRING_EQUAL(IFI, get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
 }
 
 void test_bounded_sequence()
@@ -1000,11 +1070,8 @@ void test_bounded_sequence()
   idl_streamer_output_t* generated = create_idl_streamer_output();
   idl_streamers_generate(tree, generated);
 
-  idl_ostream_t* impl = create_idl_ostream(NULL);
-  generate_bounded_sequence_funcs(impl);
-
   CU_ASSERT_STRING_EQUAL(HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
-  CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+  CU_ASSERT_STRING_EQUAL(BSI, get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
 }
 
 CU_Test(streamer_generator, base_types_namespace_absent)
@@ -1089,6 +1156,11 @@ CU_Test(streamer_generator, array_instance_namespace_absent)
 CU_Test(streamer_generator, array_instance_namespace_present)
 {
   test_array_instance(true);
+}
+
+CU_Test(streamer_generator, namespace_cross_call)
+{
+  test_namespace_cross_call();
 }
 
 CU_Test(streamer_generator, struct_inheritance)

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -351,6 +351,12 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "      position += sequenceentries*1;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "    }\n");
   format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "    default:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      *((float*)((char*)data+position)) = obj.f();  //writing bytes for member: f\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
   format_ostream_indented(ns * 2, ostr, "  }\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
@@ -379,6 +385,11 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "    {\n");
   format_ostream_indented(ns * 2, ostr, "      position += 4;  //bytes for member: str().size\n");
   format_ostream_indented(ns * 2, ostr, "      position += (obj.str().size()+1)*1;  //entries of sequence\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "    default:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 4;  //bytes for member: f\n");
   format_ostream_indented(ns * 2, ostr, "    }\n");
   format_ostream_indented(ns * 2, ostr, "    break;\n");
   format_ostream_indented(ns * 2, ostr, "  }\n");
@@ -414,6 +425,12 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "      obj.str().assign((char*)((char*)data+position),(char*)((char*)data+position)+sequenceentries);  //putting data into container\n");
   format_ostream_indented(ns * 2, ostr, "      position += sequenceentries*1;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "    default:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      obj.f(*((float*)((char*)data+position)));  //reading bytes for member: f\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "    }\n");
   format_ostream_indented(ns * 2, ostr, "    break;\n");
   format_ostream_indented(ns * 2, ostr, "  }\n");
@@ -878,6 +895,7 @@ void test_union(bool ns)
       "case 3: long l;\n"\
       "case 4:\n"\
       "case 5: string str;\n"\
+      "default: float f;\n"\
       "};\n"\
       "};\n");
   }
@@ -891,6 +909,7 @@ void test_union(bool ns)
       "case 3: long l;\n"\
       "case 4:\n"\
       "case 5: string str;\n"\
+      "default: float f;\n"\
       "};\n");
   }
   idl_tree_t* tree = NULL;
@@ -901,17 +920,6 @@ void test_union(bool ns)
 
   idl_ostream_t* impl = create_idl_ostream(NULL);
   generate_union_funcs(impl, ns);
-
-  /*
-  printf("=========generated============\n%s\n============================\n", get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
-  printf("=========tested============\n%s\n============================\n", get_ostream_buffer(impl));
-  FILE* f1 = fopen("a.txt","w");
-  FILE* f2 = fopen("b.txt","w");
-  fprintf(f1, get_ostream_buffer(impl));
-  fprintf(f2, get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
-  fclose(f1);
-  fclose(f2);
-  */
 
   CU_ASSERT_STRING_EQUAL(ns ? HNP : HNA, get_ostream_buffer(get_idl_streamer_header_buf(generated)));
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));


### PR DESCRIPTION
Created idlcxx library containing streamer generator functions.
The function idl_streamers_generate takes an idl_tree (the result of an idl file being parsed by the cyclonedds idl processor), and generates a number of functions.
For each C++ representation of each IDL object (as defined by the OMG C++11 language mapping) the following functions are generated:
- write_struct: takes a C++ IDL object and writes it in CDR representation to the supplied memory address
- write_size: takes a C++ IDL object and returns the number of bytes it would take up, if written in CDR representation
- read_struct: takes a C++ IDL object and a memory address and attempts to read the data at the address into the IDL object, assuming it is CDR formatted

Created idl_ostream to help with string buffering/writing/etc.
Added unittests for both idl_ostream and streamer generator.