### PR TITLE
Fix issue where C++ topics would always be considered keyless.

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicTraits.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicTraits.hpp
@@ -57,9 +57,9 @@ public:
         return ::std::vector<uint8_t>();
     }
 
-    static const char *getKeyList()
+    static bool isKeyless()
     {
-        return "ExampleKeylist";
+        return true;
     }
 
     static const char *getTypeName()

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -431,7 +431,7 @@ ddscxx_sertopic<T>::ddscxx_sertopic(
     type_name,
     &ddscxx_sertopic<T>::ddscxx_sertopic_ops,
     &ddscxx_serdata<T>::ddscxx_serdata_ops,
-    true);
+    org::eclipse::cyclonedds::topic::TopicTraits<T>::isKeyless());
 }
 
 template <typename T>

--- a/src/idlcxx/include/idlcxx/backend.h
+++ b/src/idlcxx/include/idlcxx/backend.h
@@ -31,6 +31,11 @@
 #define IDL_CATEGORY_MASK (IDL_BASE_TYPE | IDL_TEMPL_TYPE | IDL_MODULE | IDL_STRUCT |\
             IDL_UNION | IDL_ENUM | IDL_TYPEDEF | IDL_CONST | IDL_MEMBER | IDL_DECLARATOR | IDL_CASE)
 
+/* An idl_retcode_t value used to abort a walk function.                      */
+/* An abort does not represent an error and should therefore not be negative. */
+/* To distinguish it from IDL_RETCODE_OK we come up with a new value here.    */
+#define IDL_RETCODE_ABORT 1
+
 typedef struct idl_file_out_s {
   FILE *file;
 } *idl_file_out;

--- a/src/idlcxx/src/backendCpp11Type.c
+++ b/src/idlcxx/src/backendCpp11Type.c
@@ -1301,16 +1301,18 @@ cpp11_scope_walk(idl_backend_ctx ctx, const idl_node_t *node)
 
 typedef enum
 {
-  idl_no_dep      = 0x0,
-  idl_string_dep  = 0x01 << 0,
-  idl_array_dep   = 0x01 << 1,
-  idl_vector_dep  = 0x01 << 2,
-  idl_variant_dep = 0x01 << 3
+  idl_no_dep        = 0x0,
+  idl_string_dep    = 0x01 << 0,
+  idl_array_dep     = 0x01 << 1,
+  idl_vector_dep    = 0x01 << 2,
+  idl_variant_dep   = 0x01 << 3,
+  idl_optional_dep  = 0x01 << 4
 } idl_include_dep;
 
 static idl_retcode_t
 get_util_dependencies(idl_backend_ctx ctx, const idl_node_t *node)
 {
+  idl_retcode_t result = IDL_RETCODE_OK;
   idl_include_dep *dependency_mask = (idl_include_dep *) idl_get_custom_context(ctx);
 
   switch (node->mask & IDL_CATEGORY_MASK)
@@ -1323,6 +1325,7 @@ get_util_dependencies(idl_backend_ctx ctx, const idl_node_t *node)
     {
     case IDL_SEQUENCE:
       (*dependency_mask) |= idl_vector_dep;
+      result = get_util_dependencies(ctx, ((const idl_sequence_t *)node)->type_spec);
       break;
     case IDL_STRING:
       (*dependency_mask) |= idl_string_dep;
@@ -1339,7 +1342,7 @@ get_util_dependencies(idl_backend_ctx ctx, const idl_node_t *node)
   default:
     break;
   }
-  return IDL_RETCODE_OK;
+  return result;
 }
 
 static void

--- a/src/idlcxx/src/backendCpp11Utils.c
+++ b/src/idlcxx/src/backendCpp11Utils.c
@@ -259,6 +259,9 @@ get_cpp11_base_type_const_value(const idl_constval_t *constval)
   {
   case IDL_BOOL:
     return idl_strdup(constval->value.bln ? "true" : "false");
+  case IDL_OCTET:
+    cnt = idl_asprintf(&str, "%" PRIu8, constval->value.oct);
+    break;
   case IDL_INT8:
     cnt = idl_asprintf(&str, "%" PRId8, constval->value.int8);
     break;


### PR DESCRIPTION
A new Trait function is now generated that determines whether a type
has keys or not. The outcome of this new function is now used to set
the is_keyed propery correctly.

Signed-off-by: Erik Hendriks <erik.hendriks@adlinktech.com>