### PR TITLE
Adapt backed for scoping changes in libidl

### DIFF
--- a/src/idlcxx/src/backendCpp11Type.c
+++ b/src/idlcxx/src/backendCpp11Type.c
@@ -87,7 +87,7 @@ get_cpp11_declarator_data(idl_backend_ctx ctx, const idl_node_t *node)
 
   member_data->member_type_node = ((const idl_member_t *) node->parent)->type_spec;
   member_data->declarator_node = declarator;
-  member_data->name = get_cpp11_name(declarator->identifier);
+  member_data->name = get_cpp11_name(idl_identifier(declarator));
   member_data->type_name = get_cpp11_type(member_data->member_type_node);
   /* Check if the declarator contains also an array expression... */
   if (idl_declarator_is_array(declarator))
@@ -249,7 +249,7 @@ struct_generate_body(idl_backend_ctx ctx, const idl_struct_t *struct_node)
 
   struct_ctx.members = malloc(sizeof(cpp11_member_state) * nr_members);
   struct_ctx.member_count = 0;
-  struct_ctx.name = get_cpp11_name(struct_node->identifier);
+  struct_ctx.name = get_cpp11_name(idl_identifier(struct_node));
   if (struct_node->base_type)
   {
     const idl_node_t *base_node = (const idl_node_t *) struct_node->base_type;
@@ -396,7 +396,7 @@ get_cpp11_case_data(idl_backend_ctx ctx, const idl_node_t *node)
 
   case_data->typespec_node = case_node->type_spec;
   case_data->declarator_node = case_node->declarator;
-  case_data->name = get_cpp11_name(case_node->declarator->identifier);
+  case_data->name = get_cpp11_name(idl_identifier(case_node->declarator));
   case_data->label_count = 0;
   if (label_count > 0) {
     case_data->labels = malloc(sizeof(char *) * label_count);
@@ -1211,7 +1211,7 @@ static idl_retcode_t
 union_generate_body(idl_backend_ctx ctx, const idl_union_t *union_node)
 {
   idl_retcode_t result = IDL_RETCODE_OK;
-  char *cpp11Name = get_cpp11_name(union_node->identifier);
+  char *cpp11Name = get_cpp11_name(idl_identifier(union_node));
 
   idl_file_out_printf(ctx, "class %s\n", cpp11Name);
   idl_file_out_printf(ctx, "{\n");
@@ -1270,7 +1270,7 @@ static idl_retcode_t
 enumerator_generate_identifier(idl_backend_ctx ctx, const idl_node_t *enumerator_node)
 {
   const idl_enumerator_t *enumerator = (const idl_enumerator_t *) enumerator_node;
-  char *cpp11Name = get_cpp11_name(enumerator->identifier);
+  char *cpp11Name = get_cpp11_name(idl_identifier(enumerator));
   idl_file_out_printf(ctx, "%s,\n", cpp11Name);
   free(cpp11Name);
   return IDL_RETCODE_OK;
@@ -1280,7 +1280,7 @@ static idl_retcode_t
 enum_generate_body(idl_backend_ctx ctx, const idl_enum_t *enum_node)
 {
   idl_retcode_t result;
-  char *cpp11Name = get_cpp11_name(enum_node->identifier);
+  char *cpp11Name = get_cpp11_name(idl_identifier(enum_node));
   const idl_node_t *enumerators = (const idl_node_t *) enum_node->enumerators;
 
   idl_file_out_printf(ctx, "enum class %s\n", cpp11Name);
@@ -1296,7 +1296,7 @@ enum_generate_body(idl_backend_ctx ctx, const idl_enum_t *enum_node)
 static idl_retcode_t
 typedef_generate_body(idl_backend_ctx ctx, const idl_typedef_t *typedef_node)
 {
-  char *cpp11Name = get_cpp11_name(typedef_node->declarators->identifier);
+  char *cpp11Name = get_cpp11_name(idl_identifier(typedef_node->declarators));
   char *cpp11Type = get_cpp11_type(typedef_node->type_spec);
 
   idl_file_out_printf(ctx, "typedef %s %s;\n\n", cpp11Type, cpp11Name);
@@ -1310,7 +1310,7 @@ static idl_retcode_t
 module_generate_body(idl_backend_ctx ctx, const idl_module_t *module_node)
 {
   idl_retcode_t result;
-  char *cpp11Name = get_cpp11_name(module_node->identifier);
+  char *cpp11Name = get_cpp11_name(idl_identifier(module_node));
 
   idl_file_out_printf(ctx, "namespace %s\n", cpp11Name);
   idl_file_out_printf(ctx, "{\n", cpp11Name);
@@ -1327,7 +1327,7 @@ module_generate_body(idl_backend_ctx ctx, const idl_module_t *module_node)
 static idl_retcode_t
 forward_decl_generate_body(idl_backend_ctx ctx, const idl_forward_t *forward_node)
 {
-  char *cpp11Name = get_cpp11_name(forward_node->identifier);
+  char *cpp11Name = get_cpp11_name(idl_identifier(forward_node));
   assert(forward_node->node.mask & (IDL_STRUCT | IDL_UNION));
   idl_file_out_printf(
       ctx,
@@ -1341,7 +1341,7 @@ forward_decl_generate_body(idl_backend_ctx ctx, const idl_forward_t *forward_nod
 static idl_retcode_t
 const_generate_body(idl_backend_ctx ctx, const idl_const_t *const_node)
 {
-  char *cpp11Name = get_cpp11_name(const_node->identifier);
+  char *cpp11Name = get_cpp11_name(idl_identifier(const_node));
   char *cpp11Type = get_cpp11_type(const_node->type_spec);
   char *cpp11Value = get_cpp11_const_value((const idl_constval_t *) const_node->const_expr);
   idl_file_out_printf(

--- a/src/idlcxx/src/backendCpp11Utils.c
+++ b/src/idlcxx/src/backendCpp11Utils.c
@@ -179,26 +179,13 @@ get_cpp11_templ_type(const idl_node_t *node)
 char *
 get_cpp11_type(const idl_node_t *node)
 {
-  char *cpp11Type = NULL;
-
-  switch (node->mask & IDL_CATEGORY_MASK) {
-  case IDL_BASE_TYPE:
-    cpp11Type = get_cpp11_base_type(node);
-    break;
-  case IDL_TEMPL_TYPE:
-    cpp11Type = get_cpp11_templ_type(node);
-    break;
-  case IDL_STRUCT:
-  case IDL_UNION:
-  case IDL_ENUM:
-  case IDL_TYPEDEF:
-    cpp11Type = get_cpp11_fully_scoped_name(node);
-    break;
-  default:
-    assert(0);
-    break;
-  }
-  return cpp11Type;
+  assert(node->mask & (IDL_BASE_TYPE|IDL_TEMPL_TYPE|IDL_CONSTR_TYPE|IDL_TYPEDEF));
+  if (idl_is_base_type(node))
+    return get_cpp11_base_type(node);
+  else if (idl_is_templ_type(node))
+    return get_cpp11_templ_type(node);
+  else
+    return get_cpp11_fully_scoped_name(node);
 }
 
 char *
@@ -224,22 +211,22 @@ get_cpp11_fully_scoped_name(const idl_node_t *node)
     switch (scope_type)
     {
     case IDL_ENUMERATOR:
-      scope_names[i] = get_cpp11_name(((const idl_enumerator_t *) current_node)->identifier);
+      scope_names[i] = get_cpp11_name(idl_identifier(current_node));
       break;
     case IDL_ENUM:
-      scope_names[i] = get_cpp11_name(((const idl_enum_t *) current_node)->identifier);
+      scope_names[i] = get_cpp11_name(idl_identifier(current_node));
       break;
     case IDL_MODULE:
-      scope_names[i] = get_cpp11_name(((const idl_module_t *) current_node)->identifier);
+      scope_names[i] = get_cpp11_name(idl_identifier(current_node));
       break;
     case IDL_STRUCT:
-      scope_names[i] = get_cpp11_name(((const idl_struct_t *) current_node)->identifier);
+      scope_names[i] = get_cpp11_name(idl_identifier(current_node));
       break;
     case IDL_UNION:
-      scope_names[i] = get_cpp11_name(((const idl_union_t *) current_node)->identifier);
+      scope_names[i] = get_cpp11_name(idl_identifier(current_node));
       break;
     case IDL_TYPEDEF:
-      scope_names[i] = get_cpp11_name(((const idl_typedef_t *) current_node)->declarators->identifier);
+      scope_names[i] = get_cpp11_name(idl_identifier(((const idl_typedef_t *)current_node)->declarators));
       break;
     }
     scoped_enumerator_len += (strlen(scope_names[i]) + 2); /* scope + "::" */

--- a/src/idlcxx/src/idl_ostream.c
+++ b/src/idlcxx/src/idl_ostream.c
@@ -76,11 +76,15 @@ void format_ostream(idl_ostream_t* ostr, const char* fmt, ...)
 
 void format_ostream_va_args(idl_ostream_t* ostr, const char* fmt, va_list args)
 {
+  va_list aq;
   size_t space = ostr->_buf.size - ostr->_buf.used;
+  va_copy(aq, args);
   int wb = vsnprintf(ostr->_buf.data + ostr->_buf.used,
                       space,
                       fmt,
-                      args);
+                      aq);
+  va_end(aq);
+
   if (wb < 0)
   {
     fprintf(stderr, "a formatting error occurred during format_ostream\n");

--- a/src/idlcxx/src/streamer_generator.c
+++ b/src/idlcxx/src/streamer_generator.c
@@ -341,13 +341,13 @@ void resolve_namespace(idl_node_t* node, char** up)
     if (*up)
     {
       char *temp = NULL;
-      idl_asprintf(&temp, "%s::%s", mod->identifier, *up);
+      idl_asprintf(&temp, "%s::%s", idl_identifier(mod), *up);
       free(*up);
       *up = temp;
     }
     else
     {
-      idl_asprintf(up, "%s::", mod->identifier);
+      idl_asprintf(up, "%s::", idl_identifier(mod));
     }
   }
 
@@ -435,7 +435,7 @@ idl_retcode_t process_struct(context_t* ctx, idl_declarator_t* decl, idl_struct_
 {
   assert(ctx);
   assert(decl);
-  char* cpp11name = get_cpp11_name(decl->identifier);
+  char* cpp11name = get_cpp11_name(idl_identifier(decl));
   assert(cpp11name);
 
   uint64_t entries = array_entries(decl);
@@ -713,32 +713,20 @@ idl_retcode_t process_template(context_t* ctx, idl_declarator_t* decl, idl_type_
       idl_is_string(tspec))
   {
     // FIXME: loop!?
-    cpp11name = get_cpp11_name(decl->identifier);
+    cpp11name = get_cpp11_name(idl_identifier(decl));
     assert(cpp11name);
 
-    idl_const_expr_t* ce = NULL;
+    size_t bound;
     idl_type_spec_t* ispec = tspec;
     if (idl_is_sequence(tspec))
     {
       //change member_mask to the type of the sequence template
-      ce = ((idl_sequence_t*)tspec)->const_expr;
+      bound = ((idl_sequence_t*)tspec)->maximum;
       ispec = ((idl_sequence_t*)tspec)->type_spec;
     }
     else if (idl_is_string(tspec))
     {
-      ce = ((idl_string_t*)tspec)->const_expr;
-    }
-
-    size_t bound = 0;
-    while (ce)
-    {
-      if ((ce->mask & IDL_CONST) == IDL_CONST &&
-          (ce->mask & IDL_INTEGER_TYPE) == IDL_INTEGER_TYPE)
-      {
-        bound = ((idl_literal_t*)ce)->value.ullng;
-        break;
-      }
-      ce = ce->next;
+      bound = ((idl_string_t*)tspec)->maximum;
     }
 
     char* buffer;
@@ -856,7 +844,7 @@ idl_retcode_t process_module(context_t* ctx, idl_module_t* module)
 
   if (module->definitions)
   {
-    char* cpp11name = get_cpp11_name(module->identifier);
+    char* cpp11name = get_cpp11_name(idl_identifier(module));
     assert(cpp11name);
 
     context_t* newctx = child_context(ctx, cpp11name);
@@ -894,9 +882,9 @@ idl_retcode_t process_constructed(context_t* ctx, idl_node_t* node)
       idl_is_union(node))
   {
     if (idl_is_struct(node))
-      cpp11name = get_cpp11_name(((idl_struct_t*)node)->identifier);
+      cpp11name = get_cpp11_name(idl_identifier((idl_struct_t*)node));
     else if (idl_is_union(node))
-      cpp11name = get_cpp11_name(((idl_union_t*)node)->identifier);
+      cpp11name = get_cpp11_name(idl_identifier((idl_union_t*)node));
     assert(cpp11name);
 
     format_header_stream(1, ctx, struct_write_func_fmt, cpp11name);
@@ -928,7 +916,7 @@ idl_retcode_t process_constructed(context_t* ctx, idl_node_t* node)
       idl_struct_t* _struct = (idl_struct_t*)node;
       if (_struct->base_type)
       {
-        char* base_cpp11name = get_cpp11_name(_struct->base_type->identifier);
+        char* base_cpp11name = get_cpp11_name(idl_identifier(_struct->base_type));
         char* ns = idl_strdup("");
         assert(base_cpp11name);
         resolve_namespace((idl_node_t*)_struct->base_type, &ns);
@@ -1079,7 +1067,7 @@ idl_retcode_t process_base(context_t* ctx, idl_declarator_t* decl, idl_type_spec
   assert(decl);
   assert(tspec);
 
-  char* cpp11name = get_cpp11_name(decl->identifier);
+  char* cpp11name = get_cpp11_name(idl_identifier(decl));
   assert(cpp11name);
 
   uint64_t entries = array_entries(decl);

--- a/src/idlcxx/tests/cpp11Backend.c
+++ b/src/idlcxx/tests/cpp11Backend.c
@@ -335,18 +335,18 @@ CU_Theory((const char *input, const char *output), cpp11Backend, Typedef, .timeo
 CU_TheoryDataPoints(cpp11Backend, Union) =
 {
   /* Series of IDL input */
-  CU_DataPoints(const char *, IDL_INPUT_UNION_1_BRANCH("CaseHolder","long","1","string","name"),
-                              IDL_INPUT_UNION_1_BRANCH("try","short","0","string","_module"),
+  CU_DataPoints(const char *, //IDL_INPUT_UNION_1_BRANCH("CaseHolder","long","1","string","name"),
+                              //IDL_INPUT_UNION_1_BRANCH("try","short","0","string","_module"),
                               IDL_INPUT_ENUM("Color","Red","Yellow","Blue") IDL_INPUT_UNION_1_BRANCH("CaseHolder","Color","Red","string","name")
                               ),
   /* Series of corresponding C++ output */
-  CU_DataPoints(const char *, IDL_OUTPUT_UNION_1_BRANCH("CaseHolder","int32_t","0","1","std::string","name"),
-                              IDL_OUTPUT_UNION_1_BRANCH("_cxx_try","int16_t","1","0","std::string","module"),
-                              IDL_OUTPUT_ENUM("Color","Red","Yellow","Blue") IDL_OUTPUT_UNION_1_BRANCH("CaseHolder","Color","::Color::Yellow","::Color::Red","std::string","name")
+  CU_DataPoints(const char *, //IDL_OUTPUT_UNION_1_BRANCH("CaseHolder","int32_t","0","1","std::string","name"),
+                              //IDL_OUTPUT_UNION_1_BRANCH("_cxx_try","int16_t","1","0","std::string","module"),
+                              IDL_OUTPUT_ENUM("Color","Red","Yellow","Blue") "\n\n" IDL_OUTPUT_UNION_1_BRANCH("CaseHolder","::Color","::Color::Yellow","::Color::Red","std::string","name")
                               )
 };
 
-CU_Theory((const char *input, const char *output), cpp11Backend, Union, .disabled = true)
+CU_Theory((const char *input, const char *output), cpp11Backend, Union)
 {
   init();
   test_base_type(input, 0u, IDL_RETCODE_OK, output);


### PR DESCRIPTION
This PR basically changes every `node->identifier` dereference into `idl_identifier(node)` because every declaration now uses a `name` (location + identifier) for the benefit of better error reporting. Apart from that it also avoids reuse of the same `va_list` in one of the output functions.