### PR TITLE
Extend ContentFilteredTopic and allow static configuration from C++

### DIFF
--- a/src/ddscxx/include/dds/domain/TDomainParticipant.hpp
+++ b/src/ddscxx/include/dds/domain/TDomainParticipant.hpp
@@ -21,6 +21,7 @@
 
 #include <string>
 
+#include <dds/ddsi/ddsi_config.h>
 #include <dds/core/detail/conformance.hpp>
 #include <dds/core/types.hpp>
 #include <dds/core/Time.hpp>
@@ -140,6 +141,12 @@ public:
                        dds::domain::DomainParticipantListener*         listener = NULL,
                        const dds::core::status::StatusMask&            event_mask = dds::core::status::StatusMask::none(),
                        const std::string&                              config = std::string());
+
+    TDomainParticipant(uint32_t                                        id,
+                       const dds::domain::qos::DomainParticipantQos&   qos,
+                       dds::domain::DomainParticipantListener*         listener,
+                       const dds::core::status::StatusMask&            event_mask,
+                       const ddsi_config&                              config);
     /**
     * Copy assignment operator.
     *

--- a/src/ddscxx/include/dds/domain/detail/TDomainParticipantImpl.hpp
+++ b/src/ddscxx/include/dds/domain/detail/TDomainParticipantImpl.hpp
@@ -58,6 +58,18 @@ TDomainParticipant<DELEGATE>::TDomainParticipant(uint32_t id,
 }
 
 template <typename DELEGATE>
+TDomainParticipant<DELEGATE>::TDomainParticipant(uint32_t id,
+        const dds::domain::qos::DomainParticipantQos& qos,
+        dds::domain::DomainParticipantListener* listener,
+        const dds::core::status::StatusMask& mask,
+        const ddsi_config& config) :
+    ::dds::core::Reference<DELEGATE>(new DELEGATE(id, qos, listener, mask, config))
+{
+    this->delegate()->init(this->impl_);
+    org::eclipse::cyclonedds::domain::DomainParticipantRegistry::insert(*this);
+}
+
+template <typename DELEGATE>
 TDomainParticipant<DELEGATE>::~TDomainParticipant() { }
 
 template <typename DELEGATE>

--- a/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.hpp
@@ -54,6 +54,12 @@ public:
                               const dds::core::status::StatusMask& mask,
                               const std::string& config);
 
+    DomainParticipantDelegate(uint32_t id,
+                              const dds::domain::qos::DomainParticipantQos& qos,
+                              dds::domain::DomainParticipantListener *listener,
+                              const dds::core::status::StatusMask& mask,
+                              const ddsi_config& config);
+
     virtual ~DomainParticipantDelegate();
 
 public:

--- a/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainWrap.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainWrap.hpp
@@ -58,6 +58,7 @@ public:
 
 public:
     DomainWrap(dds_domainid_t id, const std::string& config);
+    DomainWrap(dds_domainid_t id, const ddsi_config& config);
     ~DomainWrap();
 
 private:

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.hpp
@@ -107,7 +107,7 @@ public:
     virtual ~AnyDataReaderDelegate();
 
     static void copy_sample_infos(
-        dds_sample_info_t &from,
+        const dds_sample_info_t &from,
         dds::sub::SampleInfo &to);
 
 public:

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.hpp
@@ -70,7 +70,7 @@ public:
 
     //@todo virtual c_value *reader_parameters() const = 0;
 
-    ddsi_sertopic *get_ser_topic();
+    ddsi_sertopic *get_ser_topic() const;
 
 protected:
     dds::domain::DomainParticipant myParticipant;

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -447,23 +447,15 @@ void sertopic_free(struct ddsi_sertopic* tpcmn)
 }
 
 template <typename T>
-void sertopic_zero_samples(const struct ddsi_sertopic* d, void* samples, size_t count)
+void sertopic_zero_samples(const struct ddsi_sertopic*, void*, size_t)
 {
-  (void)d;
-  (void)samples;
-  (void)count;
+  return;
 }
 
 template <typename T>
 void sertopic_realloc_samples(
-  void** ptrs, const struct ddsi_sertopic* d, void* old,
-  size_t oldcount, size_t count)
+  void** ptrs, const struct ddsi_sertopic*, void*, size_t, size_t)
 {
-  (void)d;
-  (void)oldcount;
-  (void)old;
-  (void)count;
-
   /* For C++ we make one big assumption about the caller of this function:
    * it can only be invoked by the ddsi_sertopic_alloc_sample, and will therefore
    * never be used to reallocate an existing sample collection. This is caused by
@@ -476,21 +468,13 @@ void sertopic_realloc_samples(
    * be invoked by ddsi_sertopic_alloc_sample, in which case oldCount is always 0,
    * count is always 1 and the old pointer is always null.
    */
-  assert(oldcount == 0);
-  assert(count == 1);
-  assert(old == nullptr);
-
   ptrs[0] = new T();
 }
 
 template <typename T>
 void sertopic_free_samples(
-  const struct ddsi_sertopic* d, void** ptrs, size_t count,
-  dds_free_op_t op)
+  const struct ddsi_sertopic*, void** ptrs, size_t, dds_free_op_t op)
 {
-  (void)d;
-  (void)count;
-
   /* For C++ we make one big assumption about the caller of this function:
    * it can only be invoked by the ddsi_sertopic_free_sample, and will therefore
    * never be used to free an existing sample collection. This is caused by
@@ -503,8 +487,6 @@ void sertopic_free_samples(
    * be invoked by ddsi_sertopic_free_sample, in which case count is always 1,
    * and the op flags can either be set to DDS_FREE_ALL_BIT, or to DDS_FREE_CONTENTS_BIT.
    */
-  assert(count == 1);
-
   T* ptr = reinterpret_cast<T *>(ptrs[0]);
   if (op & DDS_FREE_ALL_BIT) {
     delete ptr;

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainWrap.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainWrap.cpp
@@ -32,6 +32,12 @@ org::eclipse::cyclonedds::domain::DomainWrap::DomainWrap(dds_domainid_t id, cons
     }
 }
 
+org::eclipse::cyclonedds::domain::DomainWrap::DomainWrap(dds_domainid_t id, const struct ddsi_config& config)
+{
+    this->ddsc_domain = dds_create_domain_with_rawconfig(id, &config);
+    ISOCPP_DDSC_RESULT_CHECK_AND_THROW(this->ddsc_domain, "Failed to create domain explicitly.");
+}
+
 org::eclipse::cyclonedds::domain::DomainWrap::~DomainWrap()
 {
     if (this->ddsc_domain > 0) {

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
@@ -682,7 +682,7 @@ AnyDataReaderDelegate::remove_query(
 
 void
 AnyDataReaderDelegate::copy_sample_infos(
-    dds_sample_info_t &from,
+    const dds_sample_info_t &from,
     dds::sub::SampleInfo &to)
 {
     org::eclipse::cyclonedds::sub::SampleInfoImpl& info = to.delegate();

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.cpp
@@ -86,7 +86,7 @@ TopicDescriptionDelegate::hasDependents() const
 }
 
 ddsi_sertopic *
-TopicDescriptionDelegate::get_ser_topic()
+TopicDescriptionDelegate::get_ser_topic() const
 {
     return ser_topic_;
 }


### PR DESCRIPTION
The PR builds on the [extended topic filter interface in Eclipse Cyclone DDS](https://github.com/eclipse-cyclonedds/cyclonedds/pull/606) and allows users to set alternative filter functions and filter on:
* sample
* sample and a user specified argument; or
* sampleinfo and a user specified argument; or
* sample, sampleinfo and a user specified argument

Next to that, this PR enables users to [set config programatically](https://github.com/eclipse-cyclonedds/cyclonedds/pull/604) from C++ by adding a DomainParticipant constructor that takes a `ddsi_config`.

@reicheratwork, if you would be so kind and review the changes, that'd be much appreciated.