### PR TITLE
Bug fixes and include filtering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,9 +91,9 @@ ubuntu1804_clang10: &ubuntu1804_clang10
   install:
     - pip install conan --upgrade --user
 
-macos1015_xcode11_6: &macos1015_xcode11_6
+macos1015_xcode11_5: &macos1015_xcode11_5
   os: osx
-  osx_image: xcode11.6
+  osx_image: xcode11.5
   compiler: clang
   addons:
     homebrew:
@@ -166,9 +166,9 @@ jobs:
       env: [ ARCH=x86_64, BUILD_TYPE=Debug, SANITIZER=address ]
     - <<: *ubuntu1804_clang10
       env: [ ARCH=x86_64, BUILD_TYPE=Release ]
-    - <<: *macos1015_xcode11_6
+    - <<: *macos1015_xcode11_5
       env: [ ARCH=x86_64, BUILD_TYPE=Debug, SANITIZER=address ]
-    - <<: *macos1015_xcode11_6
+    - <<: *macos1015_xcode11_5
       env: [ ARCH=x86_64, BUILD_TYPE=Release ]
     - <<: *windows1809_vs2017
       env: [ ARCH=x86, BUILD_TYPE=Debug ]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,5 +9,10 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
+
+IF (WIN32)
+  add_compile_options(/wd4251 /wd4250)
+ENDIF()
+
 add_subdirectory(ddscxx)
 add_subdirectory(idlcxx)

--- a/src/ddscxx/include/dds/core/Duration.hpp
+++ b/src/ddscxx/include/dds/core/Duration.hpp
@@ -83,7 +83,7 @@ public:
 
     /**
      * Create a Duration from a number of milliseconds
-     * @param miliseconds number of milliseconds
+     * @param milliseconds number of milliseconds
      */
     static const Duration from_millisecs(int64_t milliseconds);
 
@@ -139,7 +139,8 @@ public:
 
     /**
      * Returns true if the Duration is greater than or equal to the comparator
-     * @param Duration &that
+     * @param that the Duration to compare
+     * @return true if that is larger than or equal to this
      */
     bool operator >=(const Duration& that) const;
 

--- a/src/ddscxx/include/dds/core/Reference.hpp
+++ b/src/ddscxx/include/dds/core/Reference.hpp
@@ -98,8 +98,6 @@ public:
 
     /**
      * Creates a "null" Reference.
-     *
-     * @param null
      */
     explicit Reference(dds::core::null_type&);
 
@@ -193,6 +191,9 @@ public:
     /** @copydoc dds::core::Reference::operator=(const Reference<D>& that) */
     template <typename R>
     Reference& operator=(const R& rhs);
+
+    /** @copydoc dds::core::Reference::operator=(const Reference<D>& that) */
+    Reference& operator=(const Reference& other) = default;
 
     /**
      * Special assignment operators that takes care of assigning

--- a/src/ddscxx/include/dds/core/TEntity.hpp
+++ b/src/ddscxx/include/dds/core/TEntity.hpp
@@ -58,6 +58,15 @@ public:
     OMG_DDS_REF_TYPE_PROTECTED_DC(TEntity, dds::core::Reference, DELEGATE)
     OMG_DDS_IMPLICIT_REF_BASE(TEntity)
 
+    /**
+    * Assign new Entity to this object.
+    *
+    * @param other the entity to copy.
+    *
+    * @return reference pointing to the entity that was assigned to.
+    */
+    TEntity& operator=(const TEntity& other) = default;
+
     /** @cond */
     virtual ~TEntity();
     /** @endcond */
@@ -118,7 +127,6 @@ public:
      * dr.enable();
      * @endcode
      *
-     * @return void
      * @throw  dds::core::PreconditionNotMetError
      *              Entities' factory is not enabled.
      */
@@ -207,8 +215,6 @@ public:
      * - Any object to which the application has a direct reference is still in use.
      * - Any object that has been explicitly retained is still in use
      * - The creator of any object that is still in use is itself still in use.
-     *
-     * @return void
      */
     void close();
 
@@ -219,8 +225,6 @@ public:
      * scope but that the application expects to look it up again later.
      * Therefore the Service must consider this object to be still in use
      * and may not close it automatically.
-     *
-     * @return void
      */
     void retain();
 };

--- a/src/ddscxx/include/dds/core/TEntityQos.hpp
+++ b/src/ddscxx/include/dds/core/TEntityQos.hpp
@@ -58,6 +58,15 @@ public:
     TEntityQos(const TEntityQos& other);
 
     /**
+     * Copy to this QoS.
+     *
+     * @param other the QoS to copy.
+     *
+     * @return reference to the Qos which was copied to.
+     */
+    TEntityQos<DELEGATE>& operator=(const TEntityQos<DELEGATE>& other) = default;
+
+    /**
      * Create/copy QoS from different QoS type.
      *
      * @param qos the QoS to copy policies from.
@@ -123,7 +132,7 @@ public:
      * Available policies depend on the actual instantiation of the template
      * class, which might be DomainParticipantQos, TopicQos, PublisherQos, etc.
      *
-     * @param TEntityQos the TEntityQos to set
+     * @param other the TEntityQos to set
      */
     template <typename T>
     TEntityQos<DELEGATE>& operator = (const TEntityQos<T>& other);

--- a/src/ddscxx/include/dds/core/TQosProvider.hpp
+++ b/src/ddscxx/include/dds/core/TQosProvider.hpp
@@ -48,7 +48,7 @@ class TQosProvider;
  *
  * The QosProvider is delivered as part of the DCPS API of Vortex OpenSplice.
  *
- * @see @ref DCPS_QoS_Provider "QoS Provider extensive information."
+ * @see for more information: @ref DCPS_QoS_Provider "QoS Provider extensive information."
  */
 template <typename DELEGATE>
 class dds::core::TQosProvider : public dds::core::Reference<DELEGATE>

--- a/src/ddscxx/include/dds/core/WeakReference.hpp
+++ b/src/ddscxx/include/dds/core/WeakReference.hpp
@@ -52,7 +52,7 @@ public:
     /**
      * Creates a weak reference for the reference type passed as argument.
      *
-     * @tparam t dds object the new weak reference will refer to
+     * @param t dds object the new weak reference will refer to
      */
     WeakReference(const T& t);
 

--- a/src/ddscxx/include/dds/core/cond/TCondition.hpp
+++ b/src/ddscxx/include/dds/core/cond/TCondition.hpp
@@ -51,8 +51,8 @@ class TCondition;
  * the Data Distribution Service (except a GuardCondition) depending on the
  * evaluation of the Condition.
  *
- * @see @ref DCPS_Modules_Infrastructure_Status  "Status concept"
- * @see @ref DCPS_Modules_Infrastructure_Waitset "WaitSet concept"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Status  "Status concept"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Waitset "WaitSet concept"
  */
 template <typename DELEGATE>
 class dds::core::cond::TCondition : public virtual dds::core::Reference<DELEGATE>
@@ -78,8 +78,7 @@ public:
      * dds::core::cond::WaitSet::dispatch() on the WaitSet to which this
      * Condition is attached to.
      *
-     * @tparam Functor The functor to be called when the StatusCondition triggers.
-     * @return void
+     * @param func The functor to be called when the StatusCondition triggers.
      * @throw  dds::core::Exception
      */
     template <typename Functor>
@@ -95,7 +94,6 @@ public:
      * After the invocation of this function no handler will be registered with
      * this Condition.
      *
-     * @return void
      * @throw  dds::core::Exception
      */
     void reset_handler();
@@ -106,7 +104,6 @@ public:
      * The Condition has to have been triggered for the functor will be called
      * by this function.
      *
-     * @return void
      * @throw  dds::core::Exception
      */
     void dispatch();

--- a/src/ddscxx/include/dds/core/cond/TGuardCondition.hpp
+++ b/src/ddscxx/include/dds/core/cond/TGuardCondition.hpp
@@ -60,8 +60,8 @@ class TGuardCondition;
  * with a WaitSet is the same.
  *
  * @see dds::core::cond::Condition
- * @see @ref DCPS_Modules_Infrastructure_Waitset "WaitSet concept"
- * @see @ref anchor_dds_core_cond_waitset_examples "WaitSet examples"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Waitset "WaitSet concept"
+ * @see for more information: @ref anchor_dds_core_cond_waitset_examples "WaitSet examples"
  */
 template <typename DELEGATE>
 class dds::core::cond::TGuardCondition : public dds::core::cond::TCondition<DELEGATE>
@@ -92,7 +92,7 @@ public:
      * dds::core::cond::WaitSet::dispatch() on the WaitSet to which this GuardCondition is
      * attached to.
      *
-     * @tparam functor The functor to be called when the GuardCondition triggers.
+     * @param functor The functor to be called when the GuardCondition triggers.
      * @throw  dds::core::Exception
      */
     template <typename FUN>

--- a/src/ddscxx/include/dds/core/cond/TStatusCondition.hpp
+++ b/src/ddscxx/include/dds/core/cond/TStatusCondition.hpp
@@ -74,9 +74,9 @@ class TStatusCondition;
  * how to use this Condition.
  *
  * @see dds::core::cond::Condition
- * @see @ref DCPS_Modules_Infrastructure_Status  "Status concept"
- * @see @ref DCPS_Modules_Infrastructure_Waitset "WaitSet concept"
- * @see @ref anchor_dds_core_cond_waitset_examples "WaitSet examples"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Status  "Status concept"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Waitset "WaitSet concept"
+ * @see for more information: @ref anchor_dds_core_cond_waitset_examples "WaitSet examples"
  */
 template <typename DELEGATE>
 class dds::core::cond::TStatusCondition : public dds::core::cond::TCondition<DELEGATE>
@@ -108,7 +108,7 @@ public:
      * attached to.
      *
      * @param  e       The Entity to associate with the StatusCondition.
-     * @tparam functor The functor to be called when the StatusCondition triggers.
+     * @param functor The functor to be called when the StatusCondition triggers.
      * @throw  dds::core::Exception
      */
     template <typename FUN>
@@ -164,7 +164,6 @@ public:
      *
      * @param  status A bit mask in which each bit sets the status which is taken
      *                into account for the StatusCondition.the enabled statuses.
-     * @return void
      * @throw  dds::core::AlreadyClosedError
      * @throw  dds::core::Error
      */

--- a/src/ddscxx/include/dds/core/cond/TWaitSet.hpp
+++ b/src/ddscxx/include/dds/core/cond/TWaitSet.hpp
@@ -104,7 +104,7 @@ class TWaitSet;
  * }
  * @endcode
  *
- * @see @ref DCPS_Modules_Infrastructure_Waitset "WaitSet concept"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Waitset "WaitSet concept"
  */
 template <typename DELEGATE>
 class dds::core::cond::TWaitSet : public dds::core::Reference<DELEGATE>
@@ -289,7 +289,6 @@ public:
      * Waits for at least one of the attached Conditions to trigger and then
      * dispatches the functor associated with the Condition.
      *
-     * @return void
      * @throws dds::core::Error
      *                  An internal error has occurred.
      * @throws dds::core::NullReferenceError
@@ -309,7 +308,6 @@ public:
      *
      * @param timeout   The maximum amount of time for which the dispatch should
      *                  block while waiting for a Condition to be triggered.
-     * @return void
      * @throws dds::core::Error
      *                  An internal error has occurred.
      * @throws dds::core::NullReferenceError

--- a/src/ddscxx/include/dds/core/policy/TCorePolicy.hpp
+++ b/src/ddscxx/include/dds/core/policy/TCorePolicy.hpp
@@ -70,6 +70,15 @@ public:
      */
     TUserData(const TUserData& other);
 
+    /**
+    * Copies a UserData QoS instance
+    *
+    * @param other the UserData QoS instance to copy
+    *
+    * @return Reference to the Userdata QoS instance that was copied to
+    */
+    TUserData& operator=(const TUserData& other) = default;
+
 public:
     /**
      * Sets the sequence
@@ -137,6 +146,15 @@ public:
      * @param other the GroupData QoS instance to copy
      */
     TGroupData(const TGroupData& other);
+
+    /**
+     * Copies a GroupData QoS instance
+     *
+     * @param other the GroupData QoS instance to copy
+     *
+     * @return Reference to the GroupData QoS instance that was copied to
+     */
+    TGroupData& operator=(const TGroupData& other) = default;
 
     /**
      * Creates a GroupData QoS instance
@@ -226,6 +244,15 @@ public:
      */
     TTopicData(const uint8_t* value_begin, const uint8_t* value_end);
 
+    /**
+     * Copies a TopicData QoS instance
+     *
+     * @param other the TopicData QoS instance to copy
+     *
+     * @return Reference to the TopicData QoS instance that was copied to
+     */
+    TTopicData& operator=(const TTopicData& other) = default;
+
 public:
     /**
      * Set the sequence
@@ -291,6 +318,15 @@ public:
      */
     TEntityFactory(const TEntityFactory& other);
 
+    /**
+     * Copies an EntityFactory QoS instance
+     *
+     * @param other the EntityFactory QoS instance to copy
+     *
+     * @return Reference to the EntityFactory QoS instance that was copied to
+     */
+    TEntityFactory& operator=(const TEntityFactory& other) = default;
+
 public:
     /**
      * Sets a boolean indicating whether created Entities should be
@@ -346,6 +382,15 @@ public:
      */
     TTransportPriority(const TTransportPriority& other);
 
+    /**
+     * Copies a TransportPriority QoS instance
+     *
+     * @param other the TransportPriority QoS instance to copy
+     *
+     * @return Reference to the TransportPriority QoS instance that was copied to
+     */
+    TTransportPriority& operator=(const TTransportPriority& other) = default;
+
 public:
     /**
      * Sets the priority value
@@ -384,6 +429,15 @@ public:
      * @param other the Lifespan QoS instance to copy
      */
     TLifespan(const TLifespan& other);
+
+    /**
+     * Copies a Lifespan QoS instance
+     *
+     * @param other the Lifespan QoS instance to copy
+     *
+     * @return Reference to the Lifespan QoS instance that was copied to
+     */
+    TLifespan& operator=(const TLifespan& other) = default;
 
 public:
     /**
@@ -424,6 +478,15 @@ public:
      */
     TDeadline(const TDeadline& other);
 
+    /**
+     * Copies a Deadline QoS instance
+     *
+     * @param other the Deadline QoS instance to copy
+     *
+     * @return reference to the Deadline QoS instance that was copied to
+     */
+    TDeadline& operator=(const TDeadline& other) = default;
+
 public:
     /**
      * Sets the deadline period
@@ -462,6 +525,15 @@ public:
      * @param other the LatencyBudget QoS instance to copy
      */
     TLatencyBudget(const TLatencyBudget& other);
+
+    /**
+     * Copies a LatencyBudget QoS instance
+     *
+     * @param other the LatencyBudget QoS instance to copy
+     *
+     * @return reference to the LatencyBudget QoS instance that was copied to
+     */
+    TLatencyBudget& operator=(const TLatencyBudget& other) = default;
 
 public:
     /**
@@ -502,6 +574,15 @@ public:
      * @param other the TimeBasedFilter QoS instance to copy
      */
     TTimeBasedFilter(const TTimeBasedFilter& other);
+
+    /**
+     * Copies a TimeBasedFilter QoS instance
+     *
+     * @param other the TimeBasedFilter QoS instance to copy
+     *
+     * @return reference to the TimeBasedFilter QoS instance that was copied to
+     */
+    TTimeBasedFilter& operator=(const TTimeBasedFilter& other) = default;
 
 public:
     /**
@@ -549,6 +630,15 @@ public:
      * @param other the Partition QoS instance to copy
      */
     TPartition(const TPartition& other);
+
+    /**
+     * Copies a Partition QoS instance
+     *
+     * @param other the Partition QoS instance to copy
+     *
+     * @return reference to the Partition QoS instance that was copied to
+     */
+    TPartition& operator=(const TPartition& other) = default;
 
 public:
     /**
@@ -601,18 +691,29 @@ public:
      */
     TOwnership(const TOwnership& other);
 
+    /**
+     * Copies an Ownership QoS instance
+     *
+     * @param other the Ownership QoS instance to copy
+     *
+     * @return reference to the Ownership QoS instance that was copied to
+     */
+    TOwnership& operator=(const TOwnership& other) = default;
+
 public:
     /**
      * Set the kind
      *
-     * @param kind the kind
+     * @param kind the kind to set
+     *
+     * @return the kind that was set
      */
     TOwnership& kind(dds::core::policy::OwnershipKind::Type kind);
 
     /**
      * Get the kind
      *
-     * @param kind the kind
+     * @return the kind
      */
     dds::core::policy::OwnershipKind::Type kind() const;
 
@@ -651,6 +752,15 @@ public:
      * @param other the OwnershipStrength QoS instance to copy
      */
     TOwnershipStrength(const TOwnershipStrength& other);
+
+    /**
+     * Copies an OwnershipStrength QoS instance
+     *
+     * @param other the OwnershipStrength QoS instance to copy
+     *
+     * @return reference to the OwnershipStrength QoS instance that was copied to
+     */
+    TOwnershipStrength& operator=(const TOwnershipStrength& other) = default;
 
 public:
     /**
@@ -692,6 +802,15 @@ public:
      * @param other the WriterDataLifecycle QoS instance to copy
      */
     TWriterDataLifecycle(const TWriterDataLifecycle& other);
+
+    /**
+     * Copies a WriterDataLifecycle QoS instance
+     *
+     * @param other the WriterDataLifecycle QoS instance to copy
+     *
+     * @return reference to the WriterDataLifecycle QoS instance that was copied to
+     */
+    TWriterDataLifecycle& operator=(const TWriterDataLifecycle& other) = default;
 
 public:
     /**
@@ -750,6 +869,15 @@ public:
      * @param other the ReaderDataLifecycle QoS instance to copy
      */
     TReaderDataLifecycle(const TReaderDataLifecycle& other);
+
+    /**
+     * Copies a ReaderDataLifecycle QoS instance
+     *
+     * @param other the ReaderDataLifecycle QoS instance to copy
+     *
+     * @return reference to the ReaderDataLifecycle QoS that was copied to
+     */
+    TReaderDataLifecycle& operator=(const TReaderDataLifecycle& other) = default;
 public:
     /**
      * Gets the autopurge nowriter samples delay
@@ -822,18 +950,29 @@ public:
      */
     TDurability(const TDurability& other);
 
+    /**
+     * Copies a Durability QoS instance
+     *
+     * @param other the Durability QoS instance to copy
+     *
+     * @return reference to the Durability QoS that was copied to
+     */
+    TDurability& operator=(const TDurability& other) = default;
+
 public:
     /**
     * Set the kind
-    *
-    * @param kind the kind
+     *
+     * @param kind the kind to set
+     *
+     * @return the kind that was set
     */
     TDurability& kind(dds::core::policy::DurabilityKind::Type kind);
 
     /**
      * Get the kind
      *
-     * @param kind the kind
+     * @return the kind
      */
     dds::core::policy::DurabilityKind::Type  kind() const;
 
@@ -887,6 +1026,15 @@ public:
      * @param other the Presentation QoS instance to copy
      */
     TPresentation(const TPresentation& other);
+
+    /**
+     * Copies a Presentation QoS instance
+     *
+     * @param other the Presentation QoS instance to copy
+     *
+     * @return reference to the Presentation QoS that was copied to
+     */
+    TPresentation& operator=(const TPresentation& other) = default;
 
 public:
     /**
@@ -986,6 +1134,15 @@ public:
      */
     TReliability(const TReliability& other);
 
+    /**
+     * Copies a Reliability QoS instance
+     *
+     * @param other the Reliability QoS instance to copy
+     *
+     * @return reference to the Reliability QoS that was copied to
+     */
+    TReliability& operator=(const TReliability& other) = default;
+
 public:
     /**
      * Sets the kind
@@ -1017,7 +1174,7 @@ public:
 
 public:
     /**
-     * @param the max_blocking_time
+     * @param max_blocking_time the max blocking time
      * @return a Reliability QoS instance with the kind set to RELIABLE and the max_blocking_time
      * set to the supplied value
      */
@@ -1051,9 +1208,18 @@ public:
     /**
      * Copies a DestinationOrder QoS instance
      *
-     * @param other the Reliability QoS instance to copy
+     * @param other the DestinationOrder QoS instance to copy
      */
     TDestinationOrder(const TDestinationOrder& other);
+
+    /**
+     * Copies a DestinationOrder QoS instance
+     *
+     * @param other the DestinationOrder QoS instance to copy
+     *
+     * @return reference to the DestinationOrder QoS that was copied to
+     */
+    TDestinationOrder& operator=(const TDestinationOrder& other) = default;
 
 public:
     /**
@@ -1107,6 +1273,15 @@ public:
      */
     THistory(const THistory& other);
 
+    /**
+     * Copies a History QoS instance
+     *
+     * @param other the History QoS instance to copy
+     *
+     * @return reference to the History QoS that was copied to
+     */
+    THistory& operator=(const THistory& other) = default;
+
 public:
     /**
      * Gets the kind
@@ -1132,7 +1307,9 @@ public:
     /**
      * Sets the history depth
      *
-     * @param the history depth
+     * @param depth the history depth to set
+     *
+     * @return the history depth that was set
      */
     THistory& depth(int32_t depth);
 
@@ -1176,6 +1353,15 @@ public:
      * @param other the ResourceLimits QoS instance to copy
      */
     TResourceLimits(const TResourceLimits& other);
+
+    /**
+     * Copies a ResourceLimits QoS instance
+     *
+     * @param other the ResourceLimits QoS instance to copy
+     *
+     * @return reference to the ResourceLimits QoS that was copied to
+     */
+    TResourceLimits& operator=(const TResourceLimits& other) = default;
 
 public:
     /**
@@ -1246,6 +1432,15 @@ public:
      * @param other the Liveliness QoS instance to copy
      */
     TLiveliness(const TLiveliness& other);
+
+    /**
+     * Copies a Liveliness QoS instance
+     *
+     * @param other the Liveliness QoS instance to copy
+     *
+     * @return reference to the Liveliness QoS that was copied to
+     */
+    TLiveliness& operator=(const TLiveliness& other) = default;
 
 public:
     /**
@@ -1331,6 +1526,13 @@ public:
      */
     TDurabilityService(const TDurabilityService& other);
 
+    /**
+     * Copies a DurabilityService QoS instance
+     *
+     * @param other the DurabilityService QoS instance to copy
+     */
+    TDurabilityService<D>& operator=(const TDurabilityService<D>& other) = default;
+
 public:
     /**
      * Sets the service_cleanup_delay value
@@ -1349,7 +1551,9 @@ public:
     /**
      * Sets the history_kind
      *
-     * @param the history_kind
+     * @param history_kind the history kind to set
+     *
+     * @return the history kind that was set
      */
     TDurabilityService& history_kind(dds::core::policy::HistoryKind::Type history_kind);
 

--- a/src/ddscxx/include/dds/core/policy/TQosPolicyCount.hpp
+++ b/src/ddscxx/include/dds/core/policy/TQosPolicyCount.hpp
@@ -53,6 +53,15 @@ public:
      */
     TQosPolicyCount(const TQosPolicyCount& other);
 
+    /**
+     * Copies a QosPolicyCount instance
+     *
+     * @param other the QosPolicyCount instance to copy
+     *
+     * @return a reference to the QosPolicyCount that was copied to
+     */
+    TQosPolicyCount& operator=(const TQosPolicyCount& other) = default;
+
 public:
     /**
      * Gets the policy_id

--- a/src/ddscxx/include/dds/core/status/State.hpp
+++ b/src/ddscxx/include/dds/core/status/State.hpp
@@ -35,7 +35,7 @@ namespace status
  * @brief
  * Class to contain the statistics about samples that have been rejected.
  *
- * @see @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo" for more information
+ * @see for more information: @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo"
  */
 class OMG_DDS_API SampleRejectedState : public std::bitset<OMG_DDS_STATE_BIT_COUNT>
 {
@@ -67,6 +67,16 @@ public:
      */
     SampleRejectedState(const MaskType& src);
 
+    /**
+    * Copy assignment operator.
+    *
+    * Copies the data from src to the current instance.
+    *
+    * @param src the SampleRejectedState to copy from
+    *
+    * @return reference to the SampleRejectedState that was copied to
+    */
+    SampleRejectedState& operator=(const SampleRejectedState&) = default;
 public:
     /**
      * Get the NOT_REJECTED.
@@ -139,7 +149,7 @@ private:
  * - set conditions in dds::core::cond::StatusCondition
  * - indicate status changes when calling dds::core::Entity::status_changes
  *
- * @see @ref DCPS_Modules_Infrastructure_Status  "Status concept"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Status  "Status concept"
  */
 class OMG_DDS_API StatusMask : public std::bitset<OMG_DDS_STATUS_COUNT>
 {
@@ -170,6 +180,17 @@ public:
      * @param other the StatusMask to copy from
      */
     StatusMask(const StatusMask& other);
+
+    /**
+     * Copy assignment operator.
+     *
+     * Copies the contents from one StatusMask to another.
+     *
+     * @param other the StatusMask to copy from
+     *
+     * @return reference to the StatusMask that was copied to
+     */
+    StatusMask& operator=(const StatusMask& other) = default;
 
     /** @cond */
     ~StatusMask();

--- a/src/ddscxx/include/dds/domain/DomainParticipantListener.hpp
+++ b/src/ddscxx/include/dds/domain/DomainParticipantListener.hpp
@@ -154,8 +154,8 @@ namespace domain
  *
  * @endcode
  *
- * @see @ref DCPS_Modules_DomainParticipant "Domain Participant"
- * @see @ref DCPS_Modules_Infrastructure_Listener "Listener information"
+ * @see for more information: @ref DCPS_Modules_DomainParticipant "Domain Participant"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Listener "Listener information"
  */
 class OMG_DDS_API DomainParticipantListener :
     public virtual dds::pub::PublisherListener,

--- a/src/ddscxx/include/dds/domain/TDomainParticipant.hpp
+++ b/src/ddscxx/include/dds/domain/TDomainParticipant.hpp
@@ -59,7 +59,7 @@ class DomainParticipantListener;
  * independent distributed applications can coexist in the same physical
  * network without interfering, or even being aware of each other.
  *
- * @see @ref DCPS_Modules_DomainParticipant "Domain Participant"
+ * @see for more information: @ref DCPS_Modules_DomainParticipant "Domain Participant"
  */
 template <typename DELEGATE>
 class dds::domain::TDomainParticipant : public ::dds::core::TEntity<DELEGATE>
@@ -140,6 +140,16 @@ public:
                        dds::domain::DomainParticipantListener*         listener = NULL,
                        const dds::core::status::StatusMask&            event_mask = dds::core::status::StatusMask::none(),
                        const std::string&                              config = std::string());
+    /**
+    * Copy assignment operator.
+    *
+    * Copies the contents from one DomainParticipant to another.
+    *
+    * @param other the DomainParticipant to copy from
+    *
+    * @return reference to the DomainParticipant that was copied to
+    */
+    TDomainParticipant& operator=(const TDomainParticipant& other) = default;
 
 public:
     /** @cond */

--- a/src/ddscxx/include/dds/domain/qos/detail/DomainParticipantQos.hpp
+++ b/src/ddscxx/include/dds/domain/qos/detail/DomainParticipantQos.hpp
@@ -53,7 +53,7 @@
  * specified either at DomainParticipant creation time or prior to calling the enable
  * operation on the DomainParticipant.
  *
- * @see @ref DCPS_QoS
+ * @see for more information: @ref DCPS_QoS
  */
 class dds::domain::qos::DomainParticipantQos : public ::dds::core::EntityQos<org::eclipse::cyclonedds::domain::qos::DomainParticipantQosDelegate>
 {

--- a/src/ddscxx/include/dds/pub/DataWriter.hpp
+++ b/src/ddscxx/include/dds/pub/DataWriter.hpp
@@ -82,8 +82,8 @@ template <typename T> class DataWriterListener;
  * writer.write(sample);
  * @endcode
  *
- * @see @ref DCPS_Modules_Publication "Publication concept"
- * @see @ref DCPS_Modules_Publication_DataWriter "DataWriter concept"
+ * @see for more information: @ref DCPS_Modules_Publication "Publication concept"
+ * @see for more information: @ref DCPS_Modules_Publication_DataWriter "DataWriter concept"
  */
 template <typename T, template <typename Q> class DELEGATE>
 class dds::pub::DataWriter : public ::dds::pub::TAnyDataWriter< DELEGATE<T> >
@@ -357,7 +357,7 @@ public:
      * <i>Blocking</i><br>
      * This operation can be blocked (see @ref anchor_dds_pub_datawriter_write_blocking "write blocking").
      *
-     * @param sample the sample to be written
+     * @param data the sample to be written
      * @param instance the handle representing the instance written
      * @param timestamp the timestamp to use for this sample
      * @throws dds::core::Error

--- a/src/ddscxx/include/dds/pub/DataWriterListener.hpp
+++ b/src/ddscxx/include/dds/pub/DataWriterListener.hpp
@@ -95,8 +95,8 @@ namespace pub
  *
  * @endcode
  *
- * @see @ref DCPS_Modules_Publication_DataWriter "Data Writer"
- * @see @ref DCPS_Modules_Infrastructure_Listener "Listener information"
+ * @see for more information: @ref DCPS_Modules_Publication_DataWriter "Data Writer"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Listener "Listener information"
  */
 template <typename T>
 class DataWriterListener

--- a/src/ddscxx/include/dds/pub/PublisherListener.hpp
+++ b/src/ddscxx/include/dds/pub/PublisherListener.hpp
@@ -97,8 +97,8 @@ class NoOpPublisherListener;
  *
  * @endcode
  *
- * @see @ref DCPS_Modules_Publisher "Publisher"
- * @see @ref DCPS_Modules_Infrastructure_Listener "Listener information"
+ * @see for more information: @ref DCPS_Modules_Publisher "Publisher"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Listener "Listener information"
  */
 class OMG_DDS_API dds::pub::PublisherListener : public virtual dds::pub::AnyDataWriterListener
 {

--- a/src/ddscxx/include/dds/pub/TCoherentSet.hpp
+++ b/src/ddscxx/include/dds/pub/TCoherentSet.hpp
@@ -63,7 +63,7 @@ class TCoherentSet;
  * can see both together; otherwise, it may, for example,
  * erroneously interpret that the aircraft is on a collision course.
  *
- * @see @ref DCPS_Modules_Publication "Publication"
+ * @see for more information: @ref DCPS_Modules_Publication "Publication"
  * @see dds::pub::Publisher
  */
 template <typename DELEGATE>

--- a/src/ddscxx/include/dds/pub/TPublisher.hpp
+++ b/src/ddscxx/include/dds/pub/TPublisher.hpp
@@ -49,7 +49,7 @@ class PublisherListener;
  * considers any extra information that goes with the data (timestamp,
  * writer, etc.) as well as the QoS of the Publisher and the DataWriter.
  *
- * @see @ref DCPS_Modules_Publisher "Publisher"
+ * @see for more information: @ref DCPS_Modules_Publisher "Publisher"
  */
 template <typename DELEGATE>
 class dds::pub::TPublisher : public dds::core::TEntity<DELEGATE>

--- a/src/ddscxx/include/dds/pub/TSuspendedPublication.hpp
+++ b/src/ddscxx/include/dds/pub/TSuspendedPublication.hpp
@@ -59,7 +59,7 @@ class TSuspendedPublication;
  * - dds::pub::DataWriter.unregister_instance (and its overloaded counterparts).
  * - dds::pub::DataWriter.dispose_instance (and its overloaded counterparts).
  *
- * @see @ref DCPS_Modules_Publication "Publication"
+ * @see for more information: @ref DCPS_Modules_Publication "Publication"
  * @see dds::pub::Publisher
  */
 template <typename DELEGATE>

--- a/src/ddscxx/include/dds/pub/qos/detail/DataWriterQos.hpp
+++ b/src/ddscxx/include/dds/pub/qos/detail/DataWriterQos.hpp
@@ -63,7 +63,7 @@
  * specified either at DataWriter creation time or prior to calling the enable
  * operation on the DataWriter.
  *
- * @see @ref DCPS_QoS
+ * @see for more information: @ref DCPS_QoS
  */
 class dds::pub::qos::DataWriterQos : public ::dds::core::EntityQos<org::eclipse::cyclonedds::pub::qos::DataWriterQosDelegate>
 {

--- a/src/ddscxx/include/dds/pub/qos/detail/PublisherQos.hpp
+++ b/src/ddscxx/include/dds/pub/qos/detail/PublisherQos.hpp
@@ -53,7 +53,7 @@
  * specified either at Publisher creation time or prior to calling the enable operation
  * on the Publisher.
  *
- * @see @ref DCPS_QoS
+ * @see for more information: @ref DCPS_QoS
  */
 class dds::pub::qos::PublisherQos : public ::dds::core::EntityQos<org::eclipse::cyclonedds::pub::qos::PublisherQosDelegate>
 {

--- a/src/ddscxx/include/dds/sub/DataReaderListener.hpp
+++ b/src/ddscxx/include/dds/sub/DataReaderListener.hpp
@@ -121,8 +121,8 @@ class NoOpDataReaderListener;
  *
  * @endcode
  *
- * @see @ref DCPS_Modules_Subscription_DataReader "Data Reader"
- * @see @ref DCPS_Modules_Infrastructure_Listener "Listener information"
+ * @see for more information: @ref DCPS_Modules_Subscription_DataReader "Data Reader"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Listener "Listener information"
  */
 template <typename T>
 class dds::sub::DataReaderListener
@@ -297,7 +297,7 @@ public:
     /**
      * <b><i>
      * NOTE: This operation is not yet implemented. It is scheduled for a future release.
-     * </i><b>
+     * </i></b>
      *
      * @param reader the DataReader the Listener is applied to
      * @param status the SampleLostStatus status

--- a/src/ddscxx/include/dds/sub/LoanedSamples.hpp
+++ b/src/ddscxx/include/dds/sub/LoanedSamples.hpp
@@ -79,9 +79,9 @@ template <typename T> typename T::const_iterator cend(const T& t);
  * // takes care of the loan and resource handling.
  * @endcode
  *
- * @see @ref DCPS_Modules_Subscription_DataSample "DataSample" for more information
- * @see @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo" for more information
- * @see @ref DCPS_Modules_Subscription "Subscription" for more information
+ * @see for more information: @ref DCPS_Modules_Subscription_DataSample "DataSample"
+ * @see for more information: @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo"
+ * @see for more information: @ref DCPS_Modules_Subscription "Subscription"
  */
 template <typename T, template <typename Q> class DELEGATE>
 class dds::sub::LoanedSamples

--- a/src/ddscxx/include/dds/sub/SubscriberListener.hpp
+++ b/src/ddscxx/include/dds/sub/SubscriberListener.hpp
@@ -118,8 +118,8 @@ namespace sub
  *
  * @endcode
  *
- * @see @ref DCPS_Modules_Subscriber "Subscriber"
- * @see @ref DCPS_Modules_Infrastructure_Listener "Listener information"
+ * @see for more information: @ref DCPS_Modules_Subscriber "Subscriber"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Listener "Listener information"
  */
 class OMG_DDS_API SubscriberListener : public virtual AnyDataReaderListener
 {

--- a/src/ddscxx/include/dds/sub/TCoherentAccess.hpp
+++ b/src/ddscxx/include/dds/sub/TCoherentAccess.hpp
@@ -87,7 +87,7 @@ class TCoherentAccess;
  * // CoherentAccess went out of scope: it is ended implicitly
  * @endcode
  *
- * @see @ref DCPS_Modules_Subscription "Subscription"
+ * @see for more information: @ref DCPS_Modules_Subscription "Subscription"
  * @see dds::sub::Subscriber
  */
 template <typename DELEGATE>

--- a/src/ddscxx/include/dds/sub/TDataReader.hpp
+++ b/src/ddscxx/include/dds/sub/TDataReader.hpp
@@ -98,8 +98,8 @@ class DataReaderListener;
  * // was automatically returned when the LoanedSamples went out of scope.
  * @endcode
  *
- * @see @ref DCPS_Modules_Subscription "Subscription concept"
- * @see @ref DCPS_Modules_Subscription_DataReader "DataReader concept"
+ * @see for more information: @ref DCPS_Modules_Subscription "Subscription concept"
+ * @see for more information: @ref DCPS_Modules_Subscription_DataReader "DataReader concept"
  */
 template <typename T, template <typename Q> class DELEGATE>
 class dds::sub::DataReader : public dds::sub::TAnyDataReader< DELEGATE<T> >
@@ -158,7 +158,7 @@ public:
      * max_samples     | dds::core::LENGTH_UNLIMITED
      * instance        | dds::core::InstanceHandle nil
      *
-     * @see @link dds::sub::DataReader::select() DataReader select() @endlink
+     * @see for more information: @link dds::sub::DataReader::select() DataReader select() @endlink
      */
     class Selector
     {
@@ -166,7 +166,7 @@ public:
         /**
          * Construct a Selector for a DataReader.
          *
-         * @param DataReader
+         * @param dr DataReader
          */
         Selector(DataReader& dr);
 
@@ -503,7 +503,7 @@ public:
      * max_samples     | dds::core::LENGTH_UNLIMITED
      * instance        | dds::core::InstanceHandle nil
      *
-     * @see @link dds::sub::DataReader::operator>>(dds::sub::LoanedSamples<T>& ls) DataReader stream operator>> @endlink
+     * @see for more information: @link dds::sub::DataReader::operator>>(dds::sub::LoanedSamples<T>& ls) DataReader stream operator>> @endlink
      */
     class ManipulatorSelector
     {

--- a/src/ddscxx/include/dds/sub/TGenerationCount.hpp
+++ b/src/ddscxx/include/dds/sub/TGenerationCount.hpp
@@ -57,7 +57,7 @@ class TGenerationCount;
  * the SampleInfo capture a snapshot of the corresponding counters at the time
  * the sample was received.
  *
- * @see @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo" for more information
+ * @see for more information: @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo"
  */
 template <typename DELEGATE>
 class dds::sub::TGenerationCount : public dds::core::Value<DELEGATE>

--- a/src/ddscxx/include/dds/sub/TQuery.hpp
+++ b/src/ddscxx/include/dds/sub/TQuery.hpp
@@ -55,7 +55,7 @@ class TQuery;
  * @see dds::sub::cond::QueryCondition
  * @see dds::sub::DataReader::Selector
  * @see dds::sub::DataReader::ManipulatorSelector
- * @see @ref DCPS_Modules_Infrastructure_Waitset "Subscription concept"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Waitset "Subscription concept"
  */
 template <typename DELEGATE>
 class dds::sub::TQuery: public virtual dds::core::Reference<DELEGATE> {
@@ -79,7 +79,7 @@ public:
    * Create a dds::sub::Query associated with an dds::sub::AnyDataReader.
    *
    * @param  dr The AnyDataReader to associate with the Query.
-   * @param  expression @ref anchor_dds_sub_query_expression "SQL expression"
+   * @param  expression an @ref anchor_dds_sub_query_expression "SQL expression"
    * @throw  dds::core::Exception
    */
   TQuery(const dds::sub::AnyDataReader& dr, const std::string& expression);
@@ -88,9 +88,9 @@ public:
    * Create a dds::sub::Query associated with an dds::sub::AnyDataReader.
    *
    * @param  dr The AnyDataReader to associate with the Query.
-   * @param  expression @ref anchor_dds_sub_query_expression "SQL expression"
-   * @tparam params_begin Iterator pointing to the beginning of the parameters to set
-   * @tparam params_end   Iterator pointing to the end of the parameters to set
+   * @param  expression an @ref anchor_dds_sub_query_expression "SQL expression"
+   * @param params_begin Iterator pointing to the beginning of the parameters to set
+   * @param params_end   Iterator pointing to the end of the parameters to set
    * @throw  dds::core::Exception
    */
   template<typename FWIterator>
@@ -101,8 +101,8 @@ public:
    * Create a dds::sub::Query associated with an dds::sub::AnyDataReader.
    *
    * @param  dr The AnyDataReader to associate with the Query.
-   * @param  expression @ref anchor_dds_sub_query_expression "SQL expression"
-   * @tparam params Vector containing SQL expression parameters
+   * @param  expression an @ref anchor_dds_sub_query_expression "SQL expression"
+   * @param params Vector containing SQL expression parameters
    * @throw  dds::core::Exception
    */
   TQuery(const dds::sub::AnyDataReader& dr, const std::string& expression,
@@ -119,7 +119,7 @@ public:
   /**
    * Set new expression.
    *
-   * @param  expr ref anchor_dds_sub_query_expression "SQL expression"
+   * @param  expr an ref anchor_dds_sub_query_expression "SQL expression"
    * @throw  dds::core::Exception
    */
   void expression(const std::string& expr);
@@ -173,8 +173,8 @@ public:
    *
    * See @ref anchor_dds_sub_query_expression "SQL expression info"
    *
-   * @tparam begin Iterator pointing to the beginning of the parameters to set
-   * @tparam end   Iterator pointing to the end of the parameters to set
+   * @param begin Iterator pointing to the beginning of the parameters to set
+   * @param end   Iterator pointing to the end of the parameters to set
    * @throw  dds::core::Exception
    */
   template<typename FWIterator>

--- a/src/ddscxx/include/dds/sub/TRank.hpp
+++ b/src/ddscxx/include/dds/sub/TRank.hpp
@@ -61,7 +61,7 @@ class TRank;
  *      (MRS.disposed_generation_count + MRS.no_writers_generation_count) -
  *      (S.disposed_generation_count + S.no_writers_generation_count)
  *
- * @see @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo" for more information
+ * @see for more information: @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo"
  */
 template <typename DELEGATE>
 class dds::sub::TRank : public dds::core::Value<DELEGATE>

--- a/src/ddscxx/include/dds/sub/TSample.hpp
+++ b/src/ddscxx/include/dds/sub/TSample.hpp
@@ -58,9 +58,9 @@ class Sample;
  * }
  * @endcode
  *
- * @see @ref DCPS_Modules_Subscription_DataSample "DataSample" for more information
- * @see @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo" for more information
- * @see @ref DCPS_Modules_Subscription "Subscription" for more information
+ * @see for more information: @ref DCPS_Modules_Subscription_DataSample "DataSample"
+ * @see for more information: @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo"
+ * @see for more information: @ref DCPS_Modules_Subscription "Subscription"
  */
 template <typename T, template <typename Q> class DELEGATE>
 class dds::sub::Sample : public dds::core::Value< DELEGATE<T> >

--- a/src/ddscxx/include/dds/sub/TSampleInfo.hpp
+++ b/src/ddscxx/include/dds/sub/TSampleInfo.hpp
@@ -55,7 +55,7 @@ class TSampleInfo;
  * - The InstanceHandle of the associated data Sample.
  * - The InstanceHandle of the associated publication.
  *
- * @see @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo" for more information
+ * @see for more information: @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo"
  */
 template <typename DELEGATE>
 class dds::sub::TSampleInfo : public dds::core::Value<DELEGATE>

--- a/src/ddscxx/include/dds/sub/TSubscriber.hpp
+++ b/src/ddscxx/include/dds/sub/TSubscriber.hpp
@@ -47,7 +47,7 @@ class SubscriberListener;
  * concerned DataReader objects through the operation get_datareaders and
  * then access the data available through operations on the DataReader.
  *
- * @see @ref DCPS_Modules_Subscriber "Subscriber"
+ * @see for more information: @ref DCPS_Modules_Subscriber "Subscriber"
  */
 template <typename DELEGATE>
 class dds::sub::TSubscriber : public dds::core::TEntity<DELEGATE>

--- a/src/ddscxx/include/dds/sub/cond/TQueryCondition.hpp
+++ b/src/ddscxx/include/dds/sub/cond/TQueryCondition.hpp
@@ -53,10 +53,10 @@ class TQueryCondition;
  * @see dds::sub::Query
  * @see dds::core::cond::Condition
  * @see dds::sub::cond::ReadCondition
- * @see @ref DCPS_Modules_Infrastructure_Waitset "WaitSet concept"
- * @see @ref DCPS_Modules_Infrastructure_Waitset "Subscription concept"
- * @see @ref anchor_dds_sub_query_expression "SQL expression info"
- * @see @ref anchor_dds_core_cond_waitset_examples "WaitSet examples"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Waitset "WaitSet concept"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Waitset "Subscription concept"
+ * @see for more information: @ref anchor_dds_sub_query_expression "SQL expression info"
+ * @see for more information: @ref anchor_dds_core_cond_waitset_examples "WaitSet examples"
  */
 template <typename DELEGATE>
 class dds::sub::cond::TQueryCondition :

--- a/src/ddscxx/include/dds/sub/cond/TReadCondition.hpp
+++ b/src/ddscxx/include/dds/sub/cond/TReadCondition.hpp
@@ -54,10 +54,10 @@ class TReadCondition;
  * with a WaitSet is the same.
  *
  * @see dds::core::cond::Condition
- * @see @ref DCPS_Modules_Infrastructure_Status  "Status concept"
- * @see @ref DCPS_Modules_Infrastructure_Waitset "WaitSet concept"
- * @see @ref DCPS_Modules_Infrastructure_Waitset "Subscription concept"
- * @see @ref anchor_dds_core_cond_waitset_examples "WaitSet examples"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Status  "Status concept"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Waitset "WaitSet concept"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Waitset "Subscription concept"
+ * @see for more information: @ref anchor_dds_core_cond_waitset_examples "WaitSet examples"
  */
 template <typename DELEGATE>
 class dds::sub::cond::TReadCondition : public dds::core::cond::TCondition<DELEGATE>

--- a/src/ddscxx/include/dds/sub/discovery.hpp
+++ b/src/ddscxx/include/dds/sub/discovery.hpp
@@ -51,8 +51,9 @@ void OMG_DDS_API ignore(const dds::domain::DomainParticipant& dp,
  * @param dp      the DomainParticipant for which the remote
  *                entity will be ignored
  *
- * @param handle  the InstanceHandle of the remote entity that
- *                has to be ignored
+ * @param begin  the start of the range to be ignored
+ *
+ * @param end    the end of the range to be ignored
  */
 template <typename FwdIterator>
 void ignore(const dds::domain::DomainParticipant& dp, FwdIterator begin, FwdIterator end);

--- a/src/ddscxx/include/dds/sub/find.hpp
+++ b/src/ddscxx/include/dds/sub/find.hpp
@@ -200,7 +200,7 @@ find(const dds::sub::Subscriber& sub,
  * an application should use to access data is fully described in dds::core::policy::Presentation.
  *
  * @param sub the Subscriber for which to find a DataReader
- * @param data_state the data_state to find
+ * @param rs the data_state to find
  * @param begin a back inserting iterator pointing to the start
  *        of a container in which to put the DataReaders
  * @return the total number of elements returned

--- a/src/ddscxx/include/dds/sub/qos/detail/DataReaderQos.hpp
+++ b/src/ddscxx/include/dds/sub/qos/detail/DataReaderQos.hpp
@@ -61,7 +61,7 @@
  * specified either at DataReader creation time or prior to calling the enable
  * operation on the DataReader.
  *
- * @see @ref DCPS_QoS
+ * @see for more information: @ref DCPS_QoS
  */
 class dds::sub::qos::DataReaderQos : public ::dds::core::EntityQos<org::eclipse::cyclonedds::sub::qos::DataReaderQosDelegate>
 {

--- a/src/ddscxx/include/dds/sub/qos/detail/SubscriberQos.hpp
+++ b/src/ddscxx/include/dds/sub/qos/detail/SubscriberQos.hpp
@@ -53,7 +53,7 @@
  * specified either at Subscriber creation time or prior to calling the enable operation
  * on the Subscriber.
  *
- * @see @ref DCPS_QoS
+ * @see for more information: @ref DCPS_QoS
  */
 class dds::sub::qos::SubscriberQos : public ::dds::core::EntityQos<org::eclipse::cyclonedds::sub::qos::SubscriberQosDelegate>
 {

--- a/src/ddscxx/include/dds/sub/status/DataState.hpp
+++ b/src/ddscxx/include/dds/sub/status/DataState.hpp
@@ -52,7 +52,7 @@ class DataState;
  * - <b><i>not_read</i></b>
  *      - The DataReader has not accessed that sample before.
  *
- * @see @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo" for more information
+ * @see for more information: @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo"
  */
 class OMG_DDS_API dds::sub::status::SampleState : public std::bitset<OMG_DDS_STATE_BIT_COUNT>
 {
@@ -82,6 +82,17 @@ public:
      * @param src the SampleState to copy from
      */
     SampleState(const SampleState& src);
+
+    /**
+     * Copy assignment operator.
+     *
+     * Copy the contents from one SampleState to another.
+     *
+     * @param src the SampleState to copy from
+     *
+     * @return reference to the SampleState instance that was copied to
+     */
+    SampleState& operator=(const SampleState& src) = default;
 
     /**
      * Construct a SampleState with existing MaskType.
@@ -141,7 +152,7 @@ public:
  *      - The DataReader has already accessed
  *        samples of the same instance and that the instance has not been reborn since.
  *
- * @see @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo" for more information
+ * @see for more information: @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo"
  */
 class OMG_DDS_API dds::sub::status::ViewState : public std::bitset<OMG_DDS_STATE_BIT_COUNT>
 {
@@ -172,6 +183,17 @@ public:
      * @param src the ViewState to copy from
      */
     ViewState(const ViewState& src);
+
+    /**
+     * Copy assignment operator.
+     *
+     * Copy the contents from one ViewState to another.
+     *
+     * @param src the ViewState to copy from
+     *
+     * @return reference to the ViewState instance that was copied to
+     */
+    ViewState& operator=(const ViewState& src) = default;
 
     /**
      * Construct a ViewState with existing MaskType.
@@ -241,7 +263,7 @@ public:
  *        declared as not-alive by the DataReader because it detected that there are no live
  *        DataWriter objects writing that instance.
  *
- * @see @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo" for more information
+ * @see for more information: @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo"
  */
 class OMG_DDS_API dds::sub::status::InstanceState : public std::bitset<OMG_DDS_STATE_BIT_COUNT>
 {
@@ -272,6 +294,17 @@ public:
      * @param src the InstanceState to copy from
      */
     InstanceState(const InstanceState& src);
+
+    /**
+     * Copy assignment operator.
+     *
+     * Copy the contents from one InstanceState to another.
+     *
+     * @param src the InstanceState to copy from
+     *
+     * @return reference to the InstanceState instance that was copied to
+     */
+    InstanceState& operator=(const InstanceState& src) = default;
 
     /**
      * Construct an InstanceState with existing MaskType.
@@ -366,7 +399,7 @@ public:
  *  - The view_state of the related instance (i.e., if the instance is NEW, or NOT_NEW for that DataReader).
  *  - The instance_state of the related instance (i.e., if the instance is ALIVE, NOT_ALIVE_DISPOSED, or NOT_ALIVE_NO_WRITERS).
  *
- * @see @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo" for more information
+ * @see for more information: @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo"
  */
 class OMG_DDS_API dds::sub::status::DataState
 {

--- a/src/ddscxx/include/dds/topic/TAnyTopic.hpp
+++ b/src/ddscxx/include/dds/topic/TAnyTopic.hpp
@@ -123,6 +123,15 @@ public:
     const TAnyTopic& operator >> (dds::topic::qos::TopicQos& qos) const;
 
     /**
+     * Copies the contents from one TAnyTopic to this
+     *
+     * @param other the TAnyTopic to copy
+     *
+     * @return reference to the TAnyTopic instance that was copied to
+     */
+    TAnyTopic& operator=(const TAnyTopic& other) = default;
+
+    /**
      * This operation obtains the InconsistentTopicStatus object of the Topic.
      *
      * The InconsistentTopicStatus can also be monitored using a

--- a/src/ddscxx/include/dds/topic/TBuiltinTopic.hpp
+++ b/src/ddscxx/include/dds/topic/TBuiltinTopic.hpp
@@ -74,8 +74,8 @@ class TSubscriptionBuiltinTopicData;
  * // dds::topic::ParticipantBuiltinTopicData samples.
  * @endcode
  *
- * @see @ref DCPS_Builtin_Topics
- * @see @ref DCPS_Builtin_Topics_ParticipantData
+ * @see for more information: @ref DCPS_Builtin_Topics
+ * @see for more information: @ref DCPS_Builtin_Topics_ParticipantData
  */
 template <typename D>
 class dds::topic::TParticipantBuiltinTopicData : public ::dds::core::Value<D>
@@ -125,8 +125,8 @@ public:
  * // dds::topic::TopicBuiltinTopicData samples.
  * @endcode
  *
- * @see @ref DCPS_Builtin_Topics
- * @see @ref DCPS_Builtin_Topics_TopicData
+ * @see for more information: @ref DCPS_Builtin_Topics
+ * @see for more information: @ref DCPS_Builtin_Topics_TopicData
  */
 template <typename D>
 class dds::topic::TTopicBuiltinTopicData : public ::dds::core::Value<D>
@@ -249,8 +249,8 @@ public:
  * // dds::topic::PublicationBuiltinTopicData samples.
  * @endcode
  *
- * @see @ref DCPS_Builtin_Topics
- * @see @ref DCPS_Builtin_Topics_PublicationData
+ * @see for more information: @ref DCPS_Builtin_Topics
+ * @see for more information: @ref DCPS_Builtin_Topics_PublicationData
  */
 template <typename D>
 class dds::topic::TPublicationBuiltinTopicData  : public ::dds::core::Value<D>
@@ -390,8 +390,8 @@ public:
  * // dds::topic::SubscriptionBuiltinTopicData samples.
  * @endcode
  *
- * @see @ref DCPS_Builtin_Topics
- * @see @ref DCPS_Builtin_Topics_SubscriptionData
+ * @see for more information: @ref DCPS_Builtin_Topics
+ * @see for more information: @ref DCPS_Builtin_Topics_SubscriptionData
  */
 template <typename D>
 class dds::topic::TSubscriptionBuiltinTopicData  : public ::dds::core::Value<D>

--- a/src/ddscxx/include/dds/topic/TContentFilteredTopic.hpp
+++ b/src/ddscxx/include/dds/topic/TContentFilteredTopic.hpp
@@ -71,7 +71,7 @@ class ContentFilteredTopic;
  * dds::sub::DataReader<Foo::Bar> reader(subscriber, cfTopic);
  * @endcode
  *
- * @see @ref DCPS_Modules_TopicDefinition "Topic Definition"
+ * @see for more information: @ref DCPS_Modules_TopicDefinition "Topic Definition"
  */
 template <typename T, template <typename Q> class DELEGATE>
 class dds::topic::ContentFilteredTopic : public dds::topic::TTopicDescription< DELEGATE<T> >
@@ -132,9 +132,8 @@ public:
      *
      * See @ref anchor_dds_topic_filter_expression "SQL expression info"
      *
-     * @tparam begin Iterator pointing to the beginning of the parameters to set
-     * @tparam end   Iterator pointing to the end of the parameters to set
-     * @return void
+     * @param begin Iterator pointing to the beginning of the parameters to set
+     * @param end   Iterator pointing to the end of the parameters to set
      * @throws dds::core::Error
      *                  An internal error has occurred.
      * @throws dds::core::NullReferenceError

--- a/src/ddscxx/include/dds/topic/TFilter.hpp
+++ b/src/ddscxx/include/dds/topic/TFilter.hpp
@@ -51,7 +51,7 @@ class TFilter;
  * Look @ref DCPS_Queries_and_Filters "here" for the specific query expression syntax.
  *
  * @see dds::topic::ContentFilteredTopic
- * @see @ref DCPS_Modules_TopicDefinition "Topic Definition"
+ * @see for more information: @ref DCPS_Modules_TopicDefinition "Topic Definition"
  */
 template <typename D>
 class dds::topic::TFilter: public dds::core::Value<D>
@@ -71,7 +71,7 @@ public:
     /**
      * Create a Filter based on a query expression.
      *
-     * @param  query_expression @ref anchor_dds_topic_filter_expression "SQL expression"
+     * @param  query_expression an @ref anchor_dds_topic_filter_expression "SQL expression"
      * @throw                   dds::core::Exception
      */
     TFilter(const std::string& query_expression);
@@ -79,9 +79,9 @@ public:
     /**
      * Create a Filter based on a query expression and an iterable parameter container.
      *
-     * @param  query_expression @ref anchor_dds_topic_filter_expression "SQL expression"
-     * @tparam params_begin     Iterator pointing to the beginning of the parameters to set
-     * @tparam params_end       Iterator pointing to the end of the parameters to set
+     * @param  query_expression an @ref anchor_dds_topic_filter_expression "SQL expression"
+     * @param params_begin     Iterator pointing to the beginning of the parameters to set
+     * @param params_end       Iterator pointing to the end of the parameters to set
      * @throw                   dds::core::Exception
      */
     template <typename FWIterator>
@@ -91,8 +91,8 @@ public:
     /**
      * Create a Filter based on a query expression and parameter vector.
      *
-     * @param  query_expression @ref anchor_dds_topic_filter_expression "SQL expression"
-     * @tparam params           Vector containing SQL expression parameters
+     * @param  query_expression an @ref anchor_dds_topic_filter_expression "SQL expression"
+     * @param params           Vector containing SQL expression parameters
      * @throw                   dds::core::Exception
      */
     TFilter(const std::string& query_expression,
@@ -155,8 +155,8 @@ public:
      *
      * See @ref anchor_dds_topic_filter_expression "SQL expression info"
      *
-     * @tparam begin Iterator pointing to the beginning of the parameters to set
-     * @tparam end   Iterator pointing to the end of the parameters to set
+     * @param begin Iterator pointing to the beginning of the parameters to set
+     * @param end   Iterator pointing to the end of the parameters to set
      * @throw        dds::core::Exception
      */
     template <typename FWIterator>

--- a/src/ddscxx/include/dds/topic/TMultiTopic.hpp
+++ b/src/ddscxx/include/dds/topic/TMultiTopic.hpp
@@ -35,7 +35,7 @@ namespace topic
 /**
  * <b><i>This operation is not yet implemented. It is scheduled for a future release.</i></b>
  *
- * @see @ref DCPS_Modules_TopicDefinition "Topic Definition"
+ * @see for more information: @ref DCPS_Modules_TopicDefinition "Topic Definition"
  */
 template <typename T, template <typename Q> class DELEGATE>
 class MultiTopic : public TTopicDescription< DELEGATE<T> >

--- a/src/ddscxx/include/dds/topic/TTopic.hpp
+++ b/src/ddscxx/include/dds/topic/TTopic.hpp
@@ -69,7 +69,7 @@ class TopicListener;
  * dds::pub::DataWriter<Foo::Bar> writer(publisher, topic);
  * @endcode
  *
- * @see @ref DCPS_Modules_TopicDefinition "Topic Definition"
+ * @see for more information: @ref DCPS_Modules_TopicDefinition "Topic Definition"
  */
 template <typename T, template <typename Q> class DELEGATE>
 class dds::topic::Topic : public dds::topic::TAnyTopic< DELEGATE<T> >

--- a/src/ddscxx/include/dds/topic/TTopicDescription.hpp
+++ b/src/ddscxx/include/dds/topic/TTopicDescription.hpp
@@ -42,7 +42,7 @@ class TTopicDescription;
  * that type.<br>
  * TopicDescription has also a name that allows it to be retrieved locally.
  *
- * @see @ref DCPS_Modules_TopicDefinition "Topic Definition"
+ * @see for more information: @ref DCPS_Modules_TopicDefinition "Topic Definition"
  */
 template <typename DELEGATE>
 class dds::topic::TTopicDescription : public virtual dds::core::Reference<DELEGATE>
@@ -51,6 +51,14 @@ public:
     OMG_DDS_REF_TYPE_PROTECTED_DC(TTopicDescription, dds::core::Reference, DELEGATE)
     OMG_DDS_IMPLICIT_REF_BASE(TTopicDescription)
 
+    /**
+     * Copies the contents of another TopicDescription to this
+     *
+     * @param other the TopicDescription instance to copy from
+     *
+     * @return reference to the TopicDescription instance that was copied to
+     */
+    TTopicDescription& operator=(const TTopicDescription& other) = default;
 public:
     /** @cond */
     virtual ~TTopicDescription();

--- a/src/ddscxx/include/dds/topic/TopicInstance.hpp
+++ b/src/ddscxx/include/dds/topic/TopicInstance.hpp
@@ -36,9 +36,9 @@ class TopicInstance;
  * A TopicInstance encapsulates a dds::sub::Sample and its associated
  * dds::core::InstanceHandle.
  *
- * @see @ref DCPS_Modules_TopicDefinition "Topic Definition"
- * @see @ref dds::sub::Sample
- * @see @ref dds::core::InstanceHandle
+ * @see for more information: @ref DCPS_Modules_TopicDefinition "Topic Definition"
+ * @see for more information: @ref dds::sub::Sample
+ * @see for more information: @ref dds::core::InstanceHandle
  */
 template <typename T>
 class dds::topic::TopicInstance

--- a/src/ddscxx/include/dds/topic/TopicListener.hpp
+++ b/src/ddscxx/include/dds/topic/TopicListener.hpp
@@ -71,8 +71,8 @@ namespace topic
  *
  * @endcode
  *
- * @see @ref DCPS_Modules_Topic "Topic"
- * @see @ref DCPS_Modules_Infrastructure_Listener "Listener information"
+ * @see for more information: @ref DCPS_Modules_Topic "Topic"
+ * @see for more information: @ref DCPS_Modules_Infrastructure_Listener "Listener information"
  */
 template <typename T>
 class TopicListener

--- a/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
@@ -200,7 +200,6 @@ dds::topic::detail::Topic<T>::Topic(const dds::domain::DomainParticipant& dp,
     this->set_ddsc_entity(ddsc_topic);
     this->listener(NULL, dds::core::status::StatusMask::none());
 
-    this->AnyTopicDelegate::set_copy_out(org::eclipse::cyclonedds::topic::TopicTraits<T>::getCopyOut());
     this->AnyTopicDelegate::set_sample(&this->sample_);
 }
 

--- a/src/ddscxx/include/dds/topic/qos/detail/TopicQos.hpp
+++ b/src/ddscxx/include/dds/topic/qos/detail/TopicQos.hpp
@@ -62,7 +62,7 @@
  * specified either at Topic creation time or prior to calling the enable
  * operation on the Topic.
  *
- * @see @ref DCPS_QoS
+ * @see for more information: @ref DCPS_QoS
  */
 class dds::topic::qos::TopicQos : public ::dds::core::EntityQos<org::eclipse::cyclonedds::topic::qos::TopicQosDelegate>
 {

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/InstanceHandleDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/InstanceHandleDelegate.hpp
@@ -46,6 +46,7 @@ public:
     InstanceHandleDelegate(const dds::core::null_type& src);
     InstanceHandleDelegate(const InstanceHandleDelegate& other);
 
+    InstanceHandleDelegate& operator=(const InstanceHandleDelegate& src) = default;
 
 public:
     bool operator==(const InstanceHandleDelegate& that) const;

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/ObjectSet.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/ObjectSet.hpp
@@ -47,13 +47,13 @@ public:
 
     /**
      *  @internal Inserts a EntityDelegate into the set.
-     * @param entity The org::eclipse::cyclonedds::core::ObjectDelegate to store
+     * @param obj The org::eclipse::cyclonedds::core::ObjectDelegate to store
      */
     void insert(org::eclipse::cyclonedds::core::ObjectDelegate& obj);
 
     /**
      *  @internal Erases a EntityDelegate from the set.
-     * @param entity The org::eclipse::cyclonedds::core::ObjectDelegate to delete
+     * @param obj The org::eclipse::cyclonedds::core::ObjectDelegate to delete
      */
     void erase(org::eclipse::cyclonedds::core::ObjectDelegate& obj);
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/WaitSetDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/WaitSetDelegate.hpp
@@ -89,8 +89,4 @@ namespace cond
 }
 }
 
-#ifdef _WIN32
-#pragma warning ( pop )
-#endif
-
 #endif /* CYCLONEDDS_CORE_COND_WAITSET_DELEGATE_HPP_ */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/PolicyDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/PolicyDelegate.hpp
@@ -83,6 +83,8 @@ public:
     DeadlineDelegate(const DeadlineDelegate& other);
     explicit DeadlineDelegate(const dds::core::Duration& d);
 
+    DeadlineDelegate& operator=(const DeadlineDelegate& other) = default;
+
     void period(const dds::core::Duration& d);
     dds::core::Duration period() const;
 
@@ -107,6 +109,8 @@ public:
     DestinationOrderDelegate(const DestinationOrderDelegate& other);
     explicit DestinationOrderDelegate(dds::core::policy::DestinationOrderKind::Type kind);
 
+    DestinationOrderDelegate& operator=(const DestinationOrderDelegate& other) = default;
+
     void kind(dds::core::policy::DestinationOrderKind::Type kind);
     dds::core::policy::DestinationOrderKind::Type kind() const;
 
@@ -128,6 +132,8 @@ class OMG_DDS_API DurabilityDelegate
 public:
     DurabilityDelegate(const DurabilityDelegate& other);
     explicit DurabilityDelegate(dds::core::policy::DurabilityKind::Type kind);
+
+    DurabilityDelegate& operator=(const DurabilityDelegate& other) = default;
 
     void kind(dds::core::policy::DurabilityKind::Type kind);
     dds::core::policy::DurabilityKind::Type kind() const;
@@ -157,6 +163,8 @@ public:
                               int32_t max_samples,
                               int32_t max_instances,
                               int32_t max_samples_per_instance);
+
+    DurabilityServiceDelegate& operator=(const DurabilityServiceDelegate& other) = default;
 
     void service_cleanup_delay(const dds::core::Duration& d);
     const dds::core::Duration service_cleanup_delay() const;
@@ -222,6 +230,8 @@ public:
 
     bool operator ==(const EntityFactoryDelegate& other) const;
 
+    EntityFactoryDelegate& operator =(const EntityFactoryDelegate& other) = default;
+
     void check() const;
 
     void set_iso_policy(const dds_qos_t* qos);
@@ -259,6 +269,15 @@ public:
     GroupDataDelegate(const GroupDataDelegate& other);
 
     /**
+     *  @internal Copies a <code>GroupData</code> instance.
+     *
+     * @param other the group data to copy
+     *
+     * @return reference to the instance which was copied to
+     */
+    GroupDataDelegate& operator=(const GroupDataDelegate& other) = default;
+
+    /**
      *  @internal Create a <code>GroupData</code> instance.
      *
      * @param seq the group data value
@@ -283,15 +302,13 @@ public:
 
     /**
      *  @internal Check if policy is consistent.
-     *
-     * @return true if consistent
      */
     void check() const;
 
     /**
      *  @internal Set internals by the ddsc policy.
      *
-     * @param the ddsc policy
+     * @param qos the ddsc policy
      */
     void set_iso_policy(const dds_qos_t* qos);
     /**
@@ -304,7 +321,7 @@ public:
     /**
      *  @internal Get the ddsc policy representation.
      *
-     * @return the ddsc policy
+     * @param qos the ddsc policy
      */
     void set_c_policy(dds_qos_t* qos) const;
 
@@ -321,6 +338,8 @@ class OMG_DDS_API HistoryDelegate
 public:
     HistoryDelegate(const HistoryDelegate& other);
     HistoryDelegate(dds::core::policy::HistoryKind::Type kind, int32_t depth);
+
+    HistoryDelegate& operator=(const HistoryDelegate& other) = default;
 
     dds::core::policy::HistoryKind::Type kind() const;
     void kind(dds::core::policy::HistoryKind::Type kind);
@@ -348,6 +367,8 @@ class OMG_DDS_API LatencyBudgetDelegate
 public:
     LatencyBudgetDelegate(const LatencyBudgetDelegate& other);
     explicit LatencyBudgetDelegate(const dds::core::Duration& d);
+
+    LatencyBudgetDelegate& operator=(const LatencyBudgetDelegate& other) = default;
 
     void duration(const dds::core::Duration& d);
     const dds::core::Duration duration() const;
@@ -388,6 +409,7 @@ class OMG_DDS_API LifespanDelegate
 public:
     LifespanDelegate(const LifespanDelegate& other);
     explicit LifespanDelegate(const dds::core::Duration& d);
+    LifespanDelegate& operator=(const LifespanDelegate& other) = default;
 
     void duration(const dds::core::Duration& d);
     const dds::core::Duration duration() const;
@@ -412,6 +434,8 @@ public:
     LivelinessDelegate(const LivelinessDelegate& other);
     LivelinessDelegate(dds::core::policy::LivelinessKind::Type kind,
                        dds::core::Duration lease_duration);
+
+    LivelinessDelegate& operator=(const LivelinessDelegate& other) = default;
 
     void kind(dds::core::policy::LivelinessKind::Type kind);
     dds::core::policy::LivelinessKind::Type kind() const;
@@ -438,6 +462,7 @@ class OMG_DDS_API OwnershipDelegate
 public:
     OwnershipDelegate(const OwnershipDelegate& other);
     explicit OwnershipDelegate(dds::core::policy::OwnershipKind::Type kind);
+    OwnershipDelegate& operator=(const OwnershipDelegate& other) = default;
 
     void kind(dds::core::policy::OwnershipKind::Type kind);
     dds::core::policy::OwnershipKind::Type kind() const;
@@ -463,6 +488,8 @@ public:
     OwnershipStrengthDelegate(const OwnershipStrengthDelegate& other);
     explicit OwnershipStrengthDelegate(int32_t s);
 
+    OwnershipStrengthDelegate& operator=(const OwnershipStrengthDelegate& other) = default;
+
     int32_t strength() const;
     void strength(int32_t s);
 
@@ -487,6 +514,8 @@ public:
     PartitionDelegate(const PartitionDelegate& other);
     explicit PartitionDelegate(const std::string& partition);
     explicit PartitionDelegate(const dds::core::StringSeq& partitions);
+
+    PartitionDelegate& operator=(const PartitionDelegate& other) = default;
 
     void name(const std::string& partition);
     void name(const dds::core::StringSeq& partitions);
@@ -514,6 +543,7 @@ public:
     PresentationDelegate(dds::core::policy::PresentationAccessScopeKind::Type access_scope,
                          bool coherent_access,
                          bool ordered_access);
+    PresentationDelegate& operator=(const PresentationDelegate& other) = default;
 
     void access_scope(dds::core::policy::PresentationAccessScopeKind::Type as);
     dds::core::policy::PresentationAccessScopeKind::Type access_scope() const;
@@ -553,6 +583,8 @@ public:
     void autopurge_disposed_samples_delay(const dds::core::Duration& d);
 
     bool operator ==(const ReaderDataLifecycleDelegate& other) const;
+
+    ReaderDataLifecycleDelegate& operator =(const ReaderDataLifecycleDelegate& other) = default;
 
     void check() const;
 
@@ -601,6 +633,8 @@ public:
     ReliabilityDelegate(dds::core::policy::ReliabilityKind::Type kind,
                         const dds::core::Duration& max_blocking_time);
 
+    ReliabilityDelegate& operator=(const ReliabilityDelegate& other) = default;
+
     void kind(dds::core::policy::ReliabilityKind::Type kind);
     dds::core::policy::ReliabilityKind::Type kind() const;
 
@@ -628,6 +662,8 @@ public:
     ResourceLimitsDelegate(int32_t max_samples,
                            int32_t max_instances,
                            int32_t max_samples_per_instance);
+
+    ResourceLimitsDelegate& operator=(const ResourceLimitsDelegate& other) = default;
 
     void max_samples(int32_t samples);
     int32_t max_samples() const;
@@ -659,6 +695,7 @@ class OMG_DDS_API TimeBasedFilterDelegate
 public:
     TimeBasedFilterDelegate(const TimeBasedFilterDelegate& other);
     explicit TimeBasedFilterDelegate(const dds::core::Duration& min_separation);
+    TimeBasedFilterDelegate& operator=(const TimeBasedFilterDelegate& other) = default;
 
     void min_separation(const dds::core::Duration& ms);
     const dds::core::Duration min_separation() const;
@@ -691,6 +728,8 @@ public:
     TopicDataDelegate();
     TopicDataDelegate(const TopicDataDelegate& other);
     explicit TopicDataDelegate(const dds::core::ByteSeq& seq);
+
+    TopicDataDelegate& operator=(const TopicDataDelegate& other) = default;
 
     void value(const dds::core::ByteSeq& seq);
     const dds::core::ByteSeq& value() const;
@@ -731,6 +770,7 @@ class OMG_DDS_API TransportPriorityDelegate
 {
 public:
     TransportPriorityDelegate(const TransportPriorityDelegate& other);
+    TransportPriorityDelegate& operator=(const TransportPriorityDelegate& other) = default;
     explicit TransportPriorityDelegate(int32_t prio);
 
     void value(int32_t prio);
@@ -777,6 +817,15 @@ public:
     UserDataDelegate(const UserDataDelegate& other);
 
     /**
+     *  @internal Copies a <code>UserData</code> instance.
+     *
+     * @param other the user data to copy
+     *
+     * @return reference to the instance that was copied to
+     */
+    UserDataDelegate& operator=(const UserDataDelegate& other) = default;
+
+    /**
      *  @internal Create a <code>UserData</code> instance.
      *
      * @param seq the sequence of octet representing the user data
@@ -801,15 +850,13 @@ public:
 
     /**
      *  @internal Check if policy is consistent.
-     *
-     * @return true if consistent
      */
     void check() const;
 
     /**
      *  @internal Set internals by the ddsc policy.
      *
-     * @param the ddsc policy
+     * @param qos the ddsc policy
      */
     void set_iso_policy(const dds_qos_t* qos);
     /**
@@ -820,8 +867,6 @@ public:
     //@todo void v_policy(const v_builtinUserDataPolicy& policy);
     /**
      *  @internal Get the ddsc policy representation.
-     *
-     * @return the ddsc policy
      */
     void set_c_policy(dds_qos_t* qos) const;
 
@@ -841,6 +886,8 @@ public:
     void autodispose(bool b);
 
     bool operator ==(const WriterDataLifecycleDelegate& other) const;
+
+    WriterDataLifecycleDelegate& operator =(const WriterDataLifecycleDelegate& other) = default;
 
     void check() const;
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/QosPolicyCountDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/QosPolicyCountDelegate.hpp
@@ -44,6 +44,8 @@ public:
           count_(other.count())
     { }
 
+    QosPolicyCountDelegate& operator=(const QosPolicyCountDelegate& other) = default;
+
 public:
     dds::core::policy::QosPolicyId policy_id() const
     {

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/TPolicy.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/TPolicy.hpp
@@ -117,7 +117,7 @@ public:
     /**
      * Creates a ProductData QoS instance
      *
-     * @param value the value
+     * @param name the name
      */
     TProductData(const std::string& name) : dds::core::Value<D>(name) { }
 
@@ -132,7 +132,7 @@ public:
     /**
      * Sets the name
      *
-     * @param value the name
+     * @param name the name to set
      */
     TProductData& name(const std::string& name)
     {
@@ -203,7 +203,7 @@ public:
     /**
      * Sets multiple keys
      *
-     * @param names a sequence containing multiple keys
+     * @param keys a sequence containing multiple keys
      */
     TSubscriptionKey& key(const dds::core::StringSeq& keys)
     {
@@ -274,7 +274,7 @@ public:
     /**
        * Sets the used flag
        *
-       * @param the used flag
+       * @param used the state of the flag to set
        */
       TReaderLifespan& used(bool used)
       {
@@ -332,7 +332,9 @@ public:
     /**
      * Creates a Scheduling QoS instance
      *
-     * @param value the value
+     * @param scheduling_kind the scheduling kind
+     * @param scheduling_priority_kind the scheduling priority kind
+     * @param scheduling_priority the scheduling priority
      */
     TScheduling(const org::eclipse::cyclonedds::core::policy::SchedulingKind::Type& scheduling_kind,
                 const org::eclipse::cyclonedds::core::policy::SchedulingPriorityKind::Type& scheduling_priority_kind,

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.hpp
@@ -104,17 +104,6 @@ protected:
     AnyDataWriterDelegate(const dds::pub::qos::DataWriterQos& qos,
                           const dds::topic::TopicDescription& td);
 
-
-    inline void setCopyIn(org::eclipse::cyclonedds::topic::copyInFunction _copyIn)
-    {
-        this->copyIn = _copyIn;
-    }
-
-    inline org::eclipse::cyclonedds::topic::copyInFunction getCopyIn()
-    {
-        return this->copyIn;
-    }
-
     inline void setSampleSize(size_t _sampleSize)
     {
         this->sampleSize = _sampleSize;
@@ -123,16 +112,6 @@ protected:
     inline size_t getSampleSize()
     {
         return this->sampleSize;
-    }
-
-    inline void setCopyOut(org::eclipse::cyclonedds::topic::copyOutFunction _copyOut)
-    {
-        this->copyOut = _copyOut;
-    }
-
-    inline org::eclipse::cyclonedds::topic::copyOutFunction getCopyOut()
-    {
-        return this->copyOut;
     }
 
     void

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.hpp
@@ -105,9 +105,9 @@ protected:
                           const dds::topic::TopicDescription& td);
 
 
-    inline void setCopyIn(org::eclipse::cyclonedds::topic::copyInFunction copyIn)
+    inline void setCopyIn(org::eclipse::cyclonedds::topic::copyInFunction _copyIn)
     {
-        this->copyIn = copyIn;
+        this->copyIn = _copyIn;
     }
 
     inline org::eclipse::cyclonedds::topic::copyInFunction getCopyIn()
@@ -115,9 +115,9 @@ protected:
         return this->copyIn;
     }
 
-    inline void setSampleSize(size_t sampleSize)
+    inline void setSampleSize(size_t _sampleSize)
     {
-        this->sampleSize = sampleSize;
+        this->sampleSize = _sampleSize;
     }
 
     inline size_t getSampleSize()
@@ -125,9 +125,9 @@ protected:
         return this->sampleSize;
     }
 
-    inline void setCopyOut(org::eclipse::cyclonedds::topic::copyOutFunction copyOut)
+    inline void setCopyOut(org::eclipse::cyclonedds::topic::copyOutFunction _copyOut)
     {
-        this->copyOut = copyOut;
+        this->copyOut = _copyOut;
     }
 
     inline org::eclipse::cyclonedds::topic::copyOutFunction getCopyOut()

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.hpp
@@ -168,16 +168,6 @@ public:
     void add_query(org::eclipse::cyclonedds::sub::QueryDelegate& query);
     void remove_query(org::eclipse::cyclonedds::sub::QueryDelegate& query);
 
-    inline void setCopyIn(org::eclipse::cyclonedds::topic::copyInFunction _copyIn)
-    {
-        this->copyIn = _copyIn;
-    }
-
-    inline org::eclipse::cyclonedds::topic::copyInFunction getCopyIn() const
-    {
-        return this->copyIn;
-    }
-
     inline void setSampleSize(size_t _sampleSize)
     {
         this->sampleSize = _sampleSize;
@@ -186,16 +176,6 @@ public:
     inline size_t getSampleSize() const
     {
         return this->sampleSize;
-    }
-
-    void setCopyOut(org::eclipse::cyclonedds::topic::copyOutFunction _copyOut)
-    {
-        this->copyOut = _copyOut;
-    }
-
-    inline org::eclipse::cyclonedds::topic::copyOutFunction getCopyOut() const
-    {
-        return this->copyOut;
     }
 
     void setSample(void* sample);

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.hpp
@@ -108,6 +108,10 @@ public:
       void**& c_sample_pointers,
       dds_sample_info_t*& c_sample_infos,
       int num_read) {
+      (void)samples;
+      (void)c_sample_pointers;
+      (void)c_sample_infos;
+      (void)num_read;
       assert(1);
     }
 public:
@@ -164,9 +168,9 @@ public:
     void add_query(org::eclipse::cyclonedds::sub::QueryDelegate& query);
     void remove_query(org::eclipse::cyclonedds::sub::QueryDelegate& query);
 
-    inline void setCopyIn(org::eclipse::cyclonedds::topic::copyInFunction copyIn)
+    inline void setCopyIn(org::eclipse::cyclonedds::topic::copyInFunction _copyIn)
     {
-        this->copyIn = copyIn;
+        this->copyIn = _copyIn;
     }
 
     inline org::eclipse::cyclonedds::topic::copyInFunction getCopyIn() const
@@ -174,9 +178,9 @@ public:
         return this->copyIn;
     }
 
-    inline void setSampleSize(size_t sampleSize)
+    inline void setSampleSize(size_t _sampleSize)
     {
-        this->sampleSize = sampleSize;
+        this->sampleSize = _sampleSize;
     }
 
     inline size_t getSampleSize() const
@@ -184,9 +188,9 @@ public:
         return this->sampleSize;
     }
 
-    void setCopyOut(org::eclipse::cyclonedds::topic::copyOutFunction copyOut)
+    void setCopyOut(org::eclipse::cyclonedds::topic::copyOutFunction _copyOut)
     {
-        this->copyOut = copyOut;
+        this->copyOut = _copyOut;
     }
 
     inline org::eclipse::cyclonedds::topic::copyOutFunction getCopyOut() const

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/AnyTopicDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/AnyTopicDelegate.hpp
@@ -88,9 +88,6 @@ public:
                     std::vector<dds::topic::TAnyTopic<AnyTopicDelegate> >& topics,
                     uint32_t max_size);
 
-    void set_copy_out(org::eclipse::cyclonedds::topic::copyOutFunction copyOut);
-    org::eclipse::cyclonedds::topic::copyOutFunction get_copy_out();
-
     void set_sample(void* sample);
     void* get_sample();
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicTraits.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicTraits.hpp
@@ -69,6 +69,7 @@ public:
 
     static ddsi_sertopic *getSerTopic(const std::string& topic_name)
     {
+        (void)topic_name;
         return NULL;
     }
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/EntityDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/EntityDelegate.cpp
@@ -144,11 +144,11 @@ org::eclipse::cyclonedds::core::EntityDelegate::retain()
 
 void
 org::eclipse::cyclonedds::core::EntityDelegate::listener_set(
-                 void *listener,
+                 void *_listener,
                  const dds::core::status::StatusMask& mask)
 {
     dds_listener_t *callbacks;
-    this->listener = listener;
+    this->listener = _listener;
     this->listener_mask = mask;
 
     callbacks = dds_create_listener(this);

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/MiscUtils.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/MiscUtils.cpp
@@ -18,6 +18,10 @@
 
 #include "dds/dds.h"
 
+#ifdef _WIN32
+#pragma warning(disable : 4996)
+#endif
+
 void
 org::eclipse::cyclonedds::core::convertByteSeq(
         const dds::core::ByteSeq &from,

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/MiscUtils.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/MiscUtils.cpp
@@ -17,10 +17,7 @@
 #include <org/eclipse/cyclonedds/core/MiscUtils.hpp>
 
 #include "dds/dds.h"
-
-#ifdef _WIN32
-#pragma warning(disable : 4996)
-#endif
+#include "dds/ddsrt/string.h"
 
 void
 org::eclipse::cyclonedds::core::convertByteSeq(
@@ -69,7 +66,7 @@ org::eclipse::cyclonedds::core::convertStringSeq(
     {
         size_t len = from[i].length() + 1;
         to[i] = new char[len];
-        strncpy(to[i], from[i].c_str(), len);
+        ddsrt_strlcpy(to[i], from[i].c_str(), len);
     }
 }
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/WaitSetDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/WaitSetDelegate.cpp
@@ -102,7 +102,8 @@ org::eclipse::cyclonedds::core::cond::WaitSetDelegate::dispatch(
     try {
         wait(triggered, timeout);
     }
-    catch(dds::core::TimeoutError) {
+    catch(dds::core::TimeoutError &e) {
+        (void)e;
         ISOCPP_THROW_EXCEPTION(ISOCPP_TIMEOUT_ERROR,
             "dds::core::cond::WaitSet::dispatch() timed out.");
     }

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
@@ -422,7 +422,7 @@ org::eclipse::cyclonedds::domain::DomainParticipantDelegate::lookup_topic(
 void
 org::eclipse::cyclonedds::domain::DomainParticipantDelegate::lookup_topics(
         const std::string& type_name,
-        std::vector<dds_entity_t>& topics,
+        std::vector<dds_entity_t>& _topics,
         uint32_t max_size)
 {
     /*
@@ -430,7 +430,7 @@ org::eclipse::cyclonedds::domain::DomainParticipantDelegate::lookup_topics(
      * AnyTopicDelegate::discover_topics(), which are used
      * by topic/discovery.hpp.
      */
-    (void)topics;
+    (void)_topics;
     (void)max_size;
     (void)type_name;
     /* Add support during Topic discovery implementation. */

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
@@ -199,6 +199,9 @@ void AnyDataReaderDelegate::fini_samples_buffers(
                     dds_sample_info_t*& c_sample_infos,
                     size_t c_sample_pointers_size)
 {
+  (void)c_sample_pointers;
+  (void)c_sample_infos;
+  (void)c_sample_pointers_size;
 #if 0
     for(size_t i = 0; i < c_sample_pointers_size; i++)
     {

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/SubscriberDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/SubscriberDelegate.cpp
@@ -210,13 +210,13 @@ SubscriberDelegate::remove_datareader(
 std::vector<org::eclipse::cyclonedds::sub::AnyDataReaderDelegate::ref_type>
 SubscriberDelegate::find_datareaders(const std::string& topic_name)
 {
-    std::vector<org::eclipse::cyclonedds::sub::AnyDataReaderDelegate::ref_type> readers;
+    std::vector<org::eclipse::cyclonedds::sub::AnyDataReaderDelegate::ref_type> _readers;
 
     org::eclipse::cyclonedds::core::EntitySet::vector entities;
     org::eclipse::cyclonedds::core::EntitySet::vectorIterator iter;
 
     entities = this->readers.copy();
-    readers.reserve(entities.size());
+    _readers.reserve(entities.size());
     for (iter = entities.begin(); iter != entities.end(); ++iter) {
         org::eclipse::cyclonedds::core::ObjectDelegate::ref_type ref = iter->lock();
         if (ref) {
@@ -224,12 +224,12 @@ SubscriberDelegate::find_datareaders(const std::string& topic_name)
                     OSPL_CXX11_STD_MODULE::dynamic_pointer_cast<AnyDataReaderDelegate>(ref);
             assert(tmp);
             if (tmp->topic_description().name() == topic_name) {
-                readers.push_back(tmp);
+                _readers.push_back(tmp);
             }
         }
     }
 
-    return readers;
+    return _readers;
 }
 
 std::vector<org::eclipse::cyclonedds::sub::AnyDataReaderDelegate::ref_type>
@@ -239,8 +239,8 @@ SubscriberDelegate::get_datareaders(
     (void)mask;
     ISOCPP_THROW_EXCEPTION(ISOCPP_UNSUPPORTED_ERROR, "Function not currently supported");
     org::eclipse::cyclonedds::core::ScopedObjectLock scopedLock(*this);
-    std::vector<org::eclipse::cyclonedds::sub::AnyDataReaderDelegate::ref_type> readers;
-    return readers;
+    std::vector<org::eclipse::cyclonedds::sub::AnyDataReaderDelegate::ref_type> _readers;
+    return _readers;
 }
 
 void

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/AnyTopicDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/AnyTopicDelegate.cpp
@@ -192,9 +192,9 @@ AnyTopicDelegate::discover_topics(
     ISOCPP_THROW_EXCEPTION(ISOCPP_UNSUPPORTED_ERROR, "Discovery of AnyTopics not implemented yet");
 }
 
-void AnyTopicDelegate::set_copy_out(org::eclipse::cyclonedds::topic::copyOutFunction copyOut)
+void AnyTopicDelegate::set_copy_out(org::eclipse::cyclonedds::topic::copyOutFunction _copyOut)
 {
-    this->copyOut = copyOut;
+    this->copyOut = _copyOut;
 }
 
 org::eclipse::cyclonedds::topic::copyOutFunction AnyTopicDelegate::get_copy_out()

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/AnyTopicDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/AnyTopicDelegate.cpp
@@ -192,16 +192,6 @@ AnyTopicDelegate::discover_topics(
     ISOCPP_THROW_EXCEPTION(ISOCPP_UNSUPPORTED_ERROR, "Discovery of AnyTopics not implemented yet");
 }
 
-void AnyTopicDelegate::set_copy_out(org::eclipse::cyclonedds::topic::copyOutFunction _copyOut)
-{
-    this->copyOut = _copyOut;
-}
-
-org::eclipse::cyclonedds::topic::copyOutFunction AnyTopicDelegate::get_copy_out()
-{
-    return this->copyOut;
-}
-
 void AnyTopicDelegate::set_sample(void* sample)
 {
     sample_ = sample;

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/hash.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/hash.cpp
@@ -33,7 +33,7 @@ namespace org
         {
           ddsrt_md5_state_t md5st;
           ddsrt_md5_init(&md5st);
-          ddsrt_md5_append(&md5st, (ddsrt_md5_byte_t*)in.data(), in.size());
+          ddsrt_md5_append(&md5st, (ddsrt_md5_byte_t*)in.data(), (unsigned int)in.size());
           ddsrt_md5_finish(&md5st, (ddsrt_md5_byte_t*)out.value);
 
           return true;

--- a/src/idlcxx/src/backend.c
+++ b/src/idlcxx/src/backend.c
@@ -17,6 +17,10 @@
 #include <stdio.h>
 #include "idlcxx/backend.h"
 
+#ifdef _WIN32
+#pragma warning(disable : 4996)
+#endif
+
 struct idl_backend_ctx_s
 {
   idl_file_out    output;
@@ -317,7 +321,6 @@ idl_walk_tree(
 static idl_retcode_t
 prune_include_list(idl_backend_ctx ctx, const idl_node_t *node)
 {
-  const idl_node_t *sub_nodes = NULL;
   idl_retcode_t result = IDL_RETCODE_OK;
 
   /* If you find a dependency to another file than your own, prune it form the include list. */

--- a/src/idlcxx/src/backendCpp11Type.c
+++ b/src/idlcxx/src/backendCpp11Type.c
@@ -420,7 +420,7 @@ get_cpp11_case_data(idl_backend_ctx ctx, const idl_node_t *node)
 static uint64_t
 get_potential_nr_discr_values(const idl_union_t *union_node)
 {
-  uint64_t nr_discr_values;
+  uint64_t nr_discr_values = 0;
   const idl_node_t *node = union_node->switch_type_spec;
 
   switch (node->mask & (IDL_BASE_TYPE | IDL_CONSTR_TYPE))
@@ -719,7 +719,7 @@ get_default_discr_value(idl_backend_ctx ctx, const idl_union_t *union_node)
 
   if (union_ctx->nr_unused_discr_values) {
     /* find the smallest available unused discr_value. */
-    void **all_labels = malloc(sizeof(void *) * union_ctx->total_label_count);
+    void **all_labels = malloc(sizeof(void *) * (size_t)union_ctx->total_label_count);
     uint32_t i = 0;
     const idl_case_t *case_data = union_node->cases;
     while (case_data)

--- a/src/idlcxx/src/backendCpp11Utils.c
+++ b/src/idlcxx/src/backendCpp11Utils.c
@@ -18,6 +18,10 @@
 #include "idl/string.h"
 #include "idlcxx/backendCpp11Utils.h"
 
+#ifdef _WIN32
+#pragma warning(disable : 4996)
+#endif
+
 /* Specify a list of all C++11 keywords */
 static const char* cpp11_keywords[] =
 {
@@ -247,7 +251,7 @@ get_default_value(idl_backend_ctx ctx, const idl_node_t *node)
 static char *
 get_cpp11_base_type_const_value(const idl_constval_t *constval)
 {
-  int cnt;
+  int cnt = -1;
   char *str = NULL;
   static const idl_mask_t mask = (IDL_BASE_TYPE_MASK|(IDL_BASE_TYPE_MASK-1));
 

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -20,6 +20,10 @@
 #include "idlcxx/backendCpp11Type.h"
 #include "idlcxx/streamer_generator.h"
 
+#ifdef _WIN32
+#pragma warning(disable : 4996)
+#endif
+
 static char *
 figure_guard(const char *file)
 {
@@ -31,7 +35,7 @@ figure_guard(const char *file)
   /* replace any non-alphanumeric characters */
   for (char *ptr = inc; *ptr; ptr++) {
     if ((*ptr >= 'a' && *ptr <= 'z'))
-      *ptr = ('A' + (*ptr - 'a'));
+      *ptr = (char)('A' + (*ptr - 'a'));
     else if (!(*ptr >= 'A' && *ptr <= 'Z') && !(*ptr >= '0' && *ptr <= '9'))
       *ptr = '_';
   }

--- a/src/idlcxx/src/streamer_generator.c
+++ b/src/idlcxx/src/streamer_generator.c
@@ -138,8 +138,8 @@ format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->read_stream, _str, ##__V
 #define typedef_write_size_call position_set "%stypedef_write_size_%s(%s, position);\n"
 #define typedef_read_call position_set "%stypedef_read_%s(%s, data, position);\n"
 #define typedef_key_size_call position_set "%stypedef_key_size_%s(%s, position);\n"
-#define typedef_key_max_size_call position_set "%stypedef_key_max_size_%(%s, position);\n"
-#define typedef_key_stream_call position_set "%stypedef_key_stream_%(%s, *data, position);\n"
+#define typedef_key_max_size_call position_set "%stypedef_key_max_size_%s(%s, position);\n"
+#define typedef_key_stream_call position_set "%stypedef_key_stream_%s(%s, *data, position);\n"
 #define union_case_max_check "if (case_max != UINT_MAX) "
 #define union_case_max_incr union_case_max_check "case_max += "
 #define union_case_max_set "case_max = "
@@ -1437,19 +1437,19 @@ idl_retcode_t process_typedef_instance(context_t* ctx, idl_declarator_t* decl, i
     assert(accessor);
 
     format_write_stream(1, ctx, false, typedef_write_call, ns, tdname, accessor);
-    format_write_size_stream(1, ctx, false, typedef_write_size_call "\n", ns, tdname, accessor);
-    format_read_stream(1, ctx, typedef_read_call "\n", ns, tdname, accessor);
+    format_write_size_stream(1, ctx, false, typedef_write_size_call, ns, tdname, accessor);
+    format_read_stream(1, ctx, typedef_read_call, ns, tdname, accessor);
     if (is_key)
     {
-      format_key_stream(1, ctx, typedef_key_size_call "\n", ns, tdname, accessor);
-      format_key_size_stream(1, ctx, typedef_key_stream_call "\n", ns, tdname, accessor);
+      format_key_stream(1, ctx, typedef_key_stream_call, ns, tdname, accessor);
+      format_key_size_stream(1, ctx, typedef_key_size_call, ns, tdname, accessor);
       if (ctx->in_union)
       {
         format_key_max_size_stream(1, ctx, union_case_max_set "%stypedef_key_max_size_%(%s, position);\n", ns, tdname, accessor);
       }
       else
       {
-        format_key_max_size_stream(1, ctx, typedef_key_max_size_call "\n", ns, tdname, accessor);
+        format_key_max_size_stream(1, ctx, typedef_key_max_size_call, ns, tdname, accessor);
       }
     }
     free(ns);

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -2414,7 +2414,7 @@ CU_Test(streamer_generator, bounded_sequence)
   test_bounded_sequence();
 }
 
-CU_Test(streamer_generator, typedef_resolution, .disabled =true)  //not working at the moment, therefore skipping
+CU_Test(streamer_generator, typedef_resolution)
 {
   test_typedef_resolution();
 }

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -1691,6 +1691,128 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  return position;\n"\
 "}\n\n"
 
+#define TDKI "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n"\
+"size_t typedef_write_td_1(const td_1 &obj, void* data, size_t position)\n"\
+"{\n"\
+"  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+"  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
+"  position += alignmentbytes;  //moving position indicator\n"\
+"  uint32_t sequenceentries = obj.size();  //number of entries in the sequence\n"\
+"  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing entries for member: obj\n"\
+"  position += 4;  //moving position indicator\n"\
+"  memcpy((char*)data+position,obj.data(),sequenceentries*4);  //contents for obj\n"\
+"  position += sequenceentries*4;  //moving position indicator\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t s::write_struct(void *data, size_t position) const\n"\
+"{\n"\
+"  *((uint8_t*)((char*)data+position)) = o();  //writing bytes for member: o()\n"\
+"  position += 1;  //moving position indicator\n"\
+"  position = typedef_write_td_1(t(), data, position);\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t typedef_write_size_td_1(const td_1 &obj, size_t position)\n"\
+"{\n"\
+"  position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  position += 4;  //bytes for sequence entries\n"\
+"  position += (obj.size())*4;  //entries of sequence\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t s::write_size(size_t position) const\n"\
+"{\n"\
+"  position += 1;  //bytes for member: o()\n"\
+"  position = typedef_write_size_td_1(t(), position);\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t typedef_key_size_td_1(const td_1 &obj, size_t position)\n"\
+"{\n"\
+"  position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  position += 4;  //bytes for sequence entries\n"\
+"  position += (obj.size())*4;  //entries of sequence\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t s::key_size(size_t position) const\n"\
+"{\n"\
+"  position = typedef_key_size_td_1(t(), position);\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t typedef_key_max_size_td_1(const td_1 &obj, size_t position)\n"\
+"{\n"\
+"  if (position != UINT_MAX)   position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  if (position != UINT_MAX)   position += 4;  //bytes for sequence entries\n"\
+"  position = UINT_MAX;\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t s::key_max_size(size_t position) const\n"\
+"{\n"\
+"  position = typedef_key_max_size_td_1(t(), position);\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t typedef_key_stream_td_1(const td_1 &obj, void *data, size_t position)\n"\
+"{\n"\
+"  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+"  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
+"  position += alignmentbytes;  //moving position indicator\n"\
+"  uint32_t sequenceentries = obj.size();  //number of entries in the sequence\n"\
+"  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing entries for member: obj\n"\
+"  position += 4;  //moving position indicator\n"\
+"  memcpy((char*)data+position,obj.data(),sequenceentries*4);  //contents for obj\n"\
+"  position += sequenceentries*4;  //moving position indicator\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t s::key_stream(void *data, size_t position) const\n"\
+"{\n"\
+"  position = typedef_key_stream_td_1(t(), *data, position);\n"\
+"  return position;\n"\
+"}\n\n"\
+"bool s::key(ddsi_keyhash_t &hash) const\n"\
+"{\n"\
+"  size_t sz = key_size(0);\n"\
+"  size_t padding = 16 - sz%16;\n"\
+"  if (sz != 0 && padding == 16) padding = 0;\n"\
+"  std::vector<unsigned char> buffer(sz+padding);\n"\
+"  memset(buffer.data()+sz,0x0,padding);\n"\
+"  key_stream(buffer.data(),0);\n"\
+"  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n"\
+"  if (fptr == NULL)\n"\
+"  {\n"\
+"    if (key_max_size(0) <= 16)\n"\
+"    {\n"\
+"      //bind to unmodified function which just copies buffer into the keyhash\n"\
+"      fptr = &org::eclipse::cyclonedds::topic::simple_key;\n"\
+"    }\n"\
+"    else\n"\
+"    {\n"\
+"      //bind to MD5 hash function\n"\
+"      fptr = &org::eclipse::cyclonedds::topic::complex_key;\n"\
+"    }\n"\
+"  }\n"\
+"  return (*fptr)(buffer,hash);\n"\
+"}\n\n"\
+"size_t typedef_read_td_1(td_1 &obj, void* data, size_t position)\n"\
+"{\n"\
+"  position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n"\
+"  position += 4;  //moving position indicator\n"\
+"  obj.assign((int32_t*)((char*)data+position),(int32_t*)((char*)data+position)+sequenceentries);  //putting data into container\n"\
+"  position += sequenceentries*4;  //moving position indicator\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t s::read_struct(const void *data, size_t position)\n"\
+"{\n"\
+"  o() = *((uint8_t*)((char*)data+position));  //reading bytes for member: o()\n"\
+"  position += 1;  //moving position indicator\n"\
+"  position = typedef_read_td_1(t(), data, position);\n"\
+"  return position;\n"\
+"}\n\n"
+
+#define TDKH "size_t typedef_write_td_1(const td_1 &obj, void* data, size_t position);\n\n"\
+"size_t typedef_write_size_td_1(const td_1 &obj, size_t position);\n\n"\
+"size_t typedef_read_td_1(td_1 &obj, void* data, size_t position);\n\n"\
+"size_t typedef_key_stream_td_1(const td_1 &obj, void *data, size_t position);\n\n"\
+"size_t typedef_key_size_td_1(const td_1 &obj, size_t position);\n\n"\
+"size_t typedef_key_max_size_td_1(const td_1 &obj, size_t position);\n\n"
+
 #define NSE "namespace N\n" \
 "{\n\n" \
 "} //end namespace N\n\n"
@@ -2186,8 +2308,8 @@ void test_keys_typedef()
   idl_streamer_output_t* generated = create_idl_streamer_output();
   idl_streamers_generate(tree, generated);
 
-  CU_ASSERT_STRING_EQUAL("", get_ostream_buffer(get_idl_streamer_impl_buf(generated)));  //not yet implemented
-  CU_ASSERT_STRING_EQUAL("", get_ostream_buffer(get_idl_streamer_head_buf(generated)));  //not yet implemented
+  CU_ASSERT_STRING_EQUAL(TDKI, get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+  CU_ASSERT_STRING_EQUAL(TDKH, get_ostream_buffer(get_idl_streamer_head_buf(generated)));
   
   destruct_idl_streamer_output(generated);
   idl_delete_tree(tree);
@@ -2292,9 +2414,9 @@ CU_Test(streamer_generator, bounded_sequence)
   test_bounded_sequence();
 }
 
-CU_Test(streamer_generator, typedef_resolution)
+CU_Test(streamer_generator, typedef_resolution, .disabled =true)  //not working at the moment, therefore skipping
 {
-  //test_typedef_resolution();  //not working at the moment, therefore skipping
+  test_typedef_resolution();
 }
 
 CU_Test(streamer_generator, key_base)
@@ -2309,5 +2431,5 @@ CU_Test(streamer_generator, key_struct)
 
 CU_Test(streamer_generator, key_typedef)
 {
-  //test_keys_typedef();  //not working yet, therefore skipping
+  test_keys_typedef();
 }


### PR DESCRIPTION
Fixed the following bugs:
- typedef function calls
- 32 windows not generating code for arrays of instances correctly
Added filtering so no code is generated for included files.