### PR TITLE
Fixes for generated code and datawriter/reader

### DIFF
--- a/src/ddscxx/include/dds/pub/detail/DataWriterImpl.hpp
+++ b/src/ddscxx/include/dds/pub/detail/DataWriterImpl.hpp
@@ -397,8 +397,6 @@ dds::pub::detail::DataWriter<T>::DataWriter(
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ddsc_writer, "Could not create DataWriter.");
     topic_.delegate()->incrNrDependents();
 
-    this->setSampleSize(org::eclipse::cyclonedds::topic::TopicTraits<T>::getSampleSize());
-
     this->set_ddsc_entity(ddsc_writer);
 
     this->listener(listener, mask);

--- a/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
@@ -503,7 +503,6 @@ dds::sub::detail::DataReader<T>::common_constructor(
 
     this->AnyDataReaderDelegate::td_.delegate()->incrNrDependents();
 
-    this->AnyDataReaderDelegate::setSampleSize(org::eclipse::cyclonedds::topic::TopicTraits<T>::getSampleSize());
     this->AnyDataReaderDelegate::setSample(&this->typed_sample_);
     this->set_ddsc_entity(ddsc_reader);
     this->listener(listener, mask);

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.hpp
@@ -104,16 +104,6 @@ protected:
     AnyDataWriterDelegate(const dds::pub::qos::DataWriterQos& qos,
                           const dds::topic::TopicDescription& td);
 
-    inline void setSampleSize(size_t _sampleSize)
-    {
-        this->sampleSize = _sampleSize;
-    }
-
-    inline size_t getSampleSize()
-    {
-        return this->sampleSize;
-    }
-
     void
     write(dds_entity_t writer,
           const void *data,
@@ -161,9 +151,6 @@ protected:
                     const void *data);
 
 private:
-    org::eclipse::cyclonedds::topic::copyInFunction  copyIn;
-    org::eclipse::cyclonedds::topic::copyOutFunction copyOut;
-    size_t sampleSize;
     dds::pub::qos::DataWriterQos qos_;
     dds::topic::TopicDescription td_;
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.hpp
@@ -163,16 +163,6 @@ public:
     void add_query(org::eclipse::cyclonedds::sub::QueryDelegate& query);
     void remove_query(org::eclipse::cyclonedds::sub::QueryDelegate& query);
 
-    inline void setSampleSize(size_t _sampleSize)
-    {
-        this->sampleSize = _sampleSize;
-    }
-
-    inline size_t getSampleSize() const
-    {
-        return this->sampleSize;
-    }
-
     void setSample(void* sample);
     void* getSample() const;
 
@@ -242,10 +232,6 @@ private:
             dds_sample_info_t*& c_sample_infos);
 
 protected:
-
-    org::eclipse::cyclonedds::topic::copyInFunction  copyIn;
-    org::eclipse::cyclonedds::topic::copyOutFunction copyOut;
-    size_t sampleSize;
     org::eclipse::cyclonedds::core::ObjectSet queries;
     dds::sub::qos::DataReaderQos qos_;
     dds::topic::TopicDescription td_;

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/AnyTopicDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/AnyTopicDelegate.hpp
@@ -98,7 +98,6 @@ protected:
                      const std::string& type_name);
 
     dds::topic::qos::TopicQos qos_;
-    org::eclipse::cyclonedds::topic::copyOutFunction copyOut;
     void* sample_;
 };
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicTraits.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicTraits.hpp
@@ -30,10 +30,6 @@ namespace cyclonedds
 namespace topic
 {
 
-typedef void (*copyInFunction)(const void *, void *);
-typedef void (*copyOutFunction)(const void *, void *);
-
-
 template <class TOPIC> class TopicTraits
 {
 public:

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -58,10 +58,10 @@ class ddscxx_serdata : public ddsi_serdata {
   std::unique_ptr<unsigned char[]> m_data{ nullptr };
   ddsi_keyhash_t m_key;
   bool m_key_md5_hashed = false;
-  bool hash_populated = false;
   T m_t = T();
 
 public:
+  bool hash_populated = false;
   static const struct ddsi_serdata_ops ddscxx_serdata_ops;
   ddscxx_serdata(const ddsi_sertopic* topic, ddsi_serdata_kind kind);
 
@@ -265,6 +265,7 @@ ddsi_serdata_t *serdata_from_sample(
       assert(0);
     }
     d->key_md5_hashed() = msg->key(d->key());
+    d->getT() = *msg;
     d->populate_hash();
 
     return d;
@@ -322,7 +323,9 @@ ddsi_serdata_t *serdata_to_topicless(const struct ddsi_serdata* dcmn)
   auto t = d->getT();
   d1->resize(t.key_size(0));
   t.key_write(d1->data(), 0);
+  d1->key_md5_hashed() = t.key(d1->key());
   d1->hash = d->hash;
+  d1->hash_populated = true;
 
   return d1;
 }

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
@@ -37,7 +37,7 @@ namespace pub
 AnyDataWriterDelegate::AnyDataWriterDelegate(
         const dds::pub::qos::DataWriterQos& qos,
         const dds::topic::TopicDescription& td)
-    : copyIn(NULL), copyOut(NULL), sampleSize(0), qos_(qos), td_(td)
+    : qos_(qos), td_(td)
 {
 }
 
@@ -111,22 +111,17 @@ AnyDataWriterDelegate::writedispose(
     const dds::core::Time& timestamp)
 {
     dds_return_t ret;
-    void *c_sample;
 
     /* Ignore the handle until ddsc supports writes with instance handles. */
     (void)handle;
 
-    c_sample = dds_alloc(this->sampleSize);
-    (*(this->copyIn))(data, c_sample);
-
     if (timestamp != dds::core::Time::invalid()) {
         dds_time_t ddsc_time = org::eclipse::cyclonedds::core::convertTime(timestamp);
-        ret = dds_writedispose_ts(writer, c_sample, ddsc_time);
+        ret = dds_writedispose_ts(writer, data, ddsc_time);
     } else {
-        ret = dds_writedispose(writer, c_sample);
+        ret = dds_writedispose(writer, data);
     }
 
-    dds_free (c_sample);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ret, "writedispose failed.");
 }
 
@@ -136,21 +131,14 @@ AnyDataWriterDelegate::register_instance(
     const void *data,
     const dds::core::Time& timestamp)
 {
-    dds_instance_handle_t ih;
-    dds_return_t ret;
-    void *c_sample;
-
     if (timestamp != dds::core::Time::invalid()) {
         ISOCPP_THROW_EXCEPTION(ISOCPP_UNSUPPORTED_ERROR,
                                "Registering with a timestamp is not supported.");
     }
 
-    c_sample = dds_alloc(this->sampleSize);
-    (*(this->copyIn))(data, c_sample);
+    dds_instance_handle_t ih;
+    dds_return_t ret = dds_register_instance(writer, &ih, data);
 
-    ret = dds_register_instance(writer, &ih, c_sample);
-
-    dds_free (c_sample);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ret, "dds_instance_register failed.");
 
     return ih;
@@ -188,24 +176,19 @@ AnyDataWriterDelegate::unregister_instance(
     const dds::core::Time& timestamp)
 {
     dds_return_t ret;
-    void *c_sample;
 
     if (data == NULL)   {
         ISOCPP_THROW_EXCEPTION(ISOCPP_PRECONDITION_NOT_MET_ERROR,
                                "data is null");
     }
 
-    c_sample = dds_alloc(this->sampleSize);
-    (*(this->copyIn))(data, c_sample);
-
     if (timestamp != dds::core::Time::invalid()) {
         dds_time_t ddsc_time = org::eclipse::cyclonedds::core::convertTime(timestamp);
-        ret = dds_unregister_instance_ts(writer, c_sample, ddsc_time);
+        ret = dds_unregister_instance_ts(writer, data, ddsc_time);
     } else {
-        ret = dds_unregister_instance(writer, c_sample);
+        ret = dds_unregister_instance(writer, data);
     }
 
-    dds_free (c_sample);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ret, "unregister failed.");
 }
 
@@ -241,24 +224,19 @@ AnyDataWriterDelegate::dispose_instance(
     const dds::core::Time& timestamp)
 {
     dds_return_t ret;
-    void *c_sample;
 
     if (data == NULL)   {
         ISOCPP_THROW_EXCEPTION(ISOCPP_PRECONDITION_NOT_MET_ERROR,
                                "data is null");
     }
 
-    c_sample = dds_alloc(this->sampleSize);
-    (*(this->copyIn))(data, c_sample);
-
     if (timestamp != dds::core::Time::invalid()) {
         dds_time_t ddsc_time = org::eclipse::cyclonedds::core::convertTime(timestamp);
-        ret = dds_dispose_ts(writer, c_sample, ddsc_time);
+        ret = dds_dispose_ts(writer, data, ddsc_time);
     } else {
-        ret = dds_dispose(writer, c_sample);
+        ret = dds_dispose(writer, data);
     }
 
-    dds_free (c_sample);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ret, "dispose failed.");
 }
 
@@ -268,10 +246,7 @@ AnyDataWriterDelegate::get_key_value(
     void *data,
     const dds::core::InstanceHandle& handle)
 {
-    void* cKey = dds_alloc (sampleSize);
-    dds_return_t ret = dds_instance_get_key(writer, handle.delegate().handle(), cKey);
-    copyOut(cKey, data);
-    dds_free(cKey);
+    dds_return_t ret = dds_instance_get_key(writer, handle.delegate().handle(), data);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ret, "dds_instance_get_key failed.");
 }
 
@@ -280,13 +255,7 @@ AnyDataWriterDelegate::lookup_instance(
     dds_entity_t writer,
     const void *data)
 {
-    void *c_sample;
-    c_sample = dds_alloc (sampleSize);
-    (*copyIn)(data, c_sample);
-
-    dds_instance_handle_t handle = dds_lookup_instance (writer, c_sample);
-    dds_free (c_sample);
-    return handle;
+    return dds_lookup_instance(writer, data);
 }
 
 const ::dds::core::status::LivelinessLostStatus

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
@@ -48,7 +48,7 @@ struct ReaderCopyInfo {
 AnyDataReaderDelegate::AnyDataReaderDelegate(
         const dds::sub::qos::DataReaderQos& qos,
         const dds::topic::TopicDescription& td)
-  : copyIn(NULL), copyOut(NULL), sampleSize(0), qos_(qos), td_(td), sample_(0)
+  : qos_(qos), td_(td), sample_(0)
 {
 }
 
@@ -441,34 +441,19 @@ AnyDataReaderDelegate::get_key_value(
     const dds::core::InstanceHandle& handle,
     void *key)
 {
-    dds_return_t ret;
-    void *cKey;
-
     org::eclipse::cyclonedds::core::ScopedObjectLock scopedLock(*this);
     this->check();
 
-    cKey = dds_alloc (sampleSize);
-    ret = dds_instance_get_key(reader, handle.delegate().handle(), cKey);
-    copyOut(cKey, key);
-    dds_free(cKey);
+    dds_return_t ret = dds_instance_get_key(reader, handle.delegate().handle(), key);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ret, "dds_instance_get_key failed.");
 }
 
 dds_instance_handle_t AnyDataReaderDelegate::lookup_instance
   (const dds_entity_t reader, const void *key) const
 {
-    dds_instance_handle_t handle;
-    void *cKey;
-
     org::eclipse::cyclonedds::core::ScopedObjectLock scopedLock(*this);
     this->check();
-
-    cKey = dds_alloc (sampleSize);
-    copyIn (key, cKey);
-    handle = dds_lookup_instance (reader, cKey);
-    dds_free (cKey);
-
-    return handle;
+    return dds_lookup_instance(reader, key);
 }
 
 dds::core::status::LivelinessChangedStatus

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/AnyTopicDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/AnyTopicDelegate.cpp
@@ -42,7 +42,6 @@ AnyTopicDelegate::AnyTopicDelegate(
     : org::eclipse::cyclonedds::core::EntityDelegate(),
       org::eclipse::cyclonedds::topic::TopicDescriptionDelegate(dp, name, type_name),
       qos_(qos),
-      copyOut(NULL),
       sample_(NULL)
 {
 }
@@ -56,7 +55,6 @@ AnyTopicDelegate::AnyTopicDelegate(
     : org::eclipse::cyclonedds::core::EntityDelegate(),
       org::eclipse::cyclonedds::topic::TopicDescriptionDelegate(dp, name, type_name),
       qos_(qos),
-      copyOut(NULL),
       sample_(NULL)
 {
     this->ddsc_entity = ddsc_topic;

--- a/src/idlcxx/src/streamer_generator.c
+++ b/src/idlcxx/src/streamer_generator.c
@@ -94,8 +94,10 @@ if (key) {format_key_read_stream(indent,ctx,_str, ##__VA_ARGS__);}
 #define primitive_read_func_read "  %s = *((%s*)((char*)data+position));  //reading bytes for member: %s\n"
 #define primitive_read_func_array "  memcpy(%s.data(),(char*)data+position,%d);  //reading bytes for member: %s\n"
 #define primitive_read_func_seq seqentries" = *((uint32_t*)((char*)data+position));  //number of entries in the sequence\n"
-#define primitive_write_seq "  memcpy((char*)data+position,%s.data(),"seqentries"*%d); //writing bytes for member: %s\n"
+#define primitive_write_seq "memcpy((char*)data+position,%s.data(),"seqentries"*%d); //writing bytes for member: %s\n"
+#define primitive_write_seq_checked "  if (0 < %s.size()) " primitive_write_seq
 #define primitive_read_seq "  %s.assign((%s*)((char*)data+position),(%s*)((char*)data+position)+"seqentries"); //reading bytes for member: %s\n"
+#define string_write "  " primitive_write_seq
 #define bool_write_seq "  for (size_t _b = 0; _b < "seqentries"; _b++) *((char*)data+position++) = (%s[_b] ? 0x1 : 0x0); //writing bytes for member: %s\n"
 #define bool_read_seq "  for (size_t _b = 0; _b < "seqentries"; _b++) %s[_b] = (*((char*)data+position++) ? 0x1 : 0x0); //reading bytes for member: %s\n"
 #define sequence_iterate "  for (size_t _i%d = 0; _i%d < "seqentries"; _i%d++) {\n"
@@ -1529,7 +1531,7 @@ idl_retcode_t process_string_impl(context_t* ctx, const char* accessor, idl_stri
   }
 
   //data
-  format_write_stream(1, ctx, is_key, primitive_write_seq, accessor, ctx->depth, 1, accessor);
+  format_write_stream(1, ctx, is_key, string_write, accessor, ctx->depth, 1, accessor);
   format_write_stream(1, ctx, is_key, seq_inc_1 entries_of_sequence_comment, ctx->depth);
   format_write_size_stream(1, ctx, is_key, seq_inc_1 entries_of_sequence_comment, ctx->depth);
 
@@ -1628,7 +1630,7 @@ idl_retcode_t process_sequence_impl(context_t* ctx, const char* accessor, idl_se
     }
     else
     {
-      format_write_stream(1, ctx, is_key, primitive_write_seq, accessor, ctx->depth, bytewidth, accessor);
+      format_write_stream(1, ctx, is_key, primitive_write_seq_checked, accessor, accessor, ctx->depth, bytewidth, accessor);
       format_write_stream(1, ctx, is_key, seq_incr entries_of_sequence_comment, ctx->depth, bytewidth);
       format_read_stream(1, ctx, is_key, primitive_read_seq, accessor, cast, cast, ctx->depth, accessor);
       format_read_stream(1, ctx, is_key, seq_incr entries_of_sequence_comment, ctx->depth, bytewidth);

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -494,7 +494,7 @@ void create_funcs_sequence(idl_ostream_t* ostr, const char* seq_name, size_t n, 
   }
   else
   {
-    format_ostream_indented(ns * 2, ostr, "  memcpy((char*)data+position,%s().data(),%s*%d); //writing bytes for member: %s()\n", seq_name, se, width, seq_name);
+    format_ostream_indented(ns * 2, ostr, "  if (0 < %s().size()) memcpy((char*)data+position,%s().data(),%s*%d); //writing bytes for member: %s()\n", seq_name, seq_name, se, width, seq_name);
     format_ostream_indented(ns * 2, ostr, "  position += %s*%d;  //entries of sequence\n", se, width);
   }
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
@@ -1505,7 +1505,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   "  *((uint32_t*)((char*)data + position)) = _se0;  //writing entries for member: mem()\n"\
   "  position += 4;  //moving position indicator\n"\
   "  if (_se0 > 20) throw dds::core::InvalidArgumentError(\"attempt to assign entries to bounded member mem() in excess of maximum length 20\");\n"\
-  "  memcpy((char*)data+position,mem().data(),_se0*4); //writing bytes for member: mem()\n"\
+  "  if (0 < mem().size()) memcpy((char*)data+position,mem().data(),_se0*4); //writing bytes for member: mem()\n"\
   "  position += _se0*4;  //entries of sequence\n"\
   "  return position;\n"\
   "}\n\n"\
@@ -1580,7 +1580,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "    uint32_t _se1 = (uint32_t) obj.size();  //number of entries in the sequence\n"\
 "    *((uint32_t*)((char*)data + position)) = _se1;  //writing entries for member: obj\n"\
 "    position += 4;  //moving position indicator\n"\
-"    memcpy((char*)data+position,obj.data(),_se1*4); //writing bytes for member: obj\n"\
+"    if (0 < obj.size()) memcpy((char*)data+position,obj.data(),_se1*4); //writing bytes for member: obj\n"\
 "    position += _se1*4;  //entries of sequence\n"\
 "    return position;\n"\
 "  }\n\n"\
@@ -1614,7 +1614,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "    uint32_t _se1 = (uint32_t) obj.size();  //number of entries in the sequence\n"\
 "    *((uint32_t*)((char*)data + position)) = _se1;  //writing entries for member: obj\n"\
 "    position += 4;  //moving position indicator\n"\
-"    memcpy((char*)data+position,obj.data(),_se1*4); //writing bytes for member: obj\n"\
+"    if (0 < obj.size()) memcpy((char*)data+position,obj.data(),_se1*4); //writing bytes for member: obj\n"\
 "    position += _se1*4;  //entries of sequence\n"\
 "    return position;\n"\
 "  }\n\n"\
@@ -1997,7 +1997,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  uint32_t _se0 = (uint32_t) obj.size();  //number of entries in the sequence\n"\
 "  *((uint32_t*)((char*)data + position)) = _se0;  //writing entries for member: obj\n"\
 "  position += 4;  //moving position indicator\n"\
-"  memcpy((char*)data+position,obj.data(),_se0*4); //writing bytes for member: obj\n"\
+"  if (0 < obj.size()) memcpy((char*)data+position,obj.data(),_se0*4); //writing bytes for member: obj\n"\
 "  position += _se0*4;  //entries of sequence\n"\
 "  return position;\n"\
 "}\n\n"\
@@ -2054,7 +2054,7 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 "  uint32_t _se0 = (uint32_t) obj.size();  //number of entries in the sequence\n"\
 "  *((uint32_t*)((char*)data + position)) = _se0;  //writing entries for member: obj\n"\
 "  position += 4;  //moving position indicator\n"\
-"  memcpy((char*)data+position,obj.data(),_se0*4); //writing bytes for member: obj\n"\
+"  if (0 < obj.size()) memcpy((char*)data+position,obj.data(),_se0*4); //writing bytes for member: obj\n"\
 "  position += _se0*4;  //entries of sequence\n"\
 "  return position;\n"\
 "}\n\n"\


### PR DESCRIPTION
In generated code, the vector is checked for emptyness before memcopying the container
Removed the use of c99 to c++ copy functions in datawriter/reader since these are no longer necessary