### PR TITLE
Several fixes

### DIFF
--- a/src/ddscxx/include/dds/sub/LoanedSamples.hpp
+++ b/src/ddscxx/include/dds/sub/LoanedSamples.hpp
@@ -121,6 +121,14 @@ public:
      */
     LoanedSamples(const LoanedSamples& other);
 
+    /**
+     * Copy-assigns a LoanedSamples instance to another.
+     *
+     * No actual data samples are copied.<br>
+     * Just references and reference counts are updated.
+     */
+    LoanedSamples& operator=(const LoanedSamples& other) = default;
+
 
 public:
     /**

--- a/src/ddscxx/include/dds/sub/cond/TQueryCondition.hpp
+++ b/src/ddscxx/include/dds/sub/cond/TQueryCondition.hpp
@@ -112,7 +112,7 @@ public:
      * @param query   The query to filter on the locally available data.
      * @param status  A mask, which selects only those samples with the desired
      *                sample/view/instance states.
-     * @tparam functor The functor to be called when the QueryCondition triggers.
+     * @param  functor The functor to be called when the QueryCondition triggers.
      * @throw  dds::core::Exception
      */
     template <typename FUN>
@@ -136,8 +136,8 @@ public:
      * See @ref anchor_dds_sub_cond_readcondition_state_mask "State mask info" in ReadCondition.
      *
      * @param dr         Query associated DataReader.
-     * @param expression @ref anchor_dds_sub_query_expression "Query expression"
-     * @param params     @ref anchor_dds_sub_query_expression "Query expression parameters"
+     * @param expression for more information: @ref anchor_dds_sub_query_expression "Query expression"
+     * @param params     for more information: @ref anchor_dds_sub_query_expression "Query expression parameters"
      * @param status     A mask, which selects only those samples with the desired
      *                   sample/view/instance states.
      * @throw dds::core::Exception
@@ -178,8 +178,8 @@ public:
      * See @ref anchor_dds_sub_cond_readcondition_state_mask "State mask info" in ReadCondition.
      *
      * @param dr         Query associated DataReader.
-     * @param expression @ref anchor_dds_sub_query_expression "Query expression"
-     * @param params     @ref anchor_dds_sub_query_expression "Query expression parameters"
+     * @param expression for more information: @ref anchor_dds_sub_query_expression "Query expression"
+     * @param params     for more information: @ref anchor_dds_sub_query_expression "Query expression parameters"
      * @param status     A mask, which selects only those samples with the desired
      *                   sample/view/instance states.
      * @throw dds::core::Exception
@@ -210,8 +210,7 @@ public:
     /**
      * Set the Query expression.
      *
-     * @param expr @ref anchor_dds_sub_query_expression "SQL expression"
-     * @return void
+     * @param expr for more information: @ref anchor_dds_sub_query_expression "SQL expression"
      * @throw  dds::core::Exception
      */
     void expression(const std::string& expr);
@@ -275,9 +274,8 @@ public:
      *
      * See @ref anchor_dds_sub_query_expression "SQL expression info"
      *
-     * @tparam begin Iterator pointing to the beginning of the parameters to set
-     * @tparam end   Iterator pointing to the end of the parameters to set
-     * @return void
+     * @param  begin Iterator pointing to the beginning of the parameters to set
+     * @param  end   Iterator pointing to the end of the parameters to set
      * @throw  dds::core::Exception
      */
     template<typename FWIterator>
@@ -289,7 +287,6 @@ public:
      * See @ref anchor_dds_sub_query_expression "SQL expression info"
      *
      * @param param The parameter to add
-     * @return void
      * @throw  dds::core::Exception
      */
     void add_parameter(const std::string& param);

--- a/src/ddscxx/include/dds/sub/cond/TReadCondition.hpp
+++ b/src/ddscxx/include/dds/sub/cond/TReadCondition.hpp
@@ -109,7 +109,7 @@ public:
      * @param  dr       The DataReader to associate with the ReadCondition.
      * @param  status   A mask, which selects only those samples with the desired
      *                  sample/view/instance states.
-     * @tparam functor The functor to be called when the ReadCondition triggers.
+     * @param  functor The functor to be called when the ReadCondition triggers.
      * @throw  dds::core::Exception
      */
     template <typename FUN>

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -169,7 +169,7 @@ void ddscxx_serdata<T>::resize(size_t requested_size)
   m_size = requested_size + n_pad_bytes;
 
   // zero the very end. The caller isn't necessarily going to overwrite it.
-  std::memset(calc_offset(m_data.get(), requested_size), '\0', n_pad_bytes);
+  std::memset(calc_offset(m_data.get(), (ptrdiff_t)requested_size), '\0', n_pad_bytes);
 }
 
 template <typename T>
@@ -210,7 +210,7 @@ template <typename T>
 void serdata_to_ser(const struct ddsi_serdata* dcmn, size_t off, size_t sz, void* buf)
 {
   auto d = static_cast<const ddscxx_serdata<T>*>(dcmn);
-  memcpy(buf, calc_offset(d->data(), off), sz);
+  memcpy(buf, calc_offset(d->data(), (ptrdiff_t)off), sz);
 }
 
 template <typename T>
@@ -219,10 +219,7 @@ ddsi_serdata_t *serdata_to_ser_ref(
   size_t sz, ddsrt_iovec_t* ref)
 {
   auto d = static_cast<const ddscxx_serdata<T>*>(dcmn);
-  uintptr_t a, b;
-  a = (uintptr_t)d->data();
-  b = (uintptr_t)calc_offset(d->data(), off);
-  ref->iov_base = calc_offset(d->data(), off);
+  ref->iov_base = calc_offset(d->data(), (ptrdiff_t)off);
   ref->iov_len = (ddsrt_iov_len_t)sz;
   return ddsi_serdata_ref(d);
 }

--- a/src/idlcxx/src/backendCpp11Type.c
+++ b/src/idlcxx/src/backendCpp11Type.c
@@ -1300,6 +1300,7 @@ cpp11_scope_walk(idl_backend_ctx ctx, const idl_node_t *node)
 
 typedef enum
 {
+  idl_no_dep      = 0x0,
   idl_string_dep  = 0x01 << 0,
   idl_array_dep   = 0x01 << 1,
   idl_vector_dep  = 0x01 << 2,
@@ -1343,7 +1344,7 @@ get_util_dependencies(idl_backend_ctx ctx, const idl_node_t *node)
 static void
 idl_generate_include_statements(idl_backend_ctx ctx, const idl_tree_t *parse_tree)
 {
-  idl_include_dep util_depencencies = 0;
+  idl_include_dep util_depencencies = idl_no_dep;
   uint32_t nr_includes = 0;
 
   /* First determine the list of files included by our IDL file itself. */

--- a/src/idlcxx/src/backendCpp11Type.c
+++ b/src/idlcxx/src/backendCpp11Type.c
@@ -239,7 +239,8 @@ generate_streamer_interfaces(idl_backend_ctx ctx)
   idl_file_out_printf(ctx, "size_t read_struct(const void* data, size_t position);\n");
   idl_file_out_printf(ctx, "size_t key_size(size_t position) const;\n");
   idl_file_out_printf(ctx, "size_t key_max_size(size_t position) const;\n");
-  idl_file_out_printf(ctx, "size_t key_stream(void* data, size_t position) const;\n");
+  idl_file_out_printf(ctx, "size_t key_write(void* data, size_t position) const;\n");
+  idl_file_out_printf(ctx, "size_t key_read(const void* data, size_t position);\n");
   idl_file_out_printf(ctx, "bool key(ddsi_keyhash_t& hash) const;\n");
   idl_indent_decr(ctx);
   return IDL_RETCODE_OK;

--- a/src/idlcxx/src/streamer_generator.c
+++ b/src/idlcxx/src/streamer_generator.c
@@ -40,19 +40,23 @@ format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->key_max_size_stream, _st
 #define format_key_max_size_intermediate_stream(indent,ctx,_str,...) \
 format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->key_max_size_intermediate_stream, _str, ##__VA_ARGS__);
 
-#define format_key_stream(indent,ctx,_str,...) \
-format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->key_stream, _str, ##__VA_ARGS__);
+#define format_key_write_stream(indent,ctx,_str,...) \
+format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->key_write_stream, _str, ##__VA_ARGS__);
+
+#define format_key_read_stream(indent,ctx,_str,...) \
+format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->key_read_stream, _str, ##__VA_ARGS__);
 
 #define format_write_stream(indent,ctx,key,_str,...) \
 format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->write_stream, _str, ##__VA_ARGS__); \
-if (key) {format_key_stream(indent,ctx,_str, ##__VA_ARGS__);}
+if (key) {format_key_write_stream(indent,ctx,_str, ##__VA_ARGS__);}
 
 #define format_write_size_stream(indent,ctx,key,_str,...) \
 format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->write_size_stream, _str, ##__VA_ARGS__); \
 if (key) {format_key_size_stream(indent,ctx,_str, ##__VA_ARGS__);}
 
-#define format_read_stream(indent,ctx,_str,...) \
-format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->read_stream, _str, ##__VA_ARGS__);
+#define format_read_stream(indent,ctx,key,_str,...) \
+format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->read_stream, _str, ##__VA_ARGS__); \
+if (key) {format_key_read_stream(indent,ctx,_str, ##__VA_ARGS__);}
 
 #define namespace_declaration "namespace %s\n"
 #define namespace_closure "} //end " namespace_declaration "\n"
@@ -100,12 +104,14 @@ format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->read_stream, _str, ##__V
 #define seq_typedef_write_size sequence_iterate position_set "%stypedef_write_size_%s(%s[_i], position);\n"
 #define seq_typedef_read_copy sequence_iterate position_set "%stypedef_read_%s(%s[_i], data, position);\n"
 #define seq_typedef_key_max_size sequence_iterate_checked position_set "%stypedef_key_max_size_%s(%s[_i], position);\n"
-#define seq_typedef_key sequence_iterate position_set "%stypedef_key_stream_%s(%s[_i], data, position);\n"
+#define seq_typedef_key_write sequence_iterate position_set "%stypedef_key_write_%s(%s[_i], data, position);\n"
+#define seq_typedef_key_read sequence_iterate position_set "%stypedef_key_read_%s(%s[_i], data, position);\n"
 #define seq_typedef_key_size sequence_iterate position_set "%stypedef_key_size_%s(%s[_i], position);\n"
 #define seq_struct_write sequence_iterate position_set "%s[_i].write_struct(data,position);\n"
 #define seq_struct_write_size sequence_iterate position_set "%s[_i].write_size(position);\n"
 #define seq_struct_read_copy sequence_iterate position_set "%s[_i].read_struct(data, position);\n"
-#define seq_struct_key sequence_iterate position_set "%s[_i].key_stream(data,position);\n"
+#define seq_struct_key_write sequence_iterate position_set "%s[_i].key_write(data,position);\n"
+#define seq_struct_key_read sequence_iterate position_set "%s[_i].key_read(data,position);\n"
 #define seq_struct_key_size sequence_iterate position_set "%s[_i].key_size(position);\n"
 #define seq_struct_key_max_size sequence_iterate_checked position_set "%s[_i].key_max_size(position);"
 #define seq_incr position_incr "sequenceentries*%d;"
@@ -114,11 +120,13 @@ format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->read_stream, _str, ##__V
 #define arr_struct_write array_iterate position_set "%s[_i].write_struct(data, position);\n"
 #define arr_struct_write_size array_iterate position_set "%s[_i].write_size(position);\n"
 #define arr_struct_read array_iterate position_set "%s[_i].read_struct(data, position);\n"
-#define arr_struct_key array_iterate position_set "%s[_i].key_stream(data, position);\n"
+#define arr_struct_key_write array_iterate position_set "%s[_i].key_write(data, position);\n"
+#define arr_struct_key_read array_iterate position_set "%s[_i].key_read(data, position);\n"
 #define arr_struct_key_size array_iterate position_set "%s[_i].key_size(position);\n"
 #define arr_struct_key_max_size array_iterate key_max_size_check position_set "%s[_i].key_max_size(position);\n"
 #define instance_write_func position_set "%s.write_struct(data, position);\n"
-#define instance_key_write_func position_set "%s.key_stream(data, position);\n"
+#define instance_key_write_func position_set "%s.key_write(data, position);\n"
+#define instance_key_read_func position_set "%s.key_read(data, position);\n"
 #define instance_size_func_calc position_set "%s.write_size(position);\n"
 #define instance_key_size_func_calc position_set "%s.key_size(position);\n"
 #define instance_key_max_size_func_calc key_max_size_check position_set "%s.key_max_size(position);\n"
@@ -132,20 +140,23 @@ format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->read_stream, _str, ##__V
 #define read_func_define "size_t %s::read_struct(const void *data, size_t position)"
 #define key_size_define "size_t %s::key_size(size_t position) const"
 #define key_max_size_define "size_t %s::key_max_size(size_t position) const"
-#define key_stream_define "size_t %s::key_stream(void *data, size_t position) const"
+#define key_write_define "size_t %s::key_write(void *data, size_t position) const"
+#define key_read_define "size_t %s::key_read(const void *data, size_t position)"
 #define key_calc_define "bool %s::key(ddsi_keyhash_t &hash) const"
 #define typedef_write_define "size_t typedef_write_%s(const %s &obj, void* data, size_t position)"
 #define typedef_write_size_define "size_t typedef_write_size_%s(const %s &obj, size_t position)"
 #define typedef_read_define "size_t typedef_read_%s(%s &obj, const void* data, size_t position)"
 #define typedef_key_size_define "size_t typedef_key_size_%s(const %s &obj, size_t position)"
 #define typedef_key_max_size_define "size_t typedef_key_max_size_%s(const %s &obj, size_t position)"
-#define typedef_key_stream_define "size_t typedef_key_stream_%s(const %s &obj, void *data, size_t position)"
+#define typedef_key_write_define "size_t typedef_key_write_%s(const %s &obj, void *data, size_t position)"
+#define typedef_key_read_define "size_t typedef_key_read_%s(%s &obj, const void *data, size_t position)"
 #define typedef_write_call position_set "%stypedef_write_%s(%s, data, position);\n"
 #define typedef_write_size_call position_set "%stypedef_write_size_%s(%s, position);\n"
 #define typedef_read_call position_set "%stypedef_read_%s(%s, data, position);\n"
 #define typedef_key_size_call position_set "%stypedef_key_size_%s(%s, position);\n"
 #define typedef_key_max_size_call position_set "%stypedef_key_max_size_%s(%s, position);\n"
-#define typedef_key_stream_call position_set "%stypedef_key_stream_%s(%s, data, position);\n"
+#define typedef_key_write_call position_set "%stypedef_key_write_%s(%s, data, position);\n"
+#define typedef_key_read_call position_set "%stypedef_key_read_%s(%s, data, position);\n"
 #define union_case_max_check "if (case_max != UINT_MAX) "
 #define union_case_max_incr union_case_max_check "case_max += "
 #define union_case_max_set "case_max = "
@@ -204,7 +215,8 @@ struct context
   idl_ostream_t* key_size_stream;
   idl_ostream_t* key_max_size_stream;
   idl_ostream_t* key_max_size_intermediate_stream;
-  idl_ostream_t* key_stream;
+  idl_ostream_t* key_write_stream;
+  idl_ostream_t* key_read_stream;
   size_t depth;
   functioncontents_t streamer_funcs;
   functioncontents_t key_funcs;
@@ -351,7 +363,8 @@ context_t* create_context(const char* name)
     ptr->key_size_stream = create_idl_ostream(NULL);
     ptr->key_max_size_stream = create_idl_ostream(NULL);
     ptr->key_max_size_intermediate_stream = create_idl_ostream(NULL);
-    ptr->key_stream = create_idl_ostream(NULL);
+    ptr->key_write_stream = create_idl_ostream(NULL);
+    ptr->key_read_stream = create_idl_ostream(NULL);
     reset_function_contents(&ptr->streamer_funcs);
     reset_function_contents(&ptr->key_funcs);
   }
@@ -397,7 +410,8 @@ void close_context(context_t* ctx, idl_streamer_output_t* str)
   transfer_ostream_buffer(ctx->write_size_stream, ctx->str->impl_stream);
   transfer_ostream_buffer(ctx->key_size_stream, ctx->str->impl_stream);
   transfer_ostream_buffer(ctx->key_max_size_stream, ctx->str->impl_stream);
-  transfer_ostream_buffer(ctx->key_stream, ctx->str->impl_stream);
+  transfer_ostream_buffer(ctx->key_write_stream, ctx->str->impl_stream);
+  transfer_ostream_buffer(ctx->key_read_stream, ctx->str->impl_stream);
   transfer_ostream_buffer(ctx->read_stream, ctx->str->impl_stream);
 
   if (get_ostream_buffer_position(ctx->str->impl_stream) != 0)
@@ -424,7 +438,8 @@ void close_context(context_t* ctx, idl_streamer_output_t* str)
   destruct_idl_ostream(ctx->key_size_stream);
   destruct_idl_ostream(ctx->key_max_size_stream);
   destruct_idl_ostream(ctx->key_max_size_intermediate_stream);
-  destruct_idl_ostream(ctx->key_stream);
+  destruct_idl_ostream(ctx->key_write_stream);
+  destruct_idl_ostream(ctx->key_read_stream);
   destruct_idl_ostream(ctx->read_stream);
 
   destruct_idl_streamer_output(ctx->str);
@@ -437,20 +452,19 @@ void resolve_namespace(idl_node_t* node, char** up)
   if (!node)
     return;
 
+  if (!*up)
+    *up = idl_strdup("");
+
   if (idl_is_module(node))
   {
     idl_module_t* mod = (idl_module_t*)node;
-    if (*up)
-    {
-      char *temp = NULL;
-      idl_asprintf(&temp, "%s::%s", idl_identifier(mod), *up);
-      free(*up);
-      *up = temp;
-    }
-    else
-    {
-      idl_asprintf(up, "%s::", idl_identifier(mod));
-    }
+    char* cppname = get_cpp11_name(idl_identifier(mod));
+    assert(cppname);
+    char *temp = NULL;
+    idl_asprintf(&temp, "%s::%s", cppname, *up);
+    free(*up);
+    *up = temp;
+    free(cppname);
   }
 
   resolve_namespace(node->parent, up);
@@ -583,11 +597,12 @@ idl_retcode_t write_instance_funcs(context_t* ctx, const char* write_accessor, c
   {
     format_write_stream(1, ctx, false, arr_struct_write, entries, write_accessor);
     format_write_size_stream(1, ctx, false, arr_struct_write_size, entries, write_accessor);
-    format_read_stream(1, ctx, arr_struct_read, entries, read_accessor);
+    format_read_stream(1, ctx, false, arr_struct_read, entries, read_accessor);
 
     if (is_key)
     {
-      format_key_stream(1, ctx, arr_struct_key, entries, write_accessor);
+      format_key_write_stream(1, ctx, arr_struct_key_write, entries, write_accessor);
+      format_key_read_stream(1, ctx, arr_struct_key_read, entries, read_accessor);
       format_key_size_stream(1, ctx, arr_struct_key_size, entries, write_accessor);
       if (ctx->in_union)
       {
@@ -603,11 +618,12 @@ idl_retcode_t write_instance_funcs(context_t* ctx, const char* write_accessor, c
   {
     format_write_stream(1, ctx, false , instance_write_func, write_accessor);
     format_write_size_stream(1, ctx, false, instance_size_func_calc, write_accessor);
-    format_read_stream(1, ctx, instance_read_func, read_accessor);
+    format_read_stream(1, ctx, false, instance_read_func, read_accessor);
 
     if (is_key)
     {
-      format_key_stream(1, ctx, instance_key_write_func, write_accessor);
+      format_key_write_stream(1, ctx, instance_key_write_func, write_accessor);
+      format_key_read_stream(1, ctx, instance_key_read_func, read_accessor);
       format_key_size_stream(1, ctx, instance_key_size_func_calc, write_accessor);
       if (ctx->in_union)
       {
@@ -662,9 +678,9 @@ idl_retcode_t check_alignment(context_t* ctx, int bytewidth, bool is_key)
     format_write_size_stream(0, ctx, false, buffer);
     format_write_size_stream(0, ctx, false, align_comment);
 
-    format_read_stream(1, ctx, position_incr);
-    format_read_stream(0, ctx, buffer);
-    format_read_stream(0, ctx, align_comment);
+    format_read_stream(1, ctx, false, position_incr);
+    format_read_stream(0, ctx, false, buffer);
+    format_read_stream(0, ctx, false, align_comment);
 
     ctx->streamer_funcs.accumulatedalignment = 0;
     ctx->streamer_funcs.currentalignment = bytewidth;
@@ -685,22 +701,27 @@ idl_retcode_t check_alignment(context_t* ctx, int bytewidth, bool is_key)
     {
       if (!ctx->key_funcs.alignmentpresent)
       {
-        format_key_stream(1, ctx, "  size_t alignmentbytes = ");
+        format_key_write_stream(1, ctx, "  size_t alignmentbytes = ");
         ctx->key_funcs.alignmentpresent = true;
       }
       else
       {
-        format_key_stream(1, ctx, "  alignmentbytes = ");
+        format_key_write_stream(1, ctx, "  alignmentbytes = ");
       }
 
-      format_key_stream(0, ctx, buffer);
-      format_key_stream(0, ctx, align_comment);
-      format_key_stream(1, ctx, primitive_write_func_alignment);
-      format_key_stream(1, ctx, position_incr_alignment incr_comment);
+      format_key_write_stream(0, ctx, buffer);
+      format_key_write_stream(0, ctx, align_comment);
+      format_key_write_stream(1, ctx, primitive_write_func_alignment);
+      format_key_write_stream(1, ctx, position_incr_alignment incr_comment);
 
       format_key_size_stream(1, ctx, position_incr);
       format_key_size_stream(0, ctx, buffer);
       format_key_size_stream(0, ctx, align_comment);
+
+      format_key_read_stream(1, ctx, position_incr);
+      format_key_read_stream(0, ctx, buffer);
+      format_key_read_stream(0, ctx, align_comment);
+
       if (ctx->in_union)
       {
         format_key_max_size_intermediate_stream(1, ctx, key_max_size_check);
@@ -743,14 +764,15 @@ idl_retcode_t add_null(context_t* ctx, int nbytes, bool stream, bool is_key)
     format_write_stream(1, ctx, false, primitive_write_func_padding, nbytes);
     format_write_stream(1, ctx, false, primitive_incr_pos incr_comment, nbytes);
     format_write_size_stream(1, ctx, false, primitive_incr_pos padding_comment, nbytes);
-    format_read_stream(1, ctx, primitive_incr_pos padding_comment, nbytes);
+    format_read_stream(1, ctx, false, primitive_incr_pos padding_comment, nbytes);
   }
 
   if (is_key)
   {
-    format_key_stream(1, ctx, primitive_write_func_padding, nbytes);
-    format_key_stream(1, ctx, primitive_incr_pos incr_comment, nbytes);
+    format_key_write_stream(1, ctx, primitive_write_func_padding, nbytes);
+    format_key_write_stream(1, ctx, primitive_incr_pos incr_comment, nbytes);
     format_key_size_stream(1, ctx, primitive_incr_pos padding_comment, nbytes);
+    format_key_read_stream(1, ctx, primitive_incr_pos padding_comment, nbytes);
     if (ctx->in_union)
     {
       format_key_max_size_intermediate_stream(1, ctx, union_case_max_incr " %d;", nbytes);
@@ -769,8 +791,9 @@ char* determine_cast(idl_node_t* typespec)
 {
   if (idl_is_enum(typespec))
   {
-    char* ns = idl_strdup(""), *returnval = NULL;
+    char* ns = NULL, *returnval = NULL;
     resolve_namespace(typespec, &ns);
+    assert(ns);
 
     idl_asprintf(&returnval, "%s%s", ns, ((idl_enum_t*)typespec)->name->identifier);
     free(ns);
@@ -862,8 +885,8 @@ idl_retcode_t process_known_width(context_t* ctx, const char* accessor, idl_node
     }
   }
 
-  format_read_stream(1, ctx, primitive_read_func_read, accessor, cast, accessor);
-  format_read_stream(1, ctx, primitive_incr_pos incr_comment, bytewidth);
+  format_read_stream(1, ctx, is_key, primitive_read_func_read, accessor, cast, accessor);
+  format_read_stream(1, ctx, is_key, primitive_incr_pos incr_comment, bytewidth);
   free(cast);
 
   return IDL_RETCODE_OK;
@@ -885,13 +908,13 @@ idl_retcode_t process_known_width_sequence(context_t* ctx, const char* accessor,
 
   if (bytewidth > 1)
   {
-    format_read_stream(1, ctx, seq_primitive_read, accessor, cast, cast);
+    format_read_stream(1, ctx, is_key, seq_primitive_read, accessor, cast, cast);
   }
   else
   {
-    format_read_stream(1, ctx, seq_primitive_read_nocast, accessor);
+    format_read_stream(1, ctx, is_key, seq_primitive_read_nocast, accessor);
   }
-  format_read_stream(1, ctx, seq_incr incr_comment, bytewidth);
+  format_read_stream(1, ctx, is_key, seq_incr incr_comment, bytewidth);
   free(cast);
 
   return IDL_RETCODE_OK;
@@ -904,12 +927,12 @@ idl_retcode_t process_sequence_entries(context_t* ctx, const char* accessor, boo
 
   check_alignment(ctx, 4, is_key);
 
-  format_read_stream(1, ctx, "  ");
+  format_read_stream(1, ctx, is_key, "  ");
   format_write_stream(1, ctx, is_key, "  ");
   format_write_size_stream(1, ctx, is_key, "  ");
   if (!ctx->streamer_funcs.sequenceentriespresent)
   {
-    format_read_stream(0, ctx, "uint32_t ");
+    format_read_stream(0, ctx, false, "uint32_t ");
     format_write_stream(0, ctx, false, "uint32_t ");
     format_write_size_stream(0, ctx, false, "uint32_t ");
     ctx->streamer_funcs.sequenceentriespresent = true;
@@ -917,7 +940,8 @@ idl_retcode_t process_sequence_entries(context_t* ctx, const char* accessor, boo
 
   if (is_key && !ctx->key_funcs.sequenceentriespresent)
   {
-    format_key_stream(0, ctx, "uint32_t ");
+    format_key_write_stream(0, ctx, "uint32_t ");
+    format_key_read_stream(0, ctx, "uint32_t ");
     format_key_size_stream(0, ctx, "uint32_t ");
     ctx->key_funcs.sequenceentriespresent = true;
   }
@@ -940,8 +964,8 @@ idl_retcode_t process_sequence_entries(context_t* ctx, const char* accessor, boo
     }
   }
 
-  format_read_stream(0, ctx, primitive_read_func_seq);
-  format_read_stream(1, ctx, primitive_incr_pos incr_comment, (int)4);
+  format_read_stream(0, ctx, is_key, primitive_read_func_seq);
+  format_read_stream(1, ctx, is_key, primitive_incr_pos incr_comment, (int)4);
 
   return IDL_RETCODE_OK;
 }
@@ -964,8 +988,8 @@ idl_retcode_t process_known_width_array(context_t* ctx, const char *accessor, ui
 
   format_write_size_stream(1, ctx, is_key, primitive_incr_pos bytes_for_member_comment, bytesinarray, accessor);
 
-  format_read_stream(1, ctx, primitive_read_func_array, accessor, bytesinarray, accessor);
-  format_read_stream(1, ctx, primitive_incr_pos incr_comment, bytesinarray);
+  format_read_stream(1, ctx, is_key, primitive_read_func_array, accessor, bytesinarray, accessor);
+  format_read_stream(1, ctx, is_key, primitive_incr_pos incr_comment, bytesinarray);
 
   if (is_key)
   {
@@ -998,7 +1022,7 @@ idl_retcode_t process_template(context_t* ctx, idl_declarator_t* decl, idl_type_
   {
     format_write_size_stream(1,ctx, is_key, array_iterate " {\n",entries);
     format_write_stream(1, ctx, is_key, array_iterate " {\n", entries);
-    format_read_stream(1, ctx, array_iterate " {\n", entries);
+    format_read_stream(1, ctx, is_key, array_iterate " {\n", entries);
 
     ctx->depth++;
   }
@@ -1098,18 +1122,21 @@ idl_retcode_t process_template(context_t* ctx, idl_declarator_t* decl, idl_type_
     {
       if (idl_is_typedef(ispec))
       {
-        char* ns = idl_strdup("");
+        char* ns = NULL;
         idl_typedef_t* td = ((idl_typedef_t*)ispec);
         resolve_namespace((idl_node_t*)td->declarators, &ns);
+        assert(ns);
         format_write_stream(1, ctx, false, seq_typedef_write, ns, idl_identifier(td->declarators), accessor);
         format_write_size_stream(1, ctx, false, seq_typedef_write_size, ns, idl_identifier(td->declarators), accessor);
-        format_read_stream(1, ctx, seq_read_resize, accessor);
-        format_read_stream(1, ctx, seq_typedef_read_copy, ns, idl_identifier(td->declarators), accessor);
+        format_read_stream(1, ctx, false, seq_read_resize, accessor);
+        format_read_stream(1, ctx, false, seq_typedef_read_copy, ns, idl_identifier(td->declarators), accessor);
         
         if (is_key)
         {
-          format_key_stream(1, ctx, seq_typedef_key, ns, idl_identifier(td->declarators), accessor);
+          format_key_write_stream(1, ctx, seq_typedef_key_write, ns, idl_identifier(td->declarators), accessor);
           format_key_size_stream(1, ctx, seq_typedef_key_size, ns, idl_identifier(td->declarators), accessor);
+          format_key_read_stream(1, ctx, seq_read_resize, accessor);
+          format_key_read_stream(1, ctx, seq_typedef_key_read, ns, idl_identifier(td->declarators), accessor);
           if (bound)
           {
             //bounded sequences have a fixed max key size
@@ -1142,13 +1169,15 @@ idl_retcode_t process_template(context_t* ctx, idl_declarator_t* decl, idl_type_
       {
         format_write_stream(1, ctx, false, seq_struct_write, accessor);
         format_write_size_stream(1, ctx, false, seq_struct_write_size, accessor);
-        format_read_stream(1, ctx, seq_read_resize, accessor);
-        format_read_stream(1, ctx, seq_struct_read_copy, accessor);
+        format_read_stream(1, ctx, false, seq_read_resize, accessor);
+        format_read_stream(1, ctx, false, seq_struct_read_copy, accessor);
 
         if (is_key)
         {
-          format_key_stream(1, ctx, seq_struct_key, accessor);
+          format_key_write_stream(1, ctx, seq_struct_key_write, accessor);
           format_key_size_stream(1, ctx, seq_struct_key_size, accessor);
+          format_key_read_stream(1, ctx, seq_read_resize, accessor);
+          format_key_read_stream(1, ctx, seq_struct_key_read, accessor);
           if (bound)
           {
             //bounded sequences have a fixed max key size
@@ -1207,7 +1236,7 @@ idl_retcode_t process_template(context_t* ctx, idl_declarator_t* decl, idl_type_
 
     format_write_size_stream(1, ctx, is_key, "  }\n");
     format_write_stream(1, ctx, is_key, "  }\n");
-    format_read_stream(1, ctx, "  }\n");
+    format_read_stream(1, ctx, is_key, "  }\n");
   }
 
   if (accessor)
@@ -1265,17 +1294,21 @@ idl_retcode_t process_constructed(context_t* ctx, idl_node_t* node)
     format_write_size_stream(1, ctx, false, write_size_func_define "\n", cpp11name);
     format_write_size_stream(1, ctx, false, open_block);
 
-    format_key_stream(1, ctx, key_stream_define "\n", cpp11name);
-    format_key_stream(1, ctx, open_block);
-    format_key_stream(1, ctx, "  (void)data;\n");
+    format_key_write_stream(1, ctx, key_write_define "\n", cpp11name);
+    format_key_write_stream(1, ctx, open_block);
+    format_key_write_stream(1, ctx, "  (void)data;\n");
 
     format_key_size_stream(1, ctx, key_size_define "\n", cpp11name);
     format_key_size_stream(1, ctx, open_block);
     format_key_max_size_stream(1, ctx, key_max_size_define "\n", cpp11name);
     format_key_max_size_stream(1, ctx, open_block);
 
-    format_read_stream(1, ctx, read_func_define "\n", cpp11name);
-    format_read_stream(1, ctx, open_block);
+    format_read_stream(1, ctx, false, read_func_define "\n", cpp11name);
+    format_read_stream(1, ctx, false, open_block);
+
+    format_key_read_stream(1, ctx, key_read_define "\n", cpp11name);
+    format_key_read_stream(1, ctx, open_block);
+    format_key_read_stream(1, ctx, "  (void)data;\n");
 
     ctx->streamer_funcs.currentalignment = -1;
     ctx->streamer_funcs.alignmentpresent = false;
@@ -1288,10 +1321,10 @@ idl_retcode_t process_constructed(context_t* ctx, idl_node_t* node)
       if (_struct->base_type)
       {
         char* base_cpp11name = get_cpp11_name(idl_identifier(_struct->base_type));
-        char* ns = idl_strdup("");
+        char* ns = NULL;
         assert(base_cpp11name);
-        assert(ns);
         resolve_namespace((idl_node_t*)_struct->base_type, &ns);
+        assert(ns);
         char* write_accessor = NULL, *read_accessor = NULL;
         if (idl_asprintf(&write_accessor, const_ref_cast, ns, base_cpp11name) != -1 &&
             idl_asprintf(&read_accessor, ref_cast, ns, base_cpp11name) != -1)
@@ -1317,14 +1350,14 @@ idl_retcode_t process_constructed(context_t* ctx, idl_node_t* node)
       idl_union_t* _union = (idl_union_t*)node;
       idl_switch_type_spec_t* st = _union->switch_type_spec;
 
-      format_read_stream(1, ctx, union_clear_func);
+      format_read_stream(1, ctx, true, union_clear_func);
       process_known_width(ctx, "_d()", st, true);
       format_write_size_stream(1, ctx, true, union_switch);
       format_write_size_stream(1, ctx, true, "  {\n");
       format_write_stream(1, ctx, true, union_switch);
       format_write_stream(1, ctx, true, "  {\n");
-      format_read_stream(1, ctx, union_switch);
-      format_read_stream(1, ctx, "  {\n");
+      format_read_stream(1, ctx, true, union_switch);
+      format_read_stream(1, ctx, true, "  {\n");
 
       ctx->in_union = true;
       format_key_max_size_intermediate_stream(1, ctx, "  size_t union_max = position;\n");
@@ -1344,15 +1377,15 @@ idl_retcode_t process_constructed(context_t* ctx, idl_node_t* node)
 
       format_write_stream(1, ctx, true, "  }\n");
       format_write_size_stream(1, ctx, true, "  }\n");
-      format_read_stream(1, ctx, "  }\n");
+      format_read_stream(1, ctx, true, "  }\n");
     }
 
     format_write_size_stream(1, ctx, true, position_return);
     format_write_size_stream(1, ctx, true, close_function);
     format_write_stream(1, ctx, true, position_return);
     format_write_stream(1, ctx, true, close_function);
-    format_read_stream(1, ctx, position_return);
-    format_read_stream(1, ctx, close_function);
+    format_read_stream(1, ctx, true, position_return);
+    format_read_stream(1, ctx, true, close_function);
 
     if (ctx->key_max_size_unlimited)
     {
@@ -1368,30 +1401,30 @@ idl_retcode_t process_constructed(context_t* ctx, idl_node_t* node)
     }
 
     format_key_max_size_stream(1, ctx, close_function);
-    format_key_stream(1, ctx, key_calc_define "\n", cpp11name);
-    format_key_stream(1, ctx, "{\n");
-    format_key_stream(1, ctx, "  size_t sz = key_size(0);\n");
-    format_key_stream(1, ctx, "  size_t padding = 16 - sz%%16;\n");
-    format_key_stream(1, ctx, "  if (sz != 0 && padding == 16) padding = 0;\n");
-    format_key_stream(1, ctx, "  std::vector<unsigned char> buffer(sz+padding);\n");
-    format_key_stream(1, ctx, "  memset(buffer.data()+sz,0x0,padding);\n");
-    format_key_stream(1, ctx, "  key_stream(buffer.data(),0);\n");
-    format_key_stream(1, ctx, "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n");
-    format_key_stream(1, ctx, "  if (fptr == NULL)\n");
-    format_key_stream(1, ctx, "  {\n");
-    format_key_stream(1, ctx, "    if (key_max_size(0) <= 16)\n");
-    format_key_stream(1, ctx, "    {\n");
-    format_key_stream(1, ctx, "      //bind to unmodified function which just copies buffer into the keyhash\n");
-    format_key_stream(1, ctx, "      fptr = &org::eclipse::cyclonedds::topic::simple_key;\n")
-    format_key_stream(1, ctx, "    }\n");
-    format_key_stream(1, ctx, "    else\n");
-    format_key_stream(1, ctx, "    {\n");
-    format_key_stream(1, ctx, "      //bind to MD5 hash function\n");
-    format_key_stream(1, ctx, "      fptr = &org::eclipse::cyclonedds::topic::complex_key;\n")
-    format_key_stream(1, ctx, "    }\n");
-    format_key_stream(1, ctx, "  }\n");
-    format_key_stream(1, ctx, "  return (*fptr)(buffer,hash);\n");
-    format_key_stream(1, ctx, close_function);
+    format_key_write_stream(1, ctx, key_calc_define "\n", cpp11name);
+    format_key_write_stream(1, ctx, "{\n");
+    format_key_write_stream(1, ctx, "  size_t sz = key_size(0);\n");
+    format_key_write_stream(1, ctx, "  size_t padding = 16 - sz%%16;\n");
+    format_key_write_stream(1, ctx, "  if (sz != 0 && padding == 16) padding = 0;\n");
+    format_key_write_stream(1, ctx, "  std::vector<unsigned char> buffer(sz+padding);\n");
+    format_key_write_stream(1, ctx, "  memset(buffer.data()+sz,0x0,padding);\n");
+    format_key_write_stream(1, ctx, "  key_write(buffer.data(),0);\n");
+    format_key_write_stream(1, ctx, "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n");
+    format_key_write_stream(1, ctx, "  if (fptr == NULL)\n");
+    format_key_write_stream(1, ctx, "  {\n");
+    format_key_write_stream(1, ctx, "    if (key_max_size(0) <= 16)\n");
+    format_key_write_stream(1, ctx, "    {\n");
+    format_key_write_stream(1, ctx, "      //bind to unmodified function which just copies buffer into the keyhash\n");
+    format_key_write_stream(1, ctx, "      fptr = &org::eclipse::cyclonedds::topic::simple_key;\n")
+    format_key_write_stream(1, ctx, "    }\n");
+    format_key_write_stream(1, ctx, "    else\n");
+    format_key_write_stream(1, ctx, "    {\n");
+    format_key_write_stream(1, ctx, "      //bind to MD5 hash function\n");
+    format_key_write_stream(1, ctx, "      fptr = &org::eclipse::cyclonedds::topic::complex_key;\n")
+    format_key_write_stream(1, ctx, "    }\n");
+    format_key_write_stream(1, ctx, "  }\n");
+    format_key_write_stream(1, ctx, "  return (*fptr)(buffer,hash);\n");
+    format_key_write_stream(1, ctx, close_function);
   }
 
   reset_function_contents(&ctx->streamer_funcs);
@@ -1411,7 +1444,7 @@ idl_retcode_t process_case(context_t* ctx, idl_case_t* _case)
 
   format_write_stream(1, ctx, true, "  {\n");
   format_write_size_stream(1, ctx, true, "  {\n");
-  format_read_stream(1, ctx, "  {\n");
+  format_read_stream(1, ctx, true, "  {\n");
   format_key_max_size_intermediate_stream(1, ctx, "{  //cases\n");
   format_key_max_size_intermediate_stream(1, ctx, "  size_t case_max = position;\n");
   ctx->depth++;
@@ -1425,8 +1458,8 @@ idl_retcode_t process_case(context_t* ctx, idl_case_t* _case)
   format_write_stream(1, ctx, true, union_case_ending);
   format_write_size_stream(1, ctx, true, "  }\n");
   format_write_size_stream(1, ctx, true, union_case_ending);
-  format_read_stream(1, ctx, "  }\n");
-  format_read_stream(1, ctx, union_case_ending);
+  format_read_stream(1, ctx, true, "  }\n");
+  format_read_stream(1, ctx, true, union_case_ending);
 
   ctx->streamer_funcs = sfuncs;
   ctx->key_funcs = kfuncs;
@@ -1460,10 +1493,12 @@ idl_retcode_t process_typedef_definition(context_t* ctx, idl_typedef_t* node)
     format_write_stream(1, ctx, false, open_block);
     format_write_size_stream(1, ctx, false, typedef_write_size_define "\n", tsname, tsname);
     format_write_size_stream(1, ctx, false, open_block);
-    format_read_stream(1, ctx, typedef_read_define "\n", tsname, tsname);
-    format_read_stream(1, ctx, open_block);
-    format_key_stream(1, ctx, typedef_key_stream_define "\n", tsname, tsname);
-    format_key_stream(1, ctx, open_block);
+    format_read_stream(1, ctx, false, typedef_read_define "\n", tsname, tsname);
+    format_read_stream(1, ctx, false, open_block);
+    format_key_write_stream(1, ctx, typedef_key_write_define "\n", tsname, tsname);
+    format_key_write_stream(1, ctx, open_block);
+    format_key_read_stream(1, ctx, typedef_key_read_define "\n", tsname, tsname);
+    format_key_read_stream(1, ctx, open_block);
     format_key_size_stream(1, ctx, typedef_key_size_define "\n", tsname, tsname);
     format_key_size_stream(1, ctx, open_block);
     format_key_max_size_stream(1, ctx, typedef_key_max_size_define "\n", tsname, tsname);
@@ -1473,7 +1508,8 @@ idl_retcode_t process_typedef_definition(context_t* ctx, idl_typedef_t* node)
     format_header_stream(1, ctx, typedef_write_define ";\n\n", tsname, tsname);
     format_header_stream(1, ctx, typedef_write_size_define ";\n\n", tsname, tsname);
     format_header_stream(1, ctx, typedef_read_define ";\n\n", tsname, tsname);
-    format_header_stream(1, ctx, typedef_key_stream_define ";\n\n", tsname, tsname);
+    format_header_stream(1, ctx, typedef_key_write_define ";\n\n", tsname, tsname);
+    format_header_stream(1, ctx, typedef_key_read_define ";\n\n", tsname, tsname);
     format_header_stream(1, ctx, typedef_key_size_define ";\n\n", tsname, tsname);
     format_header_stream(1, ctx, typedef_key_max_size_define ";\n\n", tsname, tsname);
 
@@ -1496,10 +1532,12 @@ idl_retcode_t process_typedef_definition(context_t* ctx, idl_typedef_t* node)
     format_write_stream(1, ctx, false,close_function);
     format_write_size_stream(1, ctx, false, position_return);
     format_write_size_stream(1, ctx, false, close_function);
-    format_read_stream(1, ctx, position_return);
-    format_read_stream(1, ctx, close_function);
-    format_key_stream(1, ctx, position_return);
-    format_key_stream(1, ctx, close_function);
+    format_read_stream(1, ctx, false, position_return);
+    format_read_stream(1, ctx, false, close_function);
+    format_key_write_stream(1, ctx, position_return);
+    format_key_write_stream(1, ctx, close_function);
+    format_key_read_stream(1, ctx, position_return);
+    format_key_read_stream(1, ctx, close_function);
     format_key_size_stream(1, ctx, position_return);
     format_key_size_stream(1, ctx, close_function);
     format_key_max_size_stream(1, ctx, close_function);
@@ -1519,8 +1557,9 @@ idl_retcode_t process_typedef_instance(context_t* ctx, idl_declarator_t* decl, i
   }
   else
   {
-    char* ns = idl_strdup("");  //namespace in which the typedef is declared
+    char* ns = NULL;  //namespace in which the typedef is declared
     resolve_namespace(spec, &ns);
+    assert(ns);
     const char* tdname = idl_identifier(((idl_typedef_t*)spec)->declarators);  //name of the typedef
     char* accessor = NULL;  //call accessing the typedef instance
     if (decl)
@@ -1537,10 +1576,11 @@ idl_retcode_t process_typedef_instance(context_t* ctx, idl_declarator_t* decl, i
 
     format_write_stream(1, ctx, false, typedef_write_call, ns, tdname, accessor);
     format_write_size_stream(1, ctx, false, typedef_write_size_call, ns, tdname, accessor);
-    format_read_stream(1, ctx, typedef_read_call, ns, tdname, accessor);
+    format_read_stream(1, ctx, false, typedef_read_call, ns, tdname, accessor);
     if (is_key)
     {
-      format_key_stream(1, ctx, typedef_key_stream_call, ns, tdname, accessor);
+      format_key_write_stream(1, ctx, typedef_key_write_call, ns, tdname, accessor);
+      format_key_read_stream(1, ctx, typedef_key_read_call, ns, tdname, accessor);
       format_key_size_stream(1, ctx, typedef_key_size_call, ns, tdname, accessor);
       if (ctx->in_union)
       {
@@ -1590,7 +1630,7 @@ idl_retcode_t process_case_label(context_t* ctx, idl_case_label_t* label)
     {
       format_write_stream(1, ctx, true, union_case, buffer);
       format_write_size_stream(1, ctx, true, union_case, buffer);
-      format_read_stream(1, ctx, union_case, buffer);
+      format_read_stream(1, ctx, true, union_case, buffer);
       free(buffer);
     }
   }
@@ -1609,7 +1649,7 @@ idl_retcode_t add_default_case(context_t* ctx)
 {
   format_write_stream(1, ctx, true, default_case);
   format_write_size_stream(1, ctx, true, default_case);
-  format_read_stream(1, ctx, default_case);
+  format_read_stream(1, ctx, true, default_case);
 
   return IDL_RETCODE_OK;
 }

--- a/src/idlcxx/tests/cpp11Backend.c
+++ b/src/idlcxx/tests/cpp11Backend.c
@@ -61,7 +61,8 @@
 "  size_t read_struct(const void* data, size_t position);\n"\
 "  size_t key_size(size_t position) const;\n"\
 "  size_t key_max_size(size_t position) const;\n"\
-"  size_t key_stream(void* data, size_t position) const;\n"\
+"  size_t key_write(void* data, size_t position) const;\n"\
+"  size_t key_read(const void* data, size_t position);\n"\
 "  bool key(ddsi_keyhash_t& hash) const;\n"
 
 #define IDL_OUTPUT_STRUCT_PRIM(struct_name,member_type,default_value,member_name) "" \

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -124,7 +124,7 @@ void create_funcs_base(idl_ostream_t * ostr, size_t n, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
-  format_ostream_indented(ns * 2, ostr, "size_t s::key_stream(void *data, size_t position) const\n");
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_write(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
@@ -137,7 +137,7 @@ void create_funcs_base(idl_ostream_t * ostr, size_t n, bool ns)
   format_ostream_indented(ns * 2, ostr, "  if (sz != 0 && padding == 16) padding = 0;\n");
   format_ostream_indented(ns * 2, ostr, "  std::vector<unsigned char> buffer(sz+padding);\n");
   format_ostream_indented(ns * 2, ostr, "  memset(buffer.data()+sz,0x0,padding);\n");
-  format_ostream_indented(ns * 2, ostr, "  key_stream(buffer.data(),0);\n");
+  format_ostream_indented(ns * 2, ostr, "  key_write(buffer.data(),0);\n");
   format_ostream_indented(ns * 2, ostr, "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n");
   format_ostream_indented(ns * 2, ostr, "  if (fptr == NULL)\n");
   format_ostream_indented(ns * 2, ostr, "  {\n");
@@ -153,6 +153,12 @@ void create_funcs_base(idl_ostream_t * ostr, size_t n, bool ns)
   format_ostream_indented(ns * 2, ostr, "    }\n");
   format_ostream_indented(ns * 2, ostr, "  }\n");
   format_ostream_indented(ns * 2, ostr, "  return (*fptr)(buffer,hash);\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_read(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
   format_ostream_indented(ns * 2, ostr, "size_t s::read_struct(const void *data, size_t position)\n");
@@ -237,7 +243,7 @@ void create_funcs_instance(idl_ostream_t* ostr, const char* in, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
-  format_ostream_indented(ns * 2, ostr, "size_t I::key_stream(void *data, size_t position) const\n");
+  format_ostream_indented(ns * 2, ostr, "size_t I::key_write(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
@@ -250,7 +256,7 @@ void create_funcs_instance(idl_ostream_t* ostr, const char* in, bool ns)
   format_ostream_indented(ns * 2, ostr, "  if (sz != 0 && padding == 16) padding = 0;\n");
   format_ostream_indented(ns * 2, ostr, "  std::vector<unsigned char> buffer(sz+padding);\n");
   format_ostream_indented(ns * 2, ostr, "  memset(buffer.data()+sz,0x0,padding);\n");
-  format_ostream_indented(ns * 2, ostr, "  key_stream(buffer.data(),0);\n");
+  format_ostream_indented(ns * 2, ostr, "  key_write(buffer.data(),0);\n");
   format_ostream_indented(ns * 2, ostr, "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n");
   format_ostream_indented(ns * 2, ostr, "  if (fptr == NULL)\n");
   format_ostream_indented(ns * 2, ostr, "  {\n");
@@ -268,7 +274,7 @@ void create_funcs_instance(idl_ostream_t* ostr, const char* in, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return (*fptr)(buffer,hash);\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
-  format_ostream_indented(ns * 2, ostr, "size_t s::key_stream(void *data, size_t position) const\n");
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_write(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
@@ -281,7 +287,7 @@ void create_funcs_instance(idl_ostream_t* ostr, const char* in, bool ns)
   format_ostream_indented(ns * 2, ostr, "  if (sz != 0 && padding == 16) padding = 0;\n");
   format_ostream_indented(ns * 2, ostr, "  std::vector<unsigned char> buffer(sz+padding);\n");
   format_ostream_indented(ns * 2, ostr, "  memset(buffer.data()+sz,0x0,padding);\n");
-  format_ostream_indented(ns * 2, ostr, "  key_stream(buffer.data(),0);\n");
+  format_ostream_indented(ns * 2, ostr, "  key_write(buffer.data(),0);\n");
   format_ostream_indented(ns * 2, ostr, "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n");
   format_ostream_indented(ns * 2, ostr, "  if (fptr == NULL)\n");
   format_ostream_indented(ns * 2, ostr, "  {\n");
@@ -297,6 +303,18 @@ void create_funcs_instance(idl_ostream_t* ostr, const char* in, bool ns)
   format_ostream_indented(ns * 2, ostr, "    }\n");
   format_ostream_indented(ns * 2, ostr, "  }\n");
   format_ostream_indented(ns * 2, ostr, "  return (*fptr)(buffer,hash);\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t I::key_read(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_read(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
   format_ostream_indented(ns * 2, ostr, "size_t I::read_struct(const void *data, size_t position)\n");
@@ -361,7 +379,7 @@ void create_funcs_string(idl_ostream_t* ostr, const char* in, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
-  format_ostream_indented(ns * 2, ostr, "size_t s::key_stream(void *data, size_t position) const\n");
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_write(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
@@ -374,7 +392,7 @@ void create_funcs_string(idl_ostream_t* ostr, const char* in, bool ns)
   format_ostream_indented(ns * 2, ostr, "  if (sz != 0 && padding == 16) padding = 0;\n");
   format_ostream_indented(ns * 2, ostr, "  std::vector<unsigned char> buffer(sz+padding);\n");
   format_ostream_indented(ns * 2, ostr, "  memset(buffer.data()+sz,0x0,padding);\n");
-  format_ostream_indented(ns * 2, ostr, "  key_stream(buffer.data(),0);\n");
+  format_ostream_indented(ns * 2, ostr, "  key_write(buffer.data(),0);\n");
   format_ostream_indented(ns * 2, ostr, "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n");
   format_ostream_indented(ns * 2, ostr, "  if (fptr == NULL)\n");
   format_ostream_indented(ns * 2, ostr, "  {\n");
@@ -390,6 +408,12 @@ void create_funcs_string(idl_ostream_t* ostr, const char* in, bool ns)
   format_ostream_indented(ns * 2, ostr, "    }\n");
   format_ostream_indented(ns * 2, ostr, "  }\n");
   format_ostream_indented(ns * 2, ostr, "  return (*fptr)(buffer,hash);\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_read(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
   format_ostream_indented(ns * 2, ostr, "size_t s::read_struct(const void *data, size_t position)\n");
@@ -462,7 +486,7 @@ void create_funcs_sequence(idl_ostream_t* ostr, const char* seq_name, size_t n, 
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
-  format_ostream_indented(ns * 2, ostr, "size_t s::key_stream(void *data, size_t position) const\n");
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_write(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
@@ -475,7 +499,7 @@ void create_funcs_sequence(idl_ostream_t* ostr, const char* seq_name, size_t n, 
   format_ostream_indented(ns * 2, ostr, "  if (sz != 0 && padding == 16) padding = 0;\n");
   format_ostream_indented(ns * 2, ostr, "  std::vector<unsigned char> buffer(sz+padding);\n");
   format_ostream_indented(ns * 2, ostr, "  memset(buffer.data()+sz,0x0,padding);\n");
-  format_ostream_indented(ns * 2, ostr, "  key_stream(buffer.data(),0);\n");
+  format_ostream_indented(ns * 2, ostr, "  key_write(buffer.data(),0);\n");
   format_ostream_indented(ns * 2, ostr, "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n");
   format_ostream_indented(ns * 2, ostr, "  if (fptr == NULL)\n");
   format_ostream_indented(ns * 2, ostr, "  {\n");
@@ -491,6 +515,12 @@ void create_funcs_sequence(idl_ostream_t* ostr, const char* seq_name, size_t n, 
   format_ostream_indented(ns * 2, ostr, "    }\n");
   format_ostream_indented(ns * 2, ostr, "  }\n");
   format_ostream_indented(ns * 2, ostr, "  return (*fptr)(buffer,hash);\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_read(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
   format_ostream_indented(ns * 2, ostr, "size_t s::read_struct(const void *data, size_t position)\n");
@@ -672,7 +702,7 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
-  format_ostream_indented(ns * 2, ostr, "size_t s::key_stream(void *data, size_t position) const\n");
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_write(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n");
@@ -723,7 +753,7 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "  if (sz != 0 && padding == 16) padding = 0;\n");
   format_ostream_indented(ns * 2, ostr, "  std::vector<unsigned char> buffer(sz+padding);\n");
   format_ostream_indented(ns * 2, ostr, "  memset(buffer.data()+sz,0x0,padding);\n");
-  format_ostream_indented(ns * 2, ostr, "  key_stream(buffer.data(),0);\n");
+  format_ostream_indented(ns * 2, ostr, "  key_write(buffer.data(),0);\n");
   format_ostream_indented(ns * 2, ostr, "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n");
   format_ostream_indented(ns * 2, ostr, "  if (fptr == NULL)\n");
   format_ostream_indented(ns * 2, ostr, "  {\n");
@@ -739,6 +769,48 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "    }\n");
   format_ostream_indented(ns * 2, ostr, "  }\n");
   format_ostream_indented(ns * 2, ostr, "  return (*fptr)(buffer,hash);\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_read(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  clear();\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  _d() = *((int32_t*)((char*)data+position));  //reading bytes for member: _d()\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  switch (_d())\n");
+  format_ostream_indented(ns * 2, ostr, "  {\n");
+  format_ostream_indented(ns * 2, ostr, "    case 0:\n");
+  format_ostream_indented(ns * 2, ostr, "    case 1:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      o() = *((uint8_t*)((char*)data+position));  //reading bytes for member: o()\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 1;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "    case 2:\n");
+  format_ostream_indented(ns * 2, ostr, "    case 3:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      l() = *((int32_t*)((char*)data+position));  //reading bytes for member: l()\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "    case 4:\n");
+  format_ostream_indented(ns * 2, ostr, "    case 5:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "      str().assign((char*)data+position,(char*)data+position+sequenceentries);  //putting data into container\n");
+  format_ostream_indented(ns * 2, ostr, "      position += sequenceentries*1;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "    default:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      f() = *((float*)((char*)data+position));  //reading bytes for member: f()\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "  }\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
   format_ostream_indented(ns * 2, ostr, "size_t s::read_struct(const void *data, size_t position)\n");
@@ -824,7 +896,7 @@ void generate_enum_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
-  format_ostream_indented(ns * 2, ostr, "size_t s::key_stream(void *data, size_t position) const\n");
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_write(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
@@ -837,7 +909,7 @@ void generate_enum_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "  if (sz != 0 && padding == 16) padding = 0;\n");
   format_ostream_indented(ns * 2, ostr, "  std::vector<unsigned char> buffer(sz+padding);\n");
   format_ostream_indented(ns * 2, ostr, "  memset(buffer.data()+sz,0x0,padding);\n");
-  format_ostream_indented(ns * 2, ostr, "  key_stream(buffer.data(),0);\n");
+  format_ostream_indented(ns * 2, ostr, "  key_write(buffer.data(),0);\n");
   format_ostream_indented(ns * 2, ostr, "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n");
   format_ostream_indented(ns * 2, ostr, "  if (fptr == NULL)\n");
   format_ostream_indented(ns * 2, ostr, "  {\n");
@@ -853,6 +925,12 @@ void generate_enum_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "    }\n");
   format_ostream_indented(ns * 2, ostr, "  }\n");
   format_ostream_indented(ns * 2, ostr, "  return (*fptr)(buffer,hash);\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_read(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
   format_ostream_indented(ns * 2, ostr, "size_t s::read_struct(const void *data, size_t position)\n");
@@ -909,7 +987,7 @@ void generate_array_base_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
-  format_ostream_indented(ns * 2, ostr, "size_t s::key_stream(void *data, size_t position) const\n");
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_write(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
@@ -922,7 +1000,7 @@ void generate_array_base_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "  if (sz != 0 && padding == 16) padding = 0;\n");
   format_ostream_indented(ns * 2, ostr, "  std::vector<unsigned char> buffer(sz+padding);\n");
   format_ostream_indented(ns * 2, ostr, "  memset(buffer.data()+sz,0x0,padding);\n");
-  format_ostream_indented(ns * 2, ostr, "  key_stream(buffer.data(),0);\n");
+  format_ostream_indented(ns * 2, ostr, "  key_write(buffer.data(),0);\n");
   format_ostream_indented(ns * 2, ostr, "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n");
   format_ostream_indented(ns * 2, ostr, "  if (fptr == NULL)\n");
   format_ostream_indented(ns * 2, ostr, "  {\n");
@@ -938,6 +1016,12 @@ void generate_array_base_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "    }\n");
   format_ostream_indented(ns * 2, ostr, "  }\n");
   format_ostream_indented(ns * 2, ostr, "  return (*fptr)(buffer,hash);\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_read(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
   format_ostream_indented(ns * 2, ostr, "size_t s::read_struct(const void *data, size_t position)\n");
@@ -1017,7 +1101,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
-  format_ostream_indented(ns * 2, ostr, "size_t I::key_stream(void *data, size_t position) const\n");
+  format_ostream_indented(ns * 2, ostr, "size_t I::key_write(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
@@ -1030,7 +1114,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "  if (sz != 0 && padding == 16) padding = 0;\n");
   format_ostream_indented(ns * 2, ostr, "  std::vector<unsigned char> buffer(sz+padding);\n");
   format_ostream_indented(ns * 2, ostr, "  memset(buffer.data()+sz,0x0,padding);\n");
-  format_ostream_indented(ns * 2, ostr, "  key_stream(buffer.data(),0);\n");
+  format_ostream_indented(ns * 2, ostr, "  key_write(buffer.data(),0);\n");
   format_ostream_indented(ns * 2, ostr, "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n");
   format_ostream_indented(ns * 2, ostr, "  if (fptr == NULL)\n");
   format_ostream_indented(ns * 2, ostr, "  {\n");
@@ -1048,7 +1132,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return (*fptr)(buffer,hash);\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
-  format_ostream_indented(ns * 2, ostr, "size_t s::key_stream(void *data, size_t position) const\n");
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_write(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
@@ -1061,7 +1145,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "  if (sz != 0 && padding == 16) padding = 0;\n");
   format_ostream_indented(ns * 2, ostr, "  std::vector<unsigned char> buffer(sz+padding);\n");
   format_ostream_indented(ns * 2, ostr, "  memset(buffer.data()+sz,0x0,padding);\n");
-  format_ostream_indented(ns * 2, ostr, "  key_stream(buffer.data(),0);\n");
+  format_ostream_indented(ns * 2, ostr, "  key_write(buffer.data(),0);\n");
   format_ostream_indented(ns * 2, ostr, "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n");
   format_ostream_indented(ns * 2, ostr, "  if (fptr == NULL)\n");
   format_ostream_indented(ns * 2, ostr, "  {\n");
@@ -1077,6 +1161,18 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "    }\n");
   format_ostream_indented(ns * 2, ostr, "  }\n");
   format_ostream_indented(ns * 2, ostr, "  return (*fptr)(buffer,hash);\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t I::key_read(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_read(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
   format_ostream_indented(ns * 2, ostr, "size_t I::read_struct(const void *data, size_t position)\n");
@@ -1128,7 +1224,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "    {\n"\
 "      return position;\n"\
 "    }\n\n"\
-"    size_t s_1::key_stream(void *data, size_t position) const\n"\
+"    size_t s_1::key_write(void *data, size_t position) const\n"\
 "    {\n"\
 "      (void)data;\n"\
 "      return position;\n"\
@@ -1140,7 +1236,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "      if (sz != 0 && padding == 16) padding = 0;\n"\
 "      std::vector<unsigned char> buffer(sz+padding);\n"\
 "      memset(buffer.data()+sz,0x0,padding);\n"\
-"      key_stream(buffer.data(),0);\n"\
+"      key_write(buffer.data(),0);\n"\
 "      static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n"\
 "      if (fptr == NULL)\n"\
 "      {\n"\
@@ -1156,6 +1252,11 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "        }\n"\
 "      }\n"\
 "      return (*fptr)(buffer,hash);\n"\
+"    }\n\n"\
+"    size_t s_1::key_read(const void *data, size_t position)\n"\
+"    {\n"\
+"      (void)data;\n"\
+"      return position;\n"\
 "    }\n\n"\
 "    size_t s_1::read_struct(const void *data, size_t position)\n"\
 "    {\n"\
@@ -1188,7 +1289,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "    {\n"\
 "      return position;\n"\
 "    }\n\n"\
-"    size_t s_2::key_stream(void *data, size_t position) const\n"\
+"    size_t s_2::key_write(void *data, size_t position) const\n"\
 "    {\n"\
 "      (void)data;\n"\
 "      return position;\n"\
@@ -1200,7 +1301,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "      if (sz != 0 && padding == 16) padding = 0;\n"\
 "      std::vector<unsigned char> buffer(sz+padding);\n"\
 "      memset(buffer.data()+sz,0x0,padding);\n"\
-"      key_stream(buffer.data(),0);\n"\
+"      key_write(buffer.data(),0);\n"\
 "      static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n"\
 "      if (fptr == NULL)\n"\
 "      {\n"\
@@ -1216,6 +1317,11 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "        }\n"\
 "      }\n"\
 "      return (*fptr)(buffer,hash);\n"\
+"    }\n\n"\
+"    size_t s_2::key_read(const void *data, size_t position)\n"\
+"    {\n"\
+"      (void)data;\n"\
+"      return position;\n"\
 "    }\n\n"\
 "    size_t s_2::read_struct(const void *data, size_t position)\n"\
 "    {\n"\
@@ -1276,7 +1382,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "  if (position != UINT_MAX)   position = dynamic_cast<const I&>(*this).key_max_size(position);\n"\
   "  return position;\n"\
   "}\n\n"\
-  "size_t I::key_stream(void *data, size_t position) const\n"\
+  "size_t I::key_write(void *data, size_t position) const\n"\
   "{\n"\
   "  (void)data;\n"\
   "  return position;\n"\
@@ -1288,7 +1394,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "  if (sz != 0 && padding == 16) padding = 0;\n"\
   "  std::vector<unsigned char> buffer(sz+padding);\n"\
   "  memset(buffer.data()+sz,0x0,padding);\n"\
-  "  key_stream(buffer.data(),0);\n"\
+  "  key_write(buffer.data(),0);\n"\
   "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n"\
   "  if (fptr == NULL)\n"\
   "  {\n"\
@@ -1305,10 +1411,10 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "  }\n"\
   "  return (*fptr)(buffer,hash);\n"\
   "}\n\n"\
-  "size_t s::key_stream(void *data, size_t position) const\n"\
+  "size_t s::key_write(void *data, size_t position) const\n"\
   "{\n"\
   "  (void)data;\n"\
-  "  position = dynamic_cast<const I&>(*this).key_stream(data, position);\n"\
+  "  position = dynamic_cast<const I&>(*this).key_write(data, position);\n"\
   "  return position;\n"\
   "}\n\n"\
   "bool s::key(ddsi_keyhash_t &hash) const\n"\
@@ -1318,7 +1424,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "  if (sz != 0 && padding == 16) padding = 0;\n"\
   "  std::vector<unsigned char> buffer(sz+padding);\n"\
   "  memset(buffer.data()+sz,0x0,padding);\n"\
-  "  key_stream(buffer.data(),0);\n"\
+  "  key_write(buffer.data(),0);\n"\
   "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n"\
   "  if (fptr == NULL)\n"\
   "  {\n"\
@@ -1334,6 +1440,17 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "    }\n"\
   "  }\n"\
   "  return (*fptr)(buffer,hash);\n"\
+  "}\n\n"\
+  "size_t I::key_read(const void *data, size_t position)\n"\
+  "{\n"\
+  "  (void)data;\n"\
+  "  return position;\n"\
+  "}\n\n"\
+  "size_t s::key_read(const void *data, size_t position)\n"\
+  "{\n"\
+  "  (void)data;\n"\
+  "  position = dynamic_cast<I&>(*this).key_read(data, position);\n"\
+  "  return position;\n"\
   "}\n\n"\
   "size_t I::read_struct(const void *data, size_t position)\n"\
   "{\n"\
@@ -1381,7 +1498,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "{\n"\
   "  return position;\n"\
   "}\n\n"\
-  "size_t s::key_stream(void *data, size_t position) const\n"\
+  "size_t s::key_write(void *data, size_t position) const\n"\
   "{\n"\
   "  (void)data;\n"\
   "  return position;\n"\
@@ -1393,7 +1510,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "  if (sz != 0 && padding == 16) padding = 0;\n"\
   "  std::vector<unsigned char> buffer(sz+padding);\n"\
   "  memset(buffer.data()+sz,0x0,padding);\n"\
-  "  key_stream(buffer.data(),0);\n"\
+  "  key_write(buffer.data(),0);\n"\
   "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n"\
   "  if (fptr == NULL)\n"\
   "  {\n"\
@@ -1409,6 +1526,11 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "    }\n"\
   "  }\n"\
   "  return (*fptr)(buffer,hash);\n"\
+  "}\n\n"\
+  "size_t s::key_read(const void *data, size_t position)\n"\
+  "{\n"\
+  "  (void)data;\n"\
+  "  return position;\n"\
   "}\n\n"\
   "size_t s::read_struct(const void *data, size_t position)\n"\
   "{\n"\
@@ -1457,7 +1579,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "    (void)position;\n"\
 "    return UINT_MAX;\n"\
 "  }\n\n"\
-"  size_t typedef_key_stream_td_6(const td_6 &obj, void *data, size_t position)\n"\
+"  size_t typedef_key_write_td_6(const td_6 &obj, void *data, size_t position)\n"\
 "  {\n"\
 "    size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
 "    memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
@@ -1466,6 +1588,15 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "    *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing entries for member: obj\n"\
 "    position += 4;  //moving position indicator\n"\
 "    memcpy((char*)data+position,obj.data(),sequenceentries*4);  //contents for obj\n"\
+"    position += sequenceentries*4;  //moving position indicator\n"\
+"    return position;\n"\
+"  }\n\n"\
+"  size_t typedef_key_read_td_6(td_6 &obj, const void *data, size_t position)\n"\
+"  {\n"\
+"    position += (4 - (position&0x3))&0x3;  //alignment\n"\
+"    uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n"\
+"    position += 4;  //moving position indicator\n"\
+"    obj.assign((int32_t*)((char*)data+position),(int32_t*)((char*)data+position)+sequenceentries);  //putting data into container\n"\
 "    position += sequenceentries*4;  //moving position indicator\n"\
 "    return position;\n"\
 "  }\n\n"\
@@ -1511,7 +1642,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  {\n"\
 "    return position;\n"\
 "  }\n\n"\
-"  size_t s::key_stream(void *data, size_t position) const\n"\
+"  size_t s::key_write(void *data, size_t position) const\n"\
 "  {\n"\
 "    (void)data;\n"\
 "    return position;\n"\
@@ -1523,7 +1654,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "    if (sz != 0 && padding == 16) padding = 0;\n"\
 "    std::vector<unsigned char> buffer(sz+padding);\n"\
 "    memset(buffer.data()+sz,0x0,padding);\n"\
-"    key_stream(buffer.data(),0);\n"\
+"    key_write(buffer.data(),0);\n"\
 "    static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n"\
 "    if (fptr == NULL)\n"\
 "    {\n"\
@@ -1539,6 +1670,11 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "      }\n"\
 "    }\n"\
 "    return (*fptr)(buffer,hash);\n"\
+"  }\n\n"\
+"  size_t s::key_read(const void *data, size_t position)\n"\
+"  {\n"\
+"    (void)data;\n"\
+"    return position;\n"\
 "  }\n\n"\
 "  size_t s::read_struct(const void *data, size_t position)\n"\
 "  {\n"\
@@ -1558,7 +1694,8 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  size_t typedef_write_td_6(const td_6 &obj, void* data, size_t position);\n\n"\
 "  size_t typedef_write_size_td_6(const td_6 &obj, size_t position);\n\n"\
 "  size_t typedef_read_td_6(td_6 &obj, const void* data, size_t position);\n\n"\
-"  size_t typedef_key_stream_td_6(const td_6 &obj, void *data, size_t position);\n\n"\
+"  size_t typedef_key_write_td_6(const td_6 &obj, void *data, size_t position);\n\n"\
+"  size_t typedef_key_read_td_6(td_6 &obj, const void *data, size_t position);\n\n"\
 "  size_t typedef_key_size_td_6(const td_6 &obj, size_t position);\n\n"\
 "  size_t typedef_key_max_size_td_6(const td_6 &obj, size_t position);\n\n"\
 "} //end namespace M\n\n"
@@ -1628,7 +1765,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  if (position != UINT_MAX)   position += 4;  //bytes for member: l()\n"\
 "  return position;\n"\
 "}\n\n"\
-"size_t s::key_stream(void *data, size_t position) const\n"\
+"size_t s::key_write(void *data, size_t position) const\n"\
 "{\n"\
 "  (void)data;\n"\
 "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
@@ -1645,7 +1782,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  if (sz != 0 && padding == 16) padding = 0;\n"\
 "  std::vector<unsigned char> buffer(sz+padding);\n"\
 "  memset(buffer.data()+sz,0x0,padding);\n"\
-"  key_stream(buffer.data(),0);\n"\
+"  key_write(buffer.data(),0);\n"\
 "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n"\
 "  if (fptr == NULL)\n"\
 "  {\n"\
@@ -1662,10 +1799,10 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  }\n"\
 "  return (*fptr)(buffer,hash);\n"\
 "}\n\n"\
-"size_t ss::key_stream(void *data, size_t position) const\n"\
+"size_t ss::key_write(void *data, size_t position) const\n"\
 "{\n"\
 "  (void)data;\n"\
-"  position = s_().key_stream(data, position);\n"\
+"  position = s_().key_write(data, position);\n"\
 "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
 "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
 "  position += alignmentbytes;  //moving position indicator\n"\
@@ -1680,7 +1817,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  if (sz != 0 && padding == 16) padding = 0;\n"\
 "  std::vector<unsigned char> buffer(sz+padding);\n"\
 "  memset(buffer.data()+sz,0x0,padding);\n"\
-"  key_stream(buffer.data(),0);\n"\
+"  key_write(buffer.data(),0);\n"\
 "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n"\
 "  if (fptr == NULL)\n"\
 "  {\n"\
@@ -1696,6 +1833,23 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "    }\n"\
 "  }\n"\
 "  return (*fptr)(buffer,hash);\n"\
+"}\n\n"\
+"size_t s::key_read(const void *data, size_t position)\n"\
+"{\n"\
+"  (void)data;\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
+"  l() = *((int32_t*)((char*)data+position));  //reading bytes for member: l()\n"\
+"  position += 4;  //moving position indicator\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t ss::key_read(const void *data, size_t position)\n"\
+"{\n"\
+"  (void)data;\n"\
+"  position = s_().key_read(data, position);\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
+"  l() = *((int32_t*)((char*)data+position));  //reading bytes for member: l()\n"\
+"  position += 4;  //moving position indicator\n"\
+"  return position;\n"\
 "}\n\n"\
 "size_t s::read_struct(const void *data, size_t position)\n"\
 "{\n"\
@@ -1749,7 +1903,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  if (position != UINT_MAX)   position += 4;  //bytes for member: l()\n"\
 "  return position;\n"\
 "}\n\n"\
-"size_t s::key_stream(void *data, size_t position) const\n"\
+"size_t s::key_write(void *data, size_t position) const\n"\
 "{\n"\
 "  (void)data;\n"\
 "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
@@ -1766,7 +1920,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  if (sz != 0 && padding == 16) padding = 0;\n"\
 "  std::vector<unsigned char> buffer(sz+padding);\n"\
 "  memset(buffer.data()+sz,0x0,padding);\n"\
-"  key_stream(buffer.data(),0);\n"\
+"  key_write(buffer.data(),0);\n"\
 "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n"\
 "  if (fptr == NULL)\n"\
 "  {\n"\
@@ -1782,6 +1936,14 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "    }\n"\
 "  }\n"\
 "  return (*fptr)(buffer,hash);\n"\
+"}\n\n"\
+"size_t s::key_read(const void *data, size_t position)\n"\
+"{\n"\
+"  (void)data;\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
+"  l() = *((int32_t*)((char*)data+position));  //reading bytes for member: l()\n"\
+"  position += 4;  //moving position indicator\n"\
+"  return position;\n"\
 "}\n\n"\
 "size_t s::read_struct(const void *data, size_t position)\n"\
 "{\n"\
@@ -1851,7 +2013,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  position = typedef_key_max_size_td_1(t(), position);\n"\
 "  return position;\n"\
 "}\n\n"\
-"size_t typedef_key_stream_td_1(const td_1 &obj, void *data, size_t position)\n"\
+"size_t typedef_key_write_td_1(const td_1 &obj, void *data, size_t position)\n"\
 "{\n"\
 "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
 "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
@@ -1863,10 +2025,10 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  position += sequenceentries*4;  //moving position indicator\n"\
 "  return position;\n"\
 "}\n\n"\
-"size_t s::key_stream(void *data, size_t position) const\n"\
+"size_t s::key_write(void *data, size_t position) const\n"\
 "{\n"\
 "  (void)data;\n"\
-"  position = typedef_key_stream_td_1(t(), data, position);\n"\
+"  position = typedef_key_write_td_1(t(), data, position);\n"\
 "  return position;\n"\
 "}\n\n"\
 "bool s::key(ddsi_keyhash_t &hash) const\n"\
@@ -1876,7 +2038,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  if (sz != 0 && padding == 16) padding = 0;\n"\
 "  std::vector<unsigned char> buffer(sz+padding);\n"\
 "  memset(buffer.data()+sz,0x0,padding);\n"\
-"  key_stream(buffer.data(),0);\n"\
+"  key_write(buffer.data(),0);\n"\
 "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n"\
 "  if (fptr == NULL)\n"\
 "  {\n"\
@@ -1892,6 +2054,21 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "    }\n"\
 "  }\n"\
 "  return (*fptr)(buffer,hash);\n"\
+"}\n\n"\
+"size_t typedef_key_read_td_1(td_1 &obj, const void *data, size_t position)\n"\
+"{\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
+"  uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n"\
+"  position += 4;  //moving position indicator\n"\
+"  obj.assign((int32_t*)((char*)data+position),(int32_t*)((char*)data+position)+sequenceentries);  //putting data into container\n"\
+"  position += sequenceentries*4;  //moving position indicator\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t s::key_read(const void *data, size_t position)\n"\
+"{\n"\
+"  (void)data;\n"\
+"  position = typedef_key_read_td_1(t(), data, position);\n"\
+"  return position;\n"\
 "}\n\n"\
 "size_t typedef_read_td_1(td_1 &obj, const void* data, size_t position)\n"\
 "{\n"\
@@ -1913,7 +2090,8 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 #define TDKH "size_t typedef_write_td_1(const td_1 &obj, void* data, size_t position);\n\n"\
 "size_t typedef_write_size_td_1(const td_1 &obj, size_t position);\n\n"\
 "size_t typedef_read_td_1(td_1 &obj, const void* data, size_t position);\n\n"\
-"size_t typedef_key_stream_td_1(const td_1 &obj, void *data, size_t position);\n\n"\
+"size_t typedef_key_write_td_1(const td_1 &obj, void *data, size_t position);\n\n"\
+"size_t typedef_key_read_td_1(td_1 &obj, const void *data, size_t position);\n\n"\
 "size_t typedef_key_size_td_1(const td_1 &obj, size_t position);\n\n"\
 "size_t typedef_key_max_size_td_1(const td_1 &obj, size_t position);\n\n"
 

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -1463,10 +1463,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  size_t typedef_key_stream_td_6(const td_6 &obj, void *data, size_t position);\n\n"\
 "  size_t typedef_key_size_td_6(const td_6 &obj, size_t position);\n\n"\
 "  size_t typedef_key_max_size_td_6(const td_6 &obj, size_t position);\n\n"\
-"} //end namespace M\n\n"\
-"namespace N\n"\
-"{\n\n"\
-"} //end namespace N\n\n"
+"} //end namespace M\n\n"
 
 #define KBI "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n"\
 "size_t s::write_struct(void *data, size_t position) const\n"\
@@ -1816,23 +1813,6 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "size_t typedef_key_size_td_1(const td_1 &obj, size_t position);\n\n"\
 "size_t typedef_key_max_size_td_1(const td_1 &obj, size_t position);\n\n"
 
-#define NSE "namespace N\n" \
-"{\n\n" \
-"} //end namespace N\n\n"
-
-#define NSD "namespace A_1\n"\
-"{\n\n"\
-"  namespace A_2\n"\
-"  {\n\n"\
-"  } //end namespace A_2\n\n"\
-"} //end namespace A_1\n\n"\
-"namespace B_1\n"\
-"{\n\n"\
-"  namespace B_2\n"\
-"  {\n\n"\
-"  } //end namespace B_2\n\n"\
-"} //end namespace B_1\n\n"
-
 void test_base(size_t n, bool ns)
 {
   char buffer[1024];
@@ -1865,7 +1845,7 @@ void test_base(size_t n, bool ns)
   create_funcs_base(impl, n, ns);
 
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
-  CU_ASSERT_STRING_EQUAL(ns ? NSE : "", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
+  CU_ASSERT_STRING_EQUAL("", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
 
   destruct_idl_ostream(impl);
   destruct_idl_streamer_output(generated);
@@ -1908,7 +1888,7 @@ void test_instance(bool ns)
   create_funcs_instance(impl, "mem", ns);
 
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
-  CU_ASSERT_STRING_EQUAL(ns ? NSE : "", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
+  CU_ASSERT_STRING_EQUAL("", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
 
   destruct_idl_ostream(impl);
   destruct_idl_streamer_output(generated);
@@ -1947,7 +1927,7 @@ void test_sequence(size_t n, bool ns)
   create_funcs_sequence(impl, "mem", n, ns);
 
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
-  CU_ASSERT_STRING_EQUAL(ns ? NSE : "", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
+  CU_ASSERT_STRING_EQUAL("", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
 
   destruct_idl_ostream(impl);
   destruct_idl_streamer_output(generated);
@@ -1984,7 +1964,7 @@ void test_string(bool ns)
   create_funcs_string(impl, "str", ns);
 
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
-  CU_ASSERT_STRING_EQUAL(ns ? NSE : "", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
+  CU_ASSERT_STRING_EQUAL("", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
 
   destruct_idl_ostream(impl);
   destruct_idl_streamer_output(generated);
@@ -2032,7 +2012,7 @@ void test_union(bool ns)
   generate_union_funcs(impl, ns);
 
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
-  CU_ASSERT_STRING_EQUAL(ns ? NSE : "", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
+  CU_ASSERT_STRING_EQUAL("", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
 
   destruct_idl_ostream(impl);
   destruct_idl_streamer_output(generated);
@@ -2070,7 +2050,7 @@ void test_enum(bool ns)
   generate_enum_funcs(impl, ns);
 
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
-  CU_ASSERT_STRING_EQUAL(ns ? NSE : "", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
+  CU_ASSERT_STRING_EQUAL("", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
 
   destruct_idl_ostream(impl);
   destruct_idl_streamer_output(generated);
@@ -2107,7 +2087,7 @@ void test_array_base(bool ns)
   generate_array_base_funcs(impl, ns);
 
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
-  CU_ASSERT_STRING_EQUAL(ns ? NSE : "", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
+  CU_ASSERT_STRING_EQUAL("", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
 
   destruct_idl_ostream(impl);
   destruct_idl_streamer_output(generated);
@@ -2150,7 +2130,7 @@ void test_array_instance(bool ns)
   generate_array_instance_funcs(impl, ns);
 
   CU_ASSERT_STRING_EQUAL(get_ostream_buffer(impl), get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
-  CU_ASSERT_STRING_EQUAL(ns ? NSE : "", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
+  CU_ASSERT_STRING_EQUAL("", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
 
   destruct_idl_ostream(impl);
   destruct_idl_streamer_output(generated);
@@ -2169,7 +2149,7 @@ void test_namespace_cross_call()
   idl_streamers_generate(tree, generated);
 
   CU_ASSERT_STRING_EQUAL(CCFI, get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
-  CU_ASSERT_STRING_EQUAL(NSD, get_ostream_buffer(get_idl_streamer_head_buf(generated)));
+  CU_ASSERT_STRING_EQUAL("", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
 
   destruct_idl_streamer_output(generated);
   idl_delete_tree(tree);

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -87,7 +87,7 @@ void create_funcs_base(idl_ostream_t * ostr, size_t n, bool ns)
     }
     else
     {
-      format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (%d - position&%#x)&%#x;  //alignment\n",width,width-1,width-1);
+      format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (%d - (position&%#x))&%#x;  //alignment\n",width,width-1,width-1);
     }
     format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
     format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
@@ -107,7 +107,7 @@ void create_funcs_base(idl_ostream_t * ostr, size_t n, bool ns)
     }
     else
     {
-      format_ostream_indented(ns * 2, ostr, "  position += (%d - position&%#x)&%#x;  //alignment\n",width,width-1,width-1);
+      format_ostream_indented(ns * 2, ostr, "  position += (%d - (position&%#x))&%#x;  //alignment\n",width,width-1,width-1);
     }
   }
   format_ostream_indented(ns * 2, ostr, "  position += %d;  //bytes for member: mem()\n", width);
@@ -164,7 +164,7 @@ void create_funcs_base(idl_ostream_t * ostr, size_t n, bool ns)
     }
     else
     {
-      format_ostream_indented(ns * 2, ostr, "  position += (%d - position&%#x)&%#x;  //alignment\n", width, width - 1, width - 1);
+      format_ostream_indented(ns * 2, ostr, "  position += (%d - (position&%#x))&%#x;  //alignment\n", width, width - 1, width - 1);
     }
   }
   format_ostream_indented(ns * 2, ostr, "  mem() = *((%s*)((char*)data+position));  //reading bytes for member: mem()\n", tn);
@@ -189,7 +189,7 @@ void create_funcs_instance(idl_ostream_t* ostr, const char* in, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t I::write_struct(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
   format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  *((int32_t*)((char*)data+position)) = l();  //writing bytes for member: l()\n");
@@ -205,7 +205,7 @@ void create_funcs_instance(idl_ostream_t* ostr, const char* in, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t I::write_size(size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: l()\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
@@ -298,7 +298,7 @@ void create_funcs_instance(idl_ostream_t* ostr, const char* in, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t I::read_struct(const void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  l() = *((int32_t*)((char*)data+position));  //reading bytes for member: l()\n");
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
@@ -329,10 +329,10 @@ void create_funcs_string(idl_ostream_t* ostr, const char* in, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t s::write_struct(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
   format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = %s().size()+1;  //number of entries in the sequence\n", in);
+  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = (uint32_t) %s().size()+1;  //number of entries in the sequence\n", in);
   format_ostream_indented(ns * 2, ostr, "  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing entries for member: %s()\n", in);
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  memcpy((char*)data+position,%s().data(),sequenceentries*1);  //contents for %s()\n", in, in);
@@ -342,7 +342,7 @@ void create_funcs_string(idl_ostream_t* ostr, const char* in, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t s::write_size(size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for sequence entries\n", in);
   format_ostream_indented(ns * 2, ostr, "  position += (%s().size()+1)*1;  //entries of sequence\n", in);
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
@@ -390,7 +390,7 @@ void create_funcs_string(idl_ostream_t* ostr, const char* in, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t s::read_struct(const void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n");
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  %s().assign((char*)data+position,(char*)data+position+sequenceentries);  //putting data into container\n", in);
@@ -418,15 +418,15 @@ void create_funcs_sequence(idl_ostream_t* ostr, const char* seq_name, size_t n, 
 
   format_ostream_indented(ns * 2, ostr, "size_t s::write_struct(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
   format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
-  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = %s().size();  //number of entries in the sequence\n", seq_name);
+  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = (uint32_t) %s().size();  //number of entries in the sequence\n", seq_name);
   format_ostream_indented(ns * 2, ostr, "  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing entries for member: %s()\n", seq_name);
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
   if (width > 4)
   {
-    format_ostream_indented(ns * 2, ostr, "  alignmentbytes = (%d - position&%#x)&%#x;  //alignment\n", width, width-1, width-1);
+    format_ostream_indented(ns * 2, ostr, "  alignmentbytes = (%d - (position&%#x))&%#x;  //alignment\n", width, width-1, width-1);
     format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
     format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
   }
@@ -437,11 +437,11 @@ void create_funcs_sequence(idl_ostream_t* ostr, const char* seq_name, size_t n, 
 
   format_ostream_indented(ns * 2, ostr, "size_t s::write_size(size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for sequence entries\n", seq_name);
   if (width > 4)
   {
-    format_ostream_indented(ns * 2, ostr, "  position += (%d - position&%#x)&%#x;  //alignment\n", width, width - 1, width - 1);
+    format_ostream_indented(ns * 2, ostr, "  position += (%d - (position&%#x))&%#x;  //alignment\n", width, width - 1, width - 1);
   }
   format_ostream_indented(ns * 2, ostr, "  position += (%s().size())*%d;  //entries of sequence\n", seq_name, width);
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
@@ -489,12 +489,12 @@ void create_funcs_sequence(idl_ostream_t* ostr, const char* seq_name, size_t n, 
 
   format_ostream_indented(ns * 2, ostr, "size_t s::read_struct(const void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n");
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
   if (width > 4)
   {
-    format_ostream_indented(ns * 2, ostr, "  position += (%d - position&%#x)&%#x;  //alignment\n", width, width - 1, width - 1);
+    format_ostream_indented(ns * 2, ostr, "  position += (%d - (position&%#x))&%#x;  //alignment\n", width, width - 1, width - 1);
   }
   if (width > 1)
   {
@@ -525,7 +525,7 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t s::write_struct(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
   format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  *((int32_t*)((char*)data+position)) = _d();  //writing bytes for member: _d()\n");
@@ -549,7 +549,7 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "    case 4:\n");
   format_ostream_indented(ns * 2, ostr, "    case 5:\n");
   format_ostream_indented(ns * 2, ostr, "    {\n");
-  format_ostream_indented(ns * 2, ostr, "      uint32_t sequenceentries = str().size()+1;  //number of entries in the sequence\n");
+  format_ostream_indented(ns * 2, ostr, "      uint32_t sequenceentries = (uint32_t) str().size()+1;  //number of entries in the sequence\n");
   format_ostream_indented(ns * 2, ostr, "      *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing entries for member: str()\n");
   format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "      memcpy((char*)data+position,str().data(),sequenceentries*1);  //contents for str()\n");
@@ -568,7 +568,7 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t s::write_size(size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: _d()\n");
   format_ostream_indented(ns * 2, ostr, "  switch (_d())\n");
   format_ostream_indented(ns * 2, ostr, "  {\n");
@@ -602,7 +602,7 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t s::key_size(size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: _d()\n");
   format_ostream_indented(ns * 2, ostr, "  switch (_d())\n");
   format_ostream_indented(ns * 2, ostr, "  {\n");
@@ -636,7 +636,7 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t s::key_max_size(size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  if (position != UINT_MAX)   position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  if (position != UINT_MAX)   position += (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  if (position != UINT_MAX)   position += 4;  //bytes for member: _d()\n");
   format_ostream_indented(ns * 2, ostr, "  size_t union_max = position;\n");
   format_ostream_indented(ns * 2, ostr, "  {  //cases\n");
@@ -666,7 +666,7 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t s::key_stream(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
   format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  *((int32_t*)((char*)data+position)) = _d();  //writing bytes for member: _d()\n");
@@ -690,7 +690,7 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "    case 4:\n");
   format_ostream_indented(ns * 2, ostr, "    case 5:\n");
   format_ostream_indented(ns * 2, ostr, "    {\n");
-  format_ostream_indented(ns * 2, ostr, "      uint32_t sequenceentries = str().size()+1;  //number of entries in the sequence\n");
+  format_ostream_indented(ns * 2, ostr, "      uint32_t sequenceentries = (uint32_t) str().size()+1;  //number of entries in the sequence\n");
   format_ostream_indented(ns * 2, ostr, "      *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing entries for member: str()\n");
   format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "      memcpy((char*)data+position,str().data(),sequenceentries*1);  //contents for str()\n");
@@ -735,7 +735,7 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "size_t s::read_struct(const void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  clear();\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  _d() = *((int32_t*)((char*)data+position));  //reading bytes for member: _d()\n");
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  switch (_d())\n");
@@ -795,7 +795,7 @@ void generate_array_base_funcs(idl_ostream_t* ostr, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t s::write_struct(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
   format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  memcpy((char*)data+position,mem().data(),24);  //writing bytes for member: mem()\n");
@@ -807,7 +807,7 @@ void generate_array_base_funcs(idl_ostream_t* ostr, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t s::write_size(size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  position += 24;  //bytes for member: mem()\n");
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: mem2()\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
@@ -855,7 +855,7 @@ void generate_array_base_funcs(idl_ostream_t* ostr, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t s::read_struct(const void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  memcpy(mem().data(),(char*)data+position,24);  //reading bytes for member: mem()\n");
   format_ostream_indented(ns * 2, ostr, "  position += 24;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  mem2() = *((float*)((char*)data+position));  //reading bytes for member: mem2()\n");
@@ -881,7 +881,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t I::write_struct(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
   format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  *((int32_t*)((char*)data+position)) = l();  //writing bytes for member: l()\n");
@@ -898,7 +898,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t I::write_size(size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: l()\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
@@ -992,7 +992,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t I::read_struct(const void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
-  format_ostream_indented(ns * 2, ostr, "  position += (4 - position&0x3)&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  l() = *((int32_t*)((char*)data+position));  //reading bytes for member: l()\n");
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
@@ -1018,7 +1018,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  {\n\n"\
 "    size_t s_1::write_struct(void *data, size_t position) const\n"\
 "    {\n"\
-"      size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+"      size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
 "      memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
 "      position += alignmentbytes;  //moving position indicator\n"\
 "      *((int32_t*)((char*)data+position)) = m_1();  //writing bytes for member: m_1()\n"\
@@ -1027,7 +1027,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "    }\n\n"\
 "    size_t s_1::write_size(size_t position) const\n"\
 "    {\n"\
-"      position += (4 - position&0x3)&0x3;  //alignment\n"\
+"      position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "      position += 4;  //bytes for member: m_1()\n"\
 "      return position;\n"\
 "    }\n\n"\
@@ -1069,7 +1069,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "    }\n\n"\
 "    size_t s_1::read_struct(const void *data, size_t position)\n"\
 "    {\n"\
-"      position += (4 - position&0x3)&0x3;  //alignment\n"\
+"      position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "      m_1() = *((int32_t*)((char*)data+position));  //reading bytes for member: m_1()\n"\
 "      position += 4;  //moving position indicator\n"\
 "      return position;\n"\
@@ -1137,7 +1137,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 #define IFI "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n"\
   "size_t I::write_struct(void *data, size_t position) const\n"\
   "{\n"\
-  "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+  "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
   "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
   "  position += alignmentbytes;  //moving position indicator\n"\
   "  *((int32_t*)((char*)data+position)) = inherited_member();  //writing bytes for member: inherited_member()\n"\
@@ -1146,8 +1146,8 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "}\n\n"\
   "size_t s::write_struct(void *data, size_t position) const\n"\
   "{\n"\
-  "  position = dynamic_cast<I&>(*this).write_struct(data, position);\n"\
-  "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+  "  position = dynamic_cast<const I&>(*this).write_struct(data, position);\n"\
+  "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
   "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
   "  position += alignmentbytes;  //moving position indicator\n"\
   "  *((int32_t*)((char*)data+position)) = new_member();  //writing bytes for member: new_member()\n"\
@@ -1156,14 +1156,14 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "}\n\n"\
   "size_t I::write_size(size_t position) const\n"\
   "{\n"\
-  "  position += (4 - position&0x3)&0x3;  //alignment\n"\
+  "  position += (4 - (position&0x3))&0x3;  //alignment\n"\
   "  position += 4;  //bytes for member: inherited_member()\n"\
   "  return position;\n"\
   "}\n\n"\
   "size_t s::write_size(size_t position) const\n"\
   "{\n"\
-  "  position = dynamic_cast<I&>(*this).write_size(position);\n"\
-  "  position += (4 - position&0x3)&0x3;  //alignment\n"\
+  "  position = dynamic_cast<const I&>(*this).write_size(position);\n"\
+  "  position += (4 - (position&0x3))&0x3;  //alignment\n"\
   "  position += 4;  //bytes for member: new_member()\n"\
   "  return position;\n"\
   "}\n\n"\
@@ -1173,6 +1173,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "}\n\n"\
   "size_t s::key_size(size_t position) const\n"\
   "{\n"\
+  "  position = dynamic_cast<const I&>(*this).key_size(position);\n"\
   "  return position;\n"\
   "}\n\n"\
   "size_t I::key_max_size(size_t position) const\n"\
@@ -1181,6 +1182,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "}\n\n"\
   "size_t s::key_max_size(size_t position) const\n"\
   "{\n"\
+  "  if (position != UINT_MAX)   position = dynamic_cast<const I&>(*this).key_max_size(position);\n"\
   "  return position;\n"\
   "}\n\n"\
   "size_t I::key_stream(void *data, size_t position) const\n"\
@@ -1213,6 +1215,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "}\n\n"\
   "size_t s::key_stream(void *data, size_t position) const\n"\
   "{\n"\
+  "  position = dynamic_cast<const I&>(*this).key_stream(data, position);\n"\
   "  return position;\n"\
   "}\n\n"\
   "bool s::key(ddsi_keyhash_t &hash) const\n"\
@@ -1241,7 +1244,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "}\n\n"\
   "size_t I::read_struct(const void *data, size_t position)\n"\
   "{\n"\
-  "  position += (4 - position&0x3)&0x3;  //alignment\n"\
+  "  position += (4 - (position&0x3))&0x3;  //alignment\n"\
   "  inherited_member() = *((int32_t*)((char*)data+position));  //reading bytes for member: inherited_member()\n"\
   "  position += 4;  //moving position indicator\n"\
   "  return position;\n"\
@@ -1249,7 +1252,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "size_t s::read_struct(const void *data, size_t position)\n"\
   "{\n"\
   "  position = dynamic_cast<I&>(*this).read_struct(data, position);\n"\
-  "  position += (4 - position&0x3)&0x3;  //alignment\n"\
+  "  position += (4 - (position&0x3))&0x3;  //alignment\n"\
   "  new_member() = *((int32_t*)((char*)data+position));  //reading bytes for member: new_member()\n"\
   "  position += 4;  //moving position indicator\n"\
   "  return position;\n"\
@@ -1258,10 +1261,10 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 #define BSI "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n"\
   "size_t s::write_struct(void *data, size_t position) const\n"\
   "{\n"\
-  "  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+  "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
   "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
   "  position += alignmentbytes;  //moving position indicator\n"\
-  "  uint32_t sequenceentries = mem().size();  //number of entries in the sequence\n"\
+  "  uint32_t sequenceentries = (uint32_t) mem().size();  //number of entries in the sequence\n"\
   "  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing entries for member: mem()\n"\
   "  position += 4;  //moving position indicator\n"\
   "  if (sequenceentries > 20) throw dds::core::InvalidArgumentError(\"attempt to assign entries to bounded member mem() in excess of maximum length 20\");\n"\
@@ -1271,7 +1274,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "}\n\n"\
   "size_t s::write_size(size_t position) const\n"\
   "{\n"\
-  "  position += (4 - position&0x3)&0x3;  //alignment\n"\
+  "  position += (4 - (position&0x3))&0x3;  //alignment\n"\
   "  position += 4;  //bytes for sequence entries\n"\
   "  position += (mem().size())*4;  //entries of sequence\n"\
   "  return position;\n"\
@@ -1314,7 +1317,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "}\n\n"\
   "size_t s::read_struct(const void *data, size_t position)\n"\
   "{\n"\
-  "  position += (4 - position&0x3)&0x3;  //alignment\n"\
+  "  position += (4 - (position&0x3))&0x3;  //alignment\n"\
   "  uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n"\
   "  position += 4;  //moving position indicator\n"\
   "  mem().assign((int32_t*)((char*)data+position),(int32_t*)((char*)data+position)+sequenceentries);  //putting data into container\n"\
@@ -1327,10 +1330,10 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "{\n\n"\
 "  size_t typedef_write_td_6(const td_6 &obj, void* data, size_t position)\n"\
 "  {\n"\
-"    size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+"    size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
 "    memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
 "    position += alignmentbytes;  //moving position indicator\n"\
-"    uint32_t sequenceentries = obj.size();  //number of entries in the sequence\n"\
+"    uint32_t sequenceentries = (uint32_t) obj.size();  //number of entries in the sequence\n"\
 "    *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing entries for member: obj\n"\
 "    position += 4;  //moving position indicator\n"\
 "    memcpy((char*)data+position,obj.data(),sequenceentries*4);  //contents for obj\n"\
@@ -1339,31 +1342,31 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  }\n\n"\
 "  size_t typedef_write_size_td_6(const td_6 &obj, size_t position)\n"\
 "  {\n"\
-"    position += (4 - position&0x3)&0x3;  //alignment\n"\
+"    position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "    position += 4;  //bytes for sequence entries\n"\
 "    position += (obj.size())*4;  //entries of sequence\n"\
 "    return position;\n"\
 "  }\n\n"\
 "  size_t typedef_key_size_td_6(const td_6 &obj, size_t position)\n"\
 "  {\n"\
-"    position += (4 - position&0x3)&0x3;  //alignment\n"\
+"    position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "    position += 4;  //bytes for sequence entries\n"\
 "    position += (obj.size())*4;  //entries of sequence\n"\
 "    return position;\n"\
 "  }\n\n"\
 "  size_t typedef_key_max_size_td_6(const td_6 &obj, size_t position)\n"\
 "  {\n"\
-"    if (position != UINT_MAX)   position += (4 - position&0x3)&0x3;  //alignment\n"\
+"    if (position != UINT_MAX)   position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "    if (position != UINT_MAX)   position += 4;  //bytes for sequence entries\n"\
 "    position = UINT_MAX;\n"\
 "    return position;\n"\
 "  }\n\n"\
 "  size_t typedef_key_stream_td_6(const td_6 &obj, void *data, size_t position)\n"\
 "  {\n"\
-"    size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+"    size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
 "    memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
 "    position += alignmentbytes;  //moving position indicator\n"\
-"    uint32_t sequenceentries = obj.size();  //number of entries in the sequence\n"\
+"    uint32_t sequenceentries = (uint32_t) obj.size();  //number of entries in the sequence\n"\
 "    *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing entries for member: obj\n"\
 "    position += 4;  //moving position indicator\n"\
 "    memcpy((char*)data+position,obj.data(),sequenceentries*4);  //contents for obj\n"\
@@ -1372,7 +1375,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  }\n\n"\
 "  size_t typedef_read_td_6(td_6 &obj, void* data, size_t position)\n"\
 "  {\n"\
-"    position += (4 - position&0x3)&0x3;  //alignment\n"\
+"    position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "    uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n"\
 "    position += 4;  //moving position indicator\n"\
 "    obj.assign((int32_t*)((char*)data+position),(int32_t*)((char*)data+position)+sequenceentries);  //putting data into container\n"\
@@ -1384,12 +1387,12 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "{\n\n"\
 "  size_t s::write_struct(void *data, size_t position) const\n"\
 "  {\n"\
-"    size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+"    size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
 "    memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
 "    position += alignmentbytes;  //moving position indicator\n"\
 "    *((int32_t*)((char*)data+position)) = mem_simple();  //writing bytes for member: mem_simple()\n"\
 "    position += 4;  //moving position indicator\n"\
-"    uint32_t sequenceentries = mem().size();  //number of entries in the sequence\n"\
+"    uint32_t sequenceentries = (uint32_t) mem().size();  //number of entries in the sequence\n"\
 "    *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing entries for member: mem()\n"\
 "    position += 4;  //moving position indicator\n"\
 "    for (size_t _i = 0; _i < sequenceentries; _i++)   position = M::typedef_write_td_6(mem()[_i],data,position);\n"\
@@ -1397,7 +1400,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  }\n\n"\
 "  size_t s::write_size(size_t position) const\n"\
 "  {\n"\
-"    position += (4 - position&0x3)&0x3;  //alignment\n"\
+"    position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "    position += 4;  //bytes for member: mem_simple()\n"\
 "    position += 4;  //bytes for sequence entries\n"\
 "    for (size_t _i = 0; _i < sequenceentries; _i++)   position = M::typedef_write_size_td_6(mem()[_i], position);\n"\
@@ -1441,7 +1444,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  }\n\n"\
 "  size_t s::read_struct(const void *data, size_t position)\n"\
 "  {\n"\
-"    position += (4 - position&0x3)&0x3;  //alignment\n"\
+"    position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "    mem_simple() = *((int32_t*)((char*)data+position));  //reading bytes for member: mem_simple()\n"\
 "    position += 4;  //moving position indicator\n"\
 "    uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n"\
@@ -1470,7 +1473,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "{\n"\
 "  *((uint8_t*)((char*)data+position)) = o();  //writing bytes for member: o()\n"\
 "  position += 1;  //moving position indicator\n"\
-"  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+"  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
 "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
 "  position += alignmentbytes;  //moving position indicator\n"\
 "  *((int32_t*)((char*)data+position)) = l();  //writing bytes for member: l()\n"\
@@ -1480,25 +1483,25 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "size_t s::write_size(size_t position) const\n"\
 "{\n"\
 "  position += 1;  //bytes for member: o()\n"\
-"  position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "  position += 4;  //bytes for member: l()\n"\
 "  return position;\n"\
 "}\n\n"\
 "size_t s::key_size(size_t position) const\n"\
 "{\n"\
-"  position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "  position += 4;  //bytes for member: l()\n"\
 "  return position;\n"\
 "}\n\n"\
 "size_t s::key_max_size(size_t position) const\n"\
 "{\n"\
-"  if (position != UINT_MAX)   position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  if (position != UINT_MAX)   position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "  if (position != UINT_MAX)   position += 4;  //bytes for member: l()\n"\
 "  return position;\n"\
 "}\n\n"\
 "size_t s::key_stream(void *data, size_t position) const\n"\
 "{\n"\
-"  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+"  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
 "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
 "  position += alignmentbytes;  //moving position indicator\n"\
 "  *((int32_t*)((char*)data+position)) = l();  //writing bytes for member: l()\n"\
@@ -1533,7 +1536,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "{\n"\
 "  o() = *((uint8_t*)((char*)data+position));  //reading bytes for member: o()\n"\
 "  position += 1;  //moving position indicator\n"\
-"  position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "  l() = *((int32_t*)((char*)data+position));  //reading bytes for member: l()\n"\
 "  position += 4;  //moving position indicator\n"\
 "  return position;\n"\
@@ -1544,7 +1547,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "{\n"\
 "  *((uint8_t*)((char*)data+position)) = o();  //writing bytes for member: o()\n"\
 "  position += 1;  //moving position indicator\n"\
-"  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+"  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
 "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
 "  position += alignmentbytes;  //moving position indicator\n"\
 "  *((int32_t*)((char*)data+position)) = l();  //writing bytes for member: l()\n"\
@@ -1556,7 +1559,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  *((uint8_t*)((char*)data+position)) = o();  //writing bytes for member: o()\n"\
 "  position += 1;  //moving position indicator\n"\
 "  position = s_().write_struct(data, position);\n"\
-"  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+"  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
 "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
 "  position += alignmentbytes;  //moving position indicator\n"\
 "  *((int32_t*)((char*)data+position)) = l();  //writing bytes for member: l()\n"\
@@ -1566,7 +1569,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "size_t s::write_size(size_t position) const\n"\
 "{\n"\
 "  position += 1;  //bytes for member: o()\n"\
-"  position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "  position += 4;  //bytes for member: l()\n"\
 "  return position;\n"\
 "}\n\n"\
@@ -1574,39 +1577,39 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "{\n"\
 "  position += 1;  //bytes for member: o()\n"\
 "  position = s_().write_size(position);\n"\
-"  position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "  position += 4;  //bytes for member: l()\n"\
 "  return position;\n"\
 "}\n\n"\
 "size_t s::key_size(size_t position) const\n"\
 "{\n"\
-"  position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "  position += 4;  //bytes for member: l()\n"\
 "  return position;\n"\
 "}\n\n"\
 "size_t ss::key_size(size_t position) const\n"\
 "{\n"\
 "  position = s_().key_size(position);\n"\
-"  position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "  position += 4;  //bytes for member: l()\n"\
 "  return position;\n"\
 "}\n\n"\
 "size_t s::key_max_size(size_t position) const\n"\
 "{\n"\
-"  if (position != UINT_MAX)   position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  if (position != UINT_MAX)   position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "  if (position != UINT_MAX)   position += 4;  //bytes for member: l()\n"\
 "  return position;\n"\
 "}\n\n"\
 "size_t ss::key_max_size(size_t position) const\n"\
 "{\n"\
 "  if (position != UINT_MAX)   position = s_().key_max_size(position);\n"\
-"  if (position != UINT_MAX)   position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  if (position != UINT_MAX)   position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "  if (position != UINT_MAX)   position += 4;  //bytes for member: l()\n"\
 "  return position;\n"\
 "}\n\n"\
 "size_t s::key_stream(void *data, size_t position) const\n"\
 "{\n"\
-"  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+"  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
 "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
 "  position += alignmentbytes;  //moving position indicator\n"\
 "  *((int32_t*)((char*)data+position)) = l();  //writing bytes for member: l()\n"\
@@ -1640,7 +1643,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "size_t ss::key_stream(void *data, size_t position) const\n"\
 "{\n"\
 "  position = s_().key_stream(data, position);\n"\
-"  alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+"  alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
 "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
 "  position += alignmentbytes;  //moving position indicator\n"\
 "  *((int32_t*)((char*)data+position)) = l();  //writing bytes for member: l()\n"\
@@ -1675,7 +1678,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "{\n"\
 "  o() = *((uint8_t*)((char*)data+position));  //reading bytes for member: o()\n"\
 "  position += 1;  //moving position indicator\n"\
-"  position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "  l() = *((int32_t*)((char*)data+position));  //reading bytes for member: l()\n"\
 "  position += 4;  //moving position indicator\n"\
 "  return position;\n"\
@@ -1685,7 +1688,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  o() = *((uint8_t*)((char*)data+position));  //reading bytes for member: o()\n"\
 "  position += 1;  //moving position indicator\n"\
 "  position = s_().read_struct(data, position);\n"\
-"  position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "  l() = *((int32_t*)((char*)data+position));  //reading bytes for member: l()\n"\
 "  position += 4;  //moving position indicator\n"\
 "  return position;\n"\
@@ -1694,10 +1697,10 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 #define TDKI "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n"\
 "size_t typedef_write_td_1(const td_1 &obj, void* data, size_t position)\n"\
 "{\n"\
-"  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+"  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
 "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
 "  position += alignmentbytes;  //moving position indicator\n"\
-"  uint32_t sequenceentries = obj.size();  //number of entries in the sequence\n"\
+"  uint32_t sequenceentries = (uint32_t) obj.size();  //number of entries in the sequence\n"\
 "  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing entries for member: obj\n"\
 "  position += 4;  //moving position indicator\n"\
 "  memcpy((char*)data+position,obj.data(),sequenceentries*4);  //contents for obj\n"\
@@ -1713,7 +1716,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "}\n\n"\
 "size_t typedef_write_size_td_1(const td_1 &obj, size_t position)\n"\
 "{\n"\
-"  position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "  position += 4;  //bytes for sequence entries\n"\
 "  position += (obj.size())*4;  //entries of sequence\n"\
 "  return position;\n"\
@@ -1726,7 +1729,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "}\n\n"\
 "size_t typedef_key_size_td_1(const td_1 &obj, size_t position)\n"\
 "{\n"\
-"  position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "  position += 4;  //bytes for sequence entries\n"\
 "  position += (obj.size())*4;  //entries of sequence\n"\
 "  return position;\n"\
@@ -1738,7 +1741,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "}\n\n"\
 "size_t typedef_key_max_size_td_1(const td_1 &obj, size_t position)\n"\
 "{\n"\
-"  if (position != UINT_MAX)   position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  if (position != UINT_MAX)   position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "  if (position != UINT_MAX)   position += 4;  //bytes for sequence entries\n"\
 "  position = UINT_MAX;\n"\
 "  return position;\n"\
@@ -1750,10 +1753,10 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "}\n\n"\
 "size_t typedef_key_stream_td_1(const td_1 &obj, void *data, size_t position)\n"\
 "{\n"\
-"  size_t alignmentbytes = (4 - position&0x3)&0x3;  //alignment\n"\
+"  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
 "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
 "  position += alignmentbytes;  //moving position indicator\n"\
-"  uint32_t sequenceentries = obj.size();  //number of entries in the sequence\n"\
+"  uint32_t sequenceentries = (uint32_t) obj.size();  //number of entries in the sequence\n"\
 "  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing entries for member: obj\n"\
 "  position += 4;  //moving position indicator\n"\
 "  memcpy((char*)data+position,obj.data(),sequenceentries*4);  //contents for obj\n"\
@@ -1791,7 +1794,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "}\n\n"\
 "size_t typedef_read_td_1(td_1 &obj, void* data, size_t position)\n"\
 "{\n"\
-"  position += (4 - position&0x3)&0x3;  //alignment\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "  uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n"\
 "  position += 4;  //moving position indicator\n"\
 "  obj.assign((int32_t*)((char*)data+position),(int32_t*)((char*)data+position)+sequenceentries);  //putting data into container\n"\

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -126,6 +126,7 @@ void create_funcs_base(idl_ostream_t * ostr, size_t n, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t s::key_stream(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -238,6 +239,7 @@ void create_funcs_instance(idl_ostream_t* ostr, const char* in, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t I::key_stream(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -268,6 +270,7 @@ void create_funcs_instance(idl_ostream_t* ostr, const char* in, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t s::key_stream(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -326,7 +329,6 @@ void create_funcs_string(idl_ostream_t* ostr, const char* in, bool ns)
     format_ostream_indented(0, ostr, "namespace N\n{\n\n");
   }
 
-
   format_ostream_indented(ns * 2, ostr, "size_t s::write_struct(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n");
@@ -343,8 +345,9 @@ void create_funcs_string(idl_ostream_t* ostr, const char* in, bool ns)
   format_ostream_indented(ns * 2, ostr, "size_t s::write_size(size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = (uint32_t) %s().size()+1;  //number of entries in the sequence\n", in);
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for sequence entries\n", in);
-  format_ostream_indented(ns * 2, ostr, "  position += (%s().size()+1)*1;  //entries of sequence\n", in);
+  format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*1;  //entries of sequence\n", in);
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -360,6 +363,7 @@ void create_funcs_string(idl_ostream_t* ostr, const char* in, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t s::key_stream(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -438,12 +442,13 @@ void create_funcs_sequence(idl_ostream_t* ostr, const char* seq_name, size_t n, 
   format_ostream_indented(ns * 2, ostr, "size_t s::write_size(size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  uint32_t sequenceentries = (uint32_t) %s().size();  //number of entries in the sequence\n", seq_name);
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for sequence entries\n", seq_name);
   if (width > 4)
   {
     format_ostream_indented(ns * 2, ostr, "  position += (%d - (position&%#x))&%#x;  //alignment\n", width, width - 1, width - 1);
   }
-  format_ostream_indented(ns * 2, ostr, "  position += (%s().size())*%d;  //entries of sequence\n", seq_name, width);
+  format_ostream_indented(ns * 2, ostr, "  position += sequenceentries*%d;  //entries of sequence\n", width);
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -459,6 +464,7 @@ void create_funcs_sequence(idl_ostream_t* ostr, const char* seq_name, size_t n, 
 
   format_ostream_indented(ns * 2, ostr, "size_t s::key_stream(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -587,8 +593,9 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "    case 4:\n");
   format_ostream_indented(ns * 2, ostr, "    case 5:\n");
   format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      uint32_t sequenceentries = (uint32_t) str().size()+1;  //number of entries in the sequence\n");
   format_ostream_indented(ns * 2, ostr, "      position += 4;  //bytes for sequence entries\n");
-  format_ostream_indented(ns * 2, ostr, "      position += (str().size()+1)*1;  //entries of sequence\n");
+  format_ostream_indented(ns * 2, ostr, "      position += sequenceentries*1;  //entries of sequence\n");
   format_ostream_indented(ns * 2, ostr, "    }\n");
   format_ostream_indented(ns * 2, ostr, "    break;\n");
   format_ostream_indented(ns * 2, ostr, "    default:\n");
@@ -621,8 +628,9 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "    case 4:\n");
   format_ostream_indented(ns * 2, ostr, "    case 5:\n");
   format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      uint32_t sequenceentries = (uint32_t) str().size()+1;  //number of entries in the sequence\n");
   format_ostream_indented(ns * 2, ostr, "      position += 4;  //bytes for sequence entries\n");
-  format_ostream_indented(ns * 2, ostr, "      position += (str().size()+1)*1;  //entries of sequence\n");
+  format_ostream_indented(ns * 2, ostr, "      position += sequenceentries*1;  //entries of sequence\n");
   format_ostream_indented(ns * 2, ostr, "    }\n");
   format_ostream_indented(ns * 2, ostr, "    break;\n");
   format_ostream_indented(ns * 2, ostr, "    default:\n");
@@ -666,6 +674,7 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t s::key_stream(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
   format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
@@ -781,7 +790,84 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
 
 void generate_enum_funcs(idl_ostream_t* ostr, bool ns)
 {
-  create_funcs_base(ostr, 7, ns);
+  format_ostream_indented(0, ostr, "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n");
+
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "namespace N\n{\n\n");
+  }
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::write_struct(void *data, size_t position) const\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n");
+  format_ostream_indented(ns * 2, ostr, "  position += alignmentbytes;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  *((%sE*)((char*)data+position)) = mem();  //writing bytes for member: mem()\n", ns ? "N::" : "");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::write_size(size_t position) const\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //bytes for member: mem()\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_size(size_t position) const\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_max_size(size_t position) const\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_stream(void *data, size_t position) const\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "bool s::key(ddsi_keyhash_t &hash) const\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t sz = key_size(0);\n");
+  format_ostream_indented(ns * 2, ostr, "  size_t padding = 16 - sz%%16;\n");
+  format_ostream_indented(ns * 2, ostr, "  if (sz != 0 && padding == 16) padding = 0;\n");
+  format_ostream_indented(ns * 2, ostr, "  std::vector<unsigned char> buffer(sz+padding);\n");
+  format_ostream_indented(ns * 2, ostr, "  memset(buffer.data()+sz,0x0,padding);\n");
+  format_ostream_indented(ns * 2, ostr, "  key_stream(buffer.data(),0);\n");
+  format_ostream_indented(ns * 2, ostr, "  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n");
+  format_ostream_indented(ns * 2, ostr, "  if (fptr == NULL)\n");
+  format_ostream_indented(ns * 2, ostr, "  {\n");
+  format_ostream_indented(ns * 2, ostr, "    if (key_max_size(0) <= 16)\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      //bind to unmodified function which just copies buffer into the keyhash\n");
+  format_ostream_indented(ns * 2, ostr, "      fptr = &org::eclipse::cyclonedds::topic::simple_key;\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    else\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      //bind to MD5 hash function\n");
+  format_ostream_indented(ns * 2, ostr, "      fptr = &org::eclipse::cyclonedds::topic::complex_key;\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "  }\n");
+  format_ostream_indented(ns * 2, ostr, "  return (*fptr)(buffer,hash);\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::read_struct(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  mem() = *((%sE*)((char*)data+position));  //reading bytes for member: mem()\n", ns ? "N::" : "");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  if (ns)
+  {
+    format_ostream_indented(0, ostr, "} //end namespace N\n\n");
+  }
+
 }
 
 void generate_array_base_funcs(idl_ostream_t* ostr, bool ns)
@@ -825,6 +911,7 @@ void generate_array_base_funcs(idl_ostream_t* ostr, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t s::key_stream(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -932,6 +1019,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t I::key_stream(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -962,6 +1050,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 
   format_ostream_indented(ns * 2, ostr, "size_t s::key_stream(void *data, size_t position) const\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
@@ -1041,6 +1130,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "    }\n\n"\
 "    size_t s_1::key_stream(void *data, size_t position) const\n"\
 "    {\n"\
+"      (void)data;\n"\
 "      return position;\n"\
 "    }\n\n"\
 "    bool s_1::key(ddsi_keyhash_t &hash) const\n"\
@@ -1100,6 +1190,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "    }\n\n"\
 "    size_t s_2::key_stream(void *data, size_t position) const\n"\
 "    {\n"\
+"      (void)data;\n"\
 "      return position;\n"\
 "    }\n\n"\
 "    bool s_2::key(ddsi_keyhash_t &hash) const\n"\
@@ -1187,6 +1278,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "}\n\n"\
   "size_t I::key_stream(void *data, size_t position) const\n"\
   "{\n"\
+  "  (void)data;\n"\
   "  return position;\n"\
   "}\n\n"\
   "bool I::key(ddsi_keyhash_t &hash) const\n"\
@@ -1215,6 +1307,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "}\n\n"\
   "size_t s::key_stream(void *data, size_t position) const\n"\
   "{\n"\
+  "  (void)data;\n"\
   "  position = dynamic_cast<const I&>(*this).key_stream(data, position);\n"\
   "  return position;\n"\
   "}\n\n"\
@@ -1275,8 +1368,9 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "size_t s::write_size(size_t position) const\n"\
   "{\n"\
   "  position += (4 - (position&0x3))&0x3;  //alignment\n"\
+  "  uint32_t sequenceentries = (uint32_t) mem().size();  //number of entries in the sequence\n"\
   "  position += 4;  //bytes for sequence entries\n"\
-  "  position += (mem().size())*4;  //entries of sequence\n"\
+  "  position += sequenceentries*4;  //entries of sequence\n"\
   "  return position;\n"\
   "}\n\n"\
   "size_t s::key_size(size_t position) const\n"\
@@ -1289,6 +1383,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "}\n\n"\
   "size_t s::key_stream(void *data, size_t position) const\n"\
   "{\n"\
+  "  (void)data;\n"\
   "  return position;\n"\
   "}\n\n"\
   "bool s::key(ddsi_keyhash_t &hash) const\n"\
@@ -1343,19 +1438,22 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  size_t typedef_write_size_td_6(const td_6 &obj, size_t position)\n"\
 "  {\n"\
 "    position += (4 - (position&0x3))&0x3;  //alignment\n"\
+"    uint32_t sequenceentries = (uint32_t) obj.size();  //number of entries in the sequence\n"\
 "    position += 4;  //bytes for sequence entries\n"\
-"    position += (obj.size())*4;  //entries of sequence\n"\
+"    position += sequenceentries*4;  //entries of sequence\n"\
 "    return position;\n"\
 "  }\n\n"\
 "  size_t typedef_key_size_td_6(const td_6 &obj, size_t position)\n"\
 "  {\n"\
 "    position += (4 - (position&0x3))&0x3;  //alignment\n"\
+"    uint32_t sequenceentries = (uint32_t) obj.size();  //number of entries in the sequence\n"\
 "    position += 4;  //bytes for sequence entries\n"\
-"    position += (obj.size())*4;  //entries of sequence\n"\
+"    position += sequenceentries*4;  //entries of sequence\n"\
 "    return position;\n"\
 "  }\n\n"\
 "  size_t typedef_key_max_size_td_6(const td_6 &obj, size_t position)\n"\
 "  {\n"\
+"    (void)obj;\n"\
 "    (void)position;\n"\
 "    return UINT_MAX;\n"\
 "  }\n\n"\
@@ -1371,7 +1469,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "    position += sequenceentries*4;  //moving position indicator\n"\
 "    return position;\n"\
 "  }\n\n"\
-"  size_t typedef_read_td_6(td_6 &obj, void* data, size_t position)\n"\
+"  size_t typedef_read_td_6(td_6 &obj, const void* data, size_t position)\n"\
 "  {\n"\
 "    position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "    uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n"\
@@ -1400,6 +1498,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  {\n"\
 "    position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "    position += 4;  //bytes for member: mem_simple()\n"\
+"    uint32_t sequenceentries = (uint32_t) mem().size();  //number of entries in the sequence\n"\
 "    position += 4;  //bytes for sequence entries\n"\
 "    for (size_t _i = 0; _i < sequenceentries; _i++)   position = M::typedef_write_size_td_6(mem()[_i], position);\n"\
 "    return position;\n"\
@@ -1414,6 +1513,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  }\n\n"\
 "  size_t s::key_stream(void *data, size_t position) const\n"\
 "  {\n"\
+"    (void)data;\n"\
 "    return position;\n"\
 "  }\n\n"\
 "  bool s::key(ddsi_keyhash_t &hash) const\n"\
@@ -1457,85 +1557,11 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "{\n\n"\
 "  size_t typedef_write_td_6(const td_6 &obj, void* data, size_t position);\n\n"\
 "  size_t typedef_write_size_td_6(const td_6 &obj, size_t position);\n\n"\
-"  size_t typedef_read_td_6(td_6 &obj, void* data, size_t position);\n\n"\
+"  size_t typedef_read_td_6(td_6 &obj, const void* data, size_t position);\n\n"\
 "  size_t typedef_key_stream_td_6(const td_6 &obj, void *data, size_t position);\n\n"\
 "  size_t typedef_key_size_td_6(const td_6 &obj, size_t position);\n\n"\
 "  size_t typedef_key_max_size_td_6(const td_6 &obj, size_t position);\n\n"\
 "} //end namespace M\n\n"
-
-#define KBI "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n"\
-"size_t s::write_struct(void *data, size_t position) const\n"\
-"{\n"\
-"  *((uint8_t*)((char*)data+position)) = o();  //writing bytes for member: o()\n"\
-"  position += 1;  //moving position indicator\n"\
-"  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
-"  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
-"  position += alignmentbytes;  //moving position indicator\n"\
-"  *((int32_t*)((char*)data+position)) = l();  //writing bytes for member: l()\n"\
-"  position += 4;  //moving position indicator\n"\
-"  return position;\n"\
-"}\n\n"\
-"size_t s::write_size(size_t position) const\n"\
-"{\n"\
-"  position += 1;  //bytes for member: o()\n"\
-"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
-"  position += 4;  //bytes for member: l()\n"\
-"  return position;\n"\
-"}\n\n"\
-"size_t s::key_size(size_t position) const\n"\
-"{\n"\
-"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
-"  position += 4;  //bytes for member: l()\n"\
-"  return position;\n"\
-"}\n\n"\
-"size_t s::key_max_size(size_t position) const\n"\
-"{\n"\
-"  if (position != UINT_MAX)   position += (4 - (position&0x3))&0x3;  //alignment\n"\
-"  if (position != UINT_MAX)   position += 4;  //bytes for member: l()\n"\
-"  return position;\n"\
-"}\n\n"\
-"size_t s::key_stream(void *data, size_t position) const\n"\
-"{\n"\
-"  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
-"  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
-"  position += alignmentbytes;  //moving position indicator\n"\
-"  *((int32_t*)((char*)data+position)) = l();  //writing bytes for member: l()\n"\
-"  position += 4;  //moving position indicator\n"\
-"  return position;\n"\
-"}\n\n"\
-"bool s::key(ddsi_keyhash_t &hash) const\n"\
-"{\n"\
-"  size_t sz = key_size(0);\n"\
-"  size_t padding = 16 - sz%16;\n"\
-"  if (sz != 0 && padding == 16) padding = 0;\n"\
-"  std::vector<unsigned char> buffer(sz+padding);\n"\
-"  memset(buffer.data()+sz,0x0,padding);\n"\
-"  key_stream(buffer.data(),0);\n"\
-"  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n"\
-"  if (fptr == NULL)\n"\
-"  {\n"\
-"    if (key_max_size(0) <= 16)\n"\
-"    {\n"\
-"      //bind to unmodified function which just copies buffer into the keyhash\n"\
-"      fptr = &org::eclipse::cyclonedds::topic::simple_key;\n"\
-"    }\n"\
-"    else\n"\
-"    {\n"\
-"      //bind to MD5 hash function\n"\
-"      fptr = &org::eclipse::cyclonedds::topic::complex_key;\n"\
-"    }\n"\
-"  }\n"\
-"  return (*fptr)(buffer,hash);\n"\
-"}\n\n"\
-"size_t s::read_struct(const void *data, size_t position)\n"\
-"{\n"\
-"  o() = *((uint8_t*)((char*)data+position));  //reading bytes for member: o()\n"\
-"  position += 1;  //moving position indicator\n"\
-"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
-"  l() = *((int32_t*)((char*)data+position));  //reading bytes for member: l()\n"\
-"  position += 4;  //moving position indicator\n"\
-"  return position;\n"\
-"}\n\n"
 
 #define KSI "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n"\
 "size_t s::write_struct(void *data, size_t position) const\n"\
@@ -1604,6 +1630,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "}\n\n"\
 "size_t s::key_stream(void *data, size_t position) const\n"\
 "{\n"\
+"  (void)data;\n"\
 "  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
 "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
 "  position += alignmentbytes;  //moving position indicator\n"\
@@ -1637,8 +1664,9 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "}\n\n"\
 "size_t ss::key_stream(void *data, size_t position) const\n"\
 "{\n"\
+"  (void)data;\n"\
 "  position = s_().key_stream(data, position);\n"\
-"  alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
+"  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
 "  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
 "  position += alignmentbytes;  //moving position indicator\n"\
 "  *((int32_t*)((char*)data+position)) = l();  //writing bytes for member: l()\n"\
@@ -1689,76 +1717,46 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  return position;\n"\
 "}\n\n"
 
-#define TDKI "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n"\
-"size_t typedef_write_td_1(const td_1 &obj, void* data, size_t position)\n"\
-"{\n"\
-"  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
-"  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
-"  position += alignmentbytes;  //moving position indicator\n"\
-"  uint32_t sequenceentries = (uint32_t) obj.size();  //number of entries in the sequence\n"\
-"  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing entries for member: obj\n"\
-"  position += 4;  //moving position indicator\n"\
-"  memcpy((char*)data+position,obj.data(),sequenceentries*4);  //contents for obj\n"\
-"  position += sequenceentries*4;  //moving position indicator\n"\
-"  return position;\n"\
-"}\n\n"\
+
+#define KBI "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n"\
 "size_t s::write_struct(void *data, size_t position) const\n"\
 "{\n"\
 "  *((uint8_t*)((char*)data+position)) = o();  //writing bytes for member: o()\n"\
 "  position += 1;  //moving position indicator\n"\
-"  position = typedef_write_td_1(t(), data, position);\n"\
-"  return position;\n"\
-"}\n\n"\
-"size_t typedef_write_size_td_1(const td_1 &obj, size_t position)\n"\
-"{\n"\
-"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
-"  position += 4;  //bytes for sequence entries\n"\
-"  position += (obj.size())*4;  //entries of sequence\n"\
+"  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
+"  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
+"  position += alignmentbytes;  //moving position indicator\n"\
+"  *((int32_t*)((char*)data+position)) = l();  //writing bytes for member: l()\n"\
+"  position += 4;  //moving position indicator\n"\
 "  return position;\n"\
 "}\n\n"\
 "size_t s::write_size(size_t position) const\n"\
 "{\n"\
 "  position += 1;  //bytes for member: o()\n"\
-"  position = typedef_write_size_td_1(t(), position);\n"\
-"  return position;\n"\
-"}\n\n"\
-"size_t typedef_key_size_td_1(const td_1 &obj, size_t position)\n"\
-"{\n"\
 "  position += (4 - (position&0x3))&0x3;  //alignment\n"\
-"  position += 4;  //bytes for sequence entries\n"\
-"  position += (obj.size())*4;  //entries of sequence\n"\
+"  position += 4;  //bytes for member: l()\n"\
 "  return position;\n"\
 "}\n\n"\
 "size_t s::key_size(size_t position) const\n"\
 "{\n"\
-"  position = typedef_key_size_td_1(t(), position);\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
+"  position += 4;  //bytes for member: l()\n"\
 "  return position;\n"\
-"}\n\n"\
-"size_t typedef_key_max_size_td_1(const td_1 &obj, size_t position)\n"\
-"{\n"\
-"  (void)position;\n"\
-"  return UINT_MAX;\n"\
 "}\n\n"\
 "size_t s::key_max_size(size_t position) const\n"\
 "{\n"\
-"  position = typedef_key_max_size_td_1(t(), position);\n"\
-"  return position;\n"\
-"}\n\n"\
-"size_t typedef_key_stream_td_1(const td_1 &obj, void *data, size_t position)\n"\
-"{\n"\
-"  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
-"  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
-"  position += alignmentbytes;  //moving position indicator\n"\
-"  uint32_t sequenceentries = (uint32_t) obj.size();  //number of entries in the sequence\n"\
-"  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing entries for member: obj\n"\
-"  position += 4;  //moving position indicator\n"\
-"  memcpy((char*)data+position,obj.data(),sequenceentries*4);  //contents for obj\n"\
-"  position += sequenceentries*4;  //moving position indicator\n"\
+"  if (position != UINT_MAX)   position += (4 - (position&0x3))&0x3;  //alignment\n"\
+"  if (position != UINT_MAX)   position += 4;  //bytes for member: l()\n"\
 "  return position;\n"\
 "}\n\n"\
 "size_t s::key_stream(void *data, size_t position) const\n"\
 "{\n"\
-"  position = typedef_key_stream_td_1(t(), *data, position);\n"\
+"  (void)data;\n"\
+"  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
+"  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
+"  position += alignmentbytes;  //moving position indicator\n"\
+"  *((int32_t*)((char*)data+position)) = l();  //writing bytes for member: l()\n"\
+"  position += 4;  //moving position indicator\n"\
 "  return position;\n"\
 "}\n\n"\
 "bool s::key(ddsi_keyhash_t &hash) const\n"\
@@ -1785,7 +1783,117 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  }\n"\
 "  return (*fptr)(buffer,hash);\n"\
 "}\n\n"\
-"size_t typedef_read_td_1(td_1 &obj, void* data, size_t position)\n"\
+"size_t s::read_struct(const void *data, size_t position)\n"\
+"{\n"\
+"  o() = *((uint8_t*)((char*)data+position));  //reading bytes for member: o()\n"\
+"  position += 1;  //moving position indicator\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
+"  l() = *((int32_t*)((char*)data+position));  //reading bytes for member: l()\n"\
+"  position += 4;  //moving position indicator\n"\
+"  return position;\n"\
+"}\n\n"
+
+#define TDKI "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n"\
+"size_t typedef_write_td_1(const td_1 &obj, void* data, size_t position)\n"\
+"{\n"\
+"  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
+"  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
+"  position += alignmentbytes;  //moving position indicator\n"\
+"  uint32_t sequenceentries = (uint32_t) obj.size();  //number of entries in the sequence\n"\
+"  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing entries for member: obj\n"\
+"  position += 4;  //moving position indicator\n"\
+"  memcpy((char*)data+position,obj.data(),sequenceentries*4);  //contents for obj\n"\
+"  position += sequenceentries*4;  //moving position indicator\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t s::write_struct(void *data, size_t position) const\n"\
+"{\n"\
+"  *((uint8_t*)((char*)data+position)) = o();  //writing bytes for member: o()\n"\
+"  position += 1;  //moving position indicator\n"\
+"  position = typedef_write_td_1(t(), data, position);\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t typedef_write_size_td_1(const td_1 &obj, size_t position)\n"\
+"{\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
+"  uint32_t sequenceentries = (uint32_t) obj.size();  //number of entries in the sequence\n"\
+"  position += 4;  //bytes for sequence entries\n"\
+"  position += sequenceentries*4;  //entries of sequence\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t s::write_size(size_t position) const\n"\
+"{\n"\
+"  position += 1;  //bytes for member: o()\n"\
+"  position = typedef_write_size_td_1(t(), position);\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t typedef_key_size_td_1(const td_1 &obj, size_t position)\n"\
+"{\n"\
+"  position += (4 - (position&0x3))&0x3;  //alignment\n"\
+"  uint32_t sequenceentries = (uint32_t) obj.size();  //number of entries in the sequence\n"\
+"  position += 4;  //bytes for sequence entries\n"\
+"  position += sequenceentries*4;  //entries of sequence\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t s::key_size(size_t position) const\n"\
+"{\n"\
+"  position = typedef_key_size_td_1(t(), position);\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t typedef_key_max_size_td_1(const td_1 &obj, size_t position)\n"\
+"{\n"\
+"  (void)obj;\n"\
+"  (void)position;\n"\
+"  return UINT_MAX;\n"\
+"}\n\n"\
+"size_t s::key_max_size(size_t position) const\n"\
+"{\n"\
+"  position = typedef_key_max_size_td_1(t(), position);\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t typedef_key_stream_td_1(const td_1 &obj, void *data, size_t position)\n"\
+"{\n"\
+"  size_t alignmentbytes = (4 - (position&0x3))&0x3;  //alignment\n"\
+"  memset((char*)data+position,0x0,alignmentbytes);  //setting alignment bytes to 0x0\n"\
+"  position += alignmentbytes;  //moving position indicator\n"\
+"  uint32_t sequenceentries = (uint32_t) obj.size();  //number of entries in the sequence\n"\
+"  *((uint32_t*)((char*)data + position)) = sequenceentries;  //writing entries for member: obj\n"\
+"  position += 4;  //moving position indicator\n"\
+"  memcpy((char*)data+position,obj.data(),sequenceentries*4);  //contents for obj\n"\
+"  position += sequenceentries*4;  //moving position indicator\n"\
+"  return position;\n"\
+"}\n\n"\
+"size_t s::key_stream(void *data, size_t position) const\n"\
+"{\n"\
+"  (void)data;\n"\
+"  position = typedef_key_stream_td_1(t(), data, position);\n"\
+"  return position;\n"\
+"}\n\n"\
+"bool s::key(ddsi_keyhash_t &hash) const\n"\
+"{\n"\
+"  size_t sz = key_size(0);\n"\
+"  size_t padding = 16 - sz%16;\n"\
+"  if (sz != 0 && padding == 16) padding = 0;\n"\
+"  std::vector<unsigned char> buffer(sz+padding);\n"\
+"  memset(buffer.data()+sz,0x0,padding);\n"\
+"  key_stream(buffer.data(),0);\n"\
+"  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;\n"\
+"  if (fptr == NULL)\n"\
+"  {\n"\
+"    if (key_max_size(0) <= 16)\n"\
+"    {\n"\
+"      //bind to unmodified function which just copies buffer into the keyhash\n"\
+"      fptr = &org::eclipse::cyclonedds::topic::simple_key;\n"\
+"    }\n"\
+"    else\n"\
+"    {\n"\
+"      //bind to MD5 hash function\n"\
+"      fptr = &org::eclipse::cyclonedds::topic::complex_key;\n"\
+"    }\n"\
+"  }\n"\
+"  return (*fptr)(buffer,hash);\n"\
+"}\n\n"\
+"size_t typedef_read_td_1(td_1 &obj, const void* data, size_t position)\n"\
 "{\n"\
 "  position += (4 - (position&0x3))&0x3;  //alignment\n"\
 "  uint32_t sequenceentries = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n"\
@@ -1804,7 +1912,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 
 #define TDKH "size_t typedef_write_td_1(const td_1 &obj, void* data, size_t position);\n\n"\
 "size_t typedef_write_size_td_1(const td_1 &obj, size_t position);\n\n"\
-"size_t typedef_read_td_1(td_1 &obj, void* data, size_t position);\n\n"\
+"size_t typedef_read_td_1(td_1 &obj, const void* data, size_t position);\n\n"\
 "size_t typedef_key_stream_td_1(const td_1 &obj, void *data, size_t position);\n\n"\
 "size_t typedef_key_size_td_1(const td_1 &obj, size_t position);\n\n"\
 "size_t typedef_key_max_size_td_1(const td_1 &obj, size_t position);\n\n"

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -1356,10 +1356,8 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  }\n\n"\
 "  size_t typedef_key_max_size_td_6(const td_6 &obj, size_t position)\n"\
 "  {\n"\
-"    if (position != UINT_MAX)   position += (4 - (position&0x3))&0x3;  //alignment\n"\
-"    if (position != UINT_MAX)   position += 4;  //bytes for sequence entries\n"\
-"    position = UINT_MAX;\n"\
-"    return position;\n"\
+"    (void)position;\n"\
+"    return UINT_MAX;\n"\
 "  }\n\n"\
 "  size_t typedef_key_stream_td_6(const td_6 &obj, void *data, size_t position)\n"\
 "  {\n"\
@@ -1738,10 +1736,8 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "}\n\n"\
 "size_t typedef_key_max_size_td_1(const td_1 &obj, size_t position)\n"\
 "{\n"\
-"  if (position != UINT_MAX)   position += (4 - (position&0x3))&0x3;  //alignment\n"\
-"  if (position != UINT_MAX)   position += 4;  //bytes for sequence entries\n"\
-"  position = UINT_MAX;\n"\
-"  return position;\n"\
+"  (void)position;\n"\
+"  return UINT_MAX;\n"\
 "}\n\n"\
 "size_t s::key_max_size(size_t position) const\n"\
 "{\n"\


### PR DESCRIPTION
Fixing compiler warnings in compiled code and code generated from idl files:
  - added missing copy assignment operators
  - fixed doxygen code creating compiler warnings
Generated code quality of life fixes:
  - no longer opening "empty" namespaces
  - max key size immediately returns the "infinite size" number when one member has infinite size,
     instead of calculating all previous and following members' maximum size as well
Number of bugfixes in serdata implementation, mainly related to calculating the hashes at the correct places