### PR TITLE
Add byteswapping for different orderings

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/byteswapping.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/byteswapping.hpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#ifndef IDL_BYTESWAPPING_HPP
+#define IDL_BYTESWAPPING_HPP
+
+namespace org
+{
+  namespace eclipse
+  {
+    namespace cyclonedds
+    {
+      namespace topic
+      {
+
+        inline void bswap_16(void* in)
+        {
+          uint16_t& tmp = *(static_cast<uint16_t*>(in));
+          //cast to 16 bit type done here to suppress warnings of conversion to 32 bit type in bit shift
+          tmp = static_cast<uint16_t>(tmp >> 8) | static_cast<uint16_t>(tmp << 8);
+        }
+
+        inline void bswap_32(void* in)
+        {
+          uint32_t& tmp = *(static_cast<uint32_t*>(in));
+          // swap adjacent 16-bit blocks
+          tmp = ((tmp & 0xFFFF0000) >> 16) | ((tmp & 0x0000FFFF) << 16);
+          // swap adjacent 8-bit blocks
+          tmp = ((tmp & 0xFF00FF00) >> 8) | ((tmp & 0x00FF00FF) << 8);
+        }
+
+        inline void bswap_64(void* in)
+        {
+          uint64_t& tmp = *(static_cast<uint64_t*>(in));
+          // swap adjacent 32-bit blocks
+          tmp = (tmp >> 32) | (tmp << 32);
+          // swap adjacent 16-bit blocks
+          tmp = ((tmp & 0xFFFF0000FFFF0000) >> 16) | ((tmp & 0x0000FFFF0000FFFF) << 16);
+          // swap adjacent 8-bit blocks
+          tmp = ((tmp & 0xFF00FF00FF00FF00) >> 8) | ((tmp & 0x00FF00FF00FF00FF) << 8);
+        }
+
+      }
+    }
+  }
+}
+
+#endif

--- a/src/idlcxx/src/backendCpp11Type.c
+++ b/src/idlcxx/src/backendCpp11Type.c
@@ -226,10 +226,12 @@ generate_streamer_interfaces(idl_backend_ctx ctx)
   idl_file_out_printf(ctx, "size_t write_size(size_t offset) const;\n");
   idl_file_out_printf(ctx, "size_t max_size(size_t offset) const;\n");
   idl_file_out_printf(ctx, "size_t read_struct(const void* data, size_t position);\n");
+  idl_file_out_printf(ctx, "size_t read_struct_swapped(const void* data, size_t position);\n");
   idl_file_out_printf(ctx, "size_t key_size(size_t position) const;\n");
   idl_file_out_printf(ctx, "size_t key_max_size(size_t position) const;\n");
   idl_file_out_printf(ctx, "size_t key_write(void* data, size_t position) const;\n");
   idl_file_out_printf(ctx, "size_t key_read(const void* data, size_t position);\n");
+  idl_file_out_printf(ctx, "size_t key_read_swapped(const void* data, size_t position);\n");
   idl_file_out_printf(ctx, "bool key(ddsi_keyhash_t& hash) const;\n");
   idl_indent_decr(ctx);
   return IDL_RETCODE_OK;

--- a/src/idlcxx/src/streamer_generator.c
+++ b/src/idlcxx/src/streamer_generator.c
@@ -51,6 +51,9 @@ format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->key_write_stream, __VA_A
 #define format_key_read_stream(indent,ctx, ...) \
 format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->key_read_stream, __VA_ARGS__);
 
+#define format_key_read_swapped_stream(indent,ctx, ...) \
+format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->key_read_swapped_stream, __VA_ARGS__);
+
 #define format_max_size_stream(indent,ctx,key, ...) \
 format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->max_size_stream, __VA_ARGS__); \
 if (key) { format_key_max_size_stream(indent, ctx, __VA_ARGS__); }
@@ -70,6 +73,10 @@ if (key) {format_key_size_stream(indent,ctx, __VA_ARGS__);}
 #define format_read_stream(indent,ctx,key, ...) \
 format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->read_stream, __VA_ARGS__); \
 if (key) {format_key_read_stream(indent,ctx, __VA_ARGS__);}
+
+#define format_read_swapped_stream(indent,ctx,key, ...) \
+format_ostream_indented(indent ? ctx->depth*2 : 0, ctx->read_swapped_stream, __VA_ARGS__); \
+if (key) {format_key_read_swapped_stream(indent,ctx, __VA_ARGS__);}
 
 #define namespace_declaration "namespace %s\n"
 #define namespace_closure "} //end " namespace_declaration "\n"
@@ -126,6 +133,7 @@ if (key) {format_key_read_stream(indent,ctx, __VA_ARGS__);}
 #define instance_write_func position_set "%s.write_struct(data, position);\n"
 #define instance_key_write_func position_set "%s.key_write(data, position);\n"
 #define instance_key_read_func position_set "%s.key_read(data, position);\n"
+#define instance_key_read_swapped_func position_set "%s.key_read_swapped(data, position);\n"
 #define instance_size_func_calc position_set "%s.write_size(position);\n"
 #define instance_key_size_func_calc position_set "%s.key_size(position);\n"
 #define instance_key_max_size_func_calc max_size_check position_set "%s.key_max_size(position);\n"
@@ -133,6 +141,7 @@ if (key) {format_key_read_stream(indent,ctx, __VA_ARGS__);}
 #define instance_key_max_size_union_func_calc "case_max = %s.key_max_size(case_max);\n"
 #define instance_max_size_func_union "case_max = %s.max_size(case_max);\n"
 #define instance_read_func position_set "%s.read_struct(data, position);\n"
+#define instance_read_swapped_func position_set "%s.read_struct_swapped(data, position);\n"
 #define const_ref_cast "dynamic_cast<const %s%s&>(*this)"
 #define ref_cast "dynamic_cast<%s%s&>(*this)"
 #define member_access "%s()"
@@ -140,31 +149,40 @@ if (key) {format_key_read_stream(indent,ctx, __VA_ARGS__);}
 #define write_size_func_define "size_t %s::write_size(size_t position) const"
 #define max_size_define "size_t %s::max_size(size_t position) const"
 #define read_func_define "size_t %s::read_struct(const void *data, size_t position)"
+#define read_swapped_func_define "size_t %s::read_struct_swapped(const void *data, size_t position)"
 #define key_size_define "size_t %s::key_size(size_t position) const"
 #define key_max_size_define "size_t %s::key_max_size(size_t position) const"
 #define key_write_define "size_t %s::key_write(void *data, size_t position) const"
 #define key_read_define "size_t %s::key_read(const void *data, size_t position)"
+#define key_read_swapped_define "size_t %s::key_read_swapped(const void *data, size_t position)"
 #define key_calc_define "bool %s::key(ddsi_keyhash_t &hash) const"
 #define typedef_write_define "size_t typedef_write_%s(const %s &obj, void* data, size_t position)"
 #define typedef_write_size_define "size_t typedef_write_size_%s(const %s &obj, size_t position)"
 #define typedef_read_define "size_t typedef_read_%s(%s &obj, const void* data, size_t position)"
+#define typedef_read_swapped_define "size_t typedef_read_swapped_%s(%s &obj, const void* data, size_t position)"
 #define typedef_max_size_define "size_t typedef_max_size_%s(const %s &obj, size_t position)"
 #define typedef_key_size_define "size_t typedef_key_size_%s(const %s &obj, size_t position)"
 #define typedef_key_max_size_define "size_t typedef_key_max_size_%s(const %s &obj, size_t position)"
 #define typedef_key_write_define "size_t typedef_key_write_%s(const %s &obj, void *data, size_t position)"
 #define typedef_key_read_define "size_t typedef_key_read_%s(%s &obj, const void *data, size_t position)"
+#define typedef_key_read_swapped_define "size_t typedef_key_read_swapped_%s(%s &obj, const void *data, size_t position)"
 #define typedef_write_call position_set "%stypedef_write_%s(%s, data, position);\n"
 #define typedef_write_size_call position_set "%stypedef_write_size_%s(%s, position);\n"
 #define typedef_read_call position_set "%stypedef_read_%s(%s, data, position);\n"
+#define typedef_read_swapped_call position_set "%stypedef_read_swapped_%s(%s, data, position);\n"
 #define typedef_max_size_call position_set "%stypedef_max_size_%s(%s, position);\n"
 #define typedef_key_size_call position_set "%stypedef_key_size_%s(%s, position);\n"
 #define typedef_key_max_size_call position_set "%stypedef_key_max_size_%s(%s, position);\n"
 #define typedef_key_write_call position_set "%stypedef_key_write_%s(%s, data, position);\n"
 #define typedef_key_read_call position_set "%stypedef_key_read_%s(%s, data, position);\n"
+#define typedef_key_read_swapped_call position_set "%stypedef_key_read_swapped_%s(%s, data, position);\n"
 #define union_case_max_check "if (case_max != UINT_MAX) "
 #define union_case_max_incr union_case_max_check "case_max += "
 #define union_case_max_set "case_max = "
 #define union_case_max_set_limit union_case_max_set "UINT_MAX;\n"
+#define swap_call "  org::eclipse::cyclonedds::topic::bswap_%d(&%s);\n"
+#define swap_call_array "    org::eclipse::cyclonedds::topic::bswap_%d(&"array_accessor");\n"
+#define swap_call_seqentries "  org::eclipse::cyclonedds::topic::bswap_32(&"seqentries");\n"
 
 #define char_cast "char"
 #define bool_cast "bool"
@@ -213,6 +231,7 @@ struct context
   idl_ostream_t* write_size_stream;
   idl_ostream_t* write_stream;
   idl_ostream_t* read_stream;
+  idl_ostream_t* read_swapped_stream;
   idl_ostream_t* key_size_stream;
   idl_ostream_t* max_size_stream;
   idl_ostream_t* max_size_intermediate_stream;
@@ -220,6 +239,7 @@ struct context
   idl_ostream_t* key_max_size_intermediate_stream;
   idl_ostream_t* key_write_stream;
   idl_ostream_t* key_read_stream;
+  idl_ostream_t* key_read_swapped_stream;
   size_t depth;
   functioncontents_t streamer_funcs;
   functioncontents_t key_funcs;
@@ -376,6 +396,7 @@ context_t* create_context(const char* name)
     ptr->write_size_stream = create_idl_ostream(NULL);
     ptr->write_stream = create_idl_ostream(NULL);
     ptr->read_stream = create_idl_ostream(NULL);
+    ptr->read_swapped_stream = create_idl_ostream(NULL);
     ptr->key_size_stream = create_idl_ostream(NULL);
     ptr->max_size_stream = create_idl_ostream(NULL);
     ptr->max_size_intermediate_stream = create_idl_ostream(NULL);
@@ -383,6 +404,7 @@ context_t* create_context(const char* name)
     ptr->key_max_size_intermediate_stream = create_idl_ostream(NULL);
     ptr->key_write_stream = create_idl_ostream(NULL);
     ptr->key_read_stream = create_idl_ostream(NULL);
+    ptr->key_read_swapped_stream = create_idl_ostream(NULL);
     reset_function_contents(&ptr->streamer_funcs);
     reset_function_contents(&ptr->key_funcs);
   }
@@ -432,7 +454,9 @@ void close_context(context_t* ctx, idl_streamer_output_t* str)
   transfer_ostream_buffer(ctx->key_max_size_stream, ctx->str->impl_stream);
   transfer_ostream_buffer(ctx->key_write_stream, ctx->str->impl_stream);
   transfer_ostream_buffer(ctx->key_read_stream, ctx->str->impl_stream);
+  transfer_ostream_buffer(ctx->key_read_swapped_stream, ctx->str->impl_stream);
   transfer_ostream_buffer(ctx->read_stream, ctx->str->impl_stream);
+  transfer_ostream_buffer(ctx->read_swapped_stream, ctx->str->impl_stream);
 
   if (get_ostream_buffer_position(ctx->str->impl_stream) != 0)
   {
@@ -462,7 +486,9 @@ void close_context(context_t* ctx, idl_streamer_output_t* str)
   destruct_idl_ostream(ctx->key_max_size_intermediate_stream);
   destruct_idl_ostream(ctx->key_write_stream);
   destruct_idl_ostream(ctx->key_read_stream);
+  destruct_idl_ostream(ctx->key_read_swapped_stream);
   destruct_idl_ostream(ctx->read_stream);
+  destruct_idl_ostream(ctx->read_swapped_stream);
 
   destruct_idl_streamer_output(ctx->str);
   free(ctx->context);
@@ -516,6 +542,7 @@ void start_array(context_t* ctx, uint64_t entries, bool is_key, bool* locals)
   format_write_size_stream(1, ctx, is_key, array_iterate, ctx->depth + 1, ctx->depth + 1, entries, ctx->depth + 1);
   format_write_stream(1, ctx, is_key, array_iterate, ctx->depth + 1, ctx->depth + 1, entries, ctx->depth + 1);
   format_read_stream(1, ctx, is_key, array_iterate, ctx->depth + 1, ctx->depth + 1, entries, ctx->depth + 1);
+  format_read_swapped_stream(1, ctx, is_key, array_iterate, ctx->depth + 1, ctx->depth + 1, entries, ctx->depth + 1);
   format_max_size_intermediate_stream(1, ctx, is_key, array_iterate, ctx->depth + 1, ctx->depth + 1, entries, ctx->depth + 1);
 
   ctx->depth++;
@@ -528,6 +555,7 @@ void stop_array(context_t* ctx, bool is_key, bool* locals)
   format_write_size_stream(1, ctx, is_key, close_block);
   format_write_stream(1, ctx, is_key, close_block);
   format_read_stream(1, ctx, is_key, close_block);
+  format_read_swapped_stream(1, ctx, is_key, close_block);
   format_max_size_intermediate_stream(1, ctx, is_key, close_block);
 
   ctx->depth--;
@@ -724,6 +752,7 @@ idl_retcode_t write_instance_funcs(context_t* ctx, const char* write_accessor, c
   format_write_stream(1, ctx, false , instance_write_func, write_accessor);
   format_write_size_stream(1, ctx, false, instance_size_func_calc, write_accessor);
   format_read_stream(1, ctx, false, instance_read_func, read_accessor);
+  format_read_swapped_stream(1, ctx, false, instance_read_swapped_func, read_accessor);
 
   if (ctx->in_union)
   {
@@ -740,6 +769,7 @@ idl_retcode_t write_instance_funcs(context_t* ctx, const char* write_accessor, c
     {
       format_key_write_stream(1, ctx, instance_key_write_func, write_accessor);
       format_key_read_stream(1, ctx, instance_key_read_func, read_accessor);
+      format_key_read_swapped_stream(1, ctx, instance_key_read_swapped_func, read_accessor);
       format_key_size_stream(1, ctx, instance_key_size_func_calc, write_accessor);
       if (ctx->in_union)
       {
@@ -754,6 +784,7 @@ idl_retcode_t write_instance_funcs(context_t* ctx, const char* write_accessor, c
     {
       format_key_write_stream(1, ctx, instance_write_func, write_accessor);
       format_key_read_stream(1, ctx, instance_read_func, read_accessor);
+      format_key_read_swapped_stream(1, ctx, instance_read_swapped_func, read_accessor);
       format_key_size_stream(1, ctx, instance_size_func_calc, write_accessor);
       if (ctx->in_union)
       {
@@ -806,6 +837,7 @@ idl_retcode_t check_alignment(context_t* ctx, int bytewidth, bool is_key)
     }
 
     format_read_stream(1, ctx, false, position_incr "%s" align_comment, buffer);
+    format_read_swapped_stream(1, ctx, false, position_incr "%s" align_comment, buffer);
 
     ctx->streamer_funcs.accumulatedalignment = 0;
     ctx->streamer_funcs.currentalignment = bytewidth;
@@ -841,6 +873,7 @@ idl_retcode_t check_alignment(context_t* ctx, int bytewidth, bool is_key)
       }
 
       format_key_read_stream(1, ctx, position_incr "%s" align_comment, buffer);
+      format_key_read_swapped_stream(1, ctx, position_incr "%s" align_comment, buffer);
 
       ctx->key_funcs.accumulatedalignment = 0;
       ctx->key_funcs.currentalignment = bytewidth;
@@ -869,6 +902,7 @@ idl_retcode_t add_null(context_t* ctx, int nbytes, bool stream, bool is_key)
     format_write_stream(1, ctx, false, primitive_incr_pos incr_comment, nbytes);
     format_write_size_stream(1, ctx, false, primitive_incr_pos padding_comment, nbytes);
     format_read_stream(1, ctx, false, primitive_incr_pos padding_comment, nbytes);
+    format_read_swapped_stream(1, ctx, false, primitive_incr_pos padding_comment, nbytes);
     if (ctx->in_union)
     {
       format_max_size_intermediate_stream(1, ctx, false, union_case_max_incr " %d;" padding_comment, nbytes);
@@ -885,6 +919,7 @@ idl_retcode_t add_null(context_t* ctx, int nbytes, bool stream, bool is_key)
     format_key_write_stream(1, ctx, primitive_incr_pos incr_comment, nbytes);
     format_key_size_stream(1, ctx, primitive_incr_pos padding_comment, nbytes);
     format_key_read_stream(1, ctx, primitive_incr_pos padding_comment, nbytes);
+    format_key_read_swapped_stream(1, ctx, primitive_incr_pos padding_comment, nbytes);
     if (ctx->in_union)
     {
       format_key_max_size_intermediate_stream(1, ctx, union_case_max_incr " %d;" padding_comment, nbytes);
@@ -995,6 +1030,12 @@ idl_retcode_t process_known_width(context_t* ctx, const char* accessor, idl_node
 
   format_read_stream(1, ctx, is_key, primitive_read_func_read, accessor, cast, accessor);
   format_read_stream(1, ctx, is_key, primitive_incr_pos incr_comment, bytewidth);
+  format_read_swapped_stream(1, ctx, is_key, primitive_read_func_read, accessor, cast, accessor);
+  if (bytewidth == 2 || bytewidth == 4 || bytewidth == 8)
+  {
+    format_read_swapped_stream(1, ctx, is_key, swap_call, bytewidth * 8, accessor);
+  }
+  format_read_swapped_stream(1, ctx, is_key, primitive_incr_pos incr_comment, bytewidth);
   free(cast);
 
   return IDL_RETCODE_OK;
@@ -1008,11 +1049,13 @@ idl_retcode_t process_sequence_entries(context_t* ctx, const char* accessor, boo
   check_alignment(ctx, 4, is_key);
 
   format_read_stream(1, ctx, is_key, "  ");
+  format_read_swapped_stream(1, ctx, is_key, "  ");
   format_write_stream(1, ctx, is_key, "  ");
   format_write_size_stream(1, ctx, is_key, "  ");
   if (!ctx->streamer_funcs.sequenceentriespresent)
   {
     format_read_stream(0, ctx, false, "uint32_t ");
+    format_read_swapped_stream(0, ctx, false, "uint32_t ");
     format_write_stream(0, ctx, false, "uint32_t ");
     format_write_size_stream(0, ctx, false, "uint32_t ");
     ctx->streamer_funcs.sequenceentriespresent = true;
@@ -1021,6 +1064,7 @@ idl_retcode_t process_sequence_entries(context_t* ctx, const char* accessor, boo
   if (is_key && !ctx->key_funcs.sequenceentriespresent)
   {
     format_key_read_stream(0, ctx, "uint32_t ");
+    format_key_read_swapped_stream(0, ctx, "uint32_t ");
     format_key_write_stream(0, ctx, "uint32_t ");
     format_key_size_stream(0, ctx, "uint32_t ");
     ctx->key_funcs.sequenceentriespresent = true;
@@ -1028,6 +1072,10 @@ idl_retcode_t process_sequence_entries(context_t* ctx, const char* accessor, boo
 
   format_read_stream(0, ctx, is_key, primitive_read_func_seq, ctx->depth);
   format_read_stream(1, ctx, is_key, primitive_incr_pos incr_comment, (int)4);
+
+  format_read_swapped_stream(0, ctx, is_key, primitive_read_func_seq, ctx->depth);
+  format_read_swapped_stream(1, ctx, is_key, swap_call_seqentries, ctx->depth);
+  format_read_swapped_stream(1, ctx, is_key, primitive_incr_pos incr_comment, (int)4);
 
   format_write_stream(0, ctx, is_key, primitive_write_func_seq, ctx->depth, accessor, plusone ? "+1" : "");
   format_write_stream(1, ctx, is_key, primitive_write_func_seq2, ctx->depth, accessor);
@@ -1068,6 +1116,15 @@ idl_retcode_t process_known_width_array(context_t* ctx, const char *accessor, ui
 
   format_read_stream(1, ctx, is_key, primitive_read_func_array, accessor, bytesinarray, accessor);
   format_read_stream(1, ctx, is_key, primitive_incr_pos incr_comment, bytesinarray);
+
+  format_read_swapped_stream(1, ctx, is_key, primitive_read_func_array, accessor, bytesinarray, accessor);
+  if (bytewidth == 2 || bytewidth == 4 || bytewidth == 8)
+  {
+    format_read_swapped_stream(1, ctx, is_key, array_iterate, ctx->depth + 1, ctx->depth + 1, entries, ctx->depth + 1);
+    format_read_swapped_stream(1, ctx, is_key, swap_call_array, bytewidth * 8, accessor, ctx->depth + 1);
+    format_read_swapped_stream(1, ctx, is_key, "  " close_block);
+  }
+  format_read_swapped_stream(1, ctx, is_key, primitive_incr_pos incr_comment, bytesinarray);
 
   if (ctx->in_union)
   {
@@ -1142,9 +1199,16 @@ idl_retcode_t process_constructed(context_t* ctx, idl_node_t* node)
     format_read_stream(1, ctx, false, read_func_define "\n", cpp11name);
     format_read_stream(1, ctx, false, open_block);
 
+    format_read_swapped_stream(1, ctx, false, read_swapped_func_define "\n", cpp11name);
+    format_read_swapped_stream(1, ctx, false, open_block);
+
     format_key_read_stream(1, ctx, key_read_define "\n", cpp11name);
     format_key_read_stream(1, ctx, open_block);
     format_key_read_stream(1, ctx, "  (void)data;\n");
+
+    format_key_read_swapped_stream(1, ctx, key_read_swapped_define "\n", cpp11name);
+    format_key_read_swapped_stream(1, ctx, open_block);
+    format_key_read_swapped_stream(1, ctx, "  (void)data;\n");
 
     ctx->streamer_funcs.currentalignment = -1;
     ctx->streamer_funcs.alignmentpresent = false;
@@ -1188,6 +1252,7 @@ idl_retcode_t process_constructed(context_t* ctx, idl_node_t* node)
       bool disc_is_key = idl_is_masked(st, IDL_KEY);
 
       format_read_stream(1, ctx, true, union_clear_func);
+      format_read_swapped_stream(1, ctx, true, union_clear_func);
       process_known_width(ctx, "_d()", st, disc_is_key);
       format_write_size_stream(1, ctx, false, union_switch);
       format_write_size_stream(1, ctx, false, "  {\n");
@@ -1195,6 +1260,8 @@ idl_retcode_t process_constructed(context_t* ctx, idl_node_t* node)
       format_write_stream(1, ctx, false, "  {\n");
       format_read_stream(1, ctx, false, union_switch);
       format_read_stream(1, ctx, false, "  {\n");
+      format_read_swapped_stream(1, ctx, false, union_switch);
+      format_read_swapped_stream(1, ctx, false, "  {\n");
 
       ctx->in_union = true;
       format_max_size_intermediate_stream(1, ctx, false, "  size_t union_max = position;\n");
@@ -1215,6 +1282,7 @@ idl_retcode_t process_constructed(context_t* ctx, idl_node_t* node)
       format_write_stream(1, ctx, false, "  }\n");
       format_write_size_stream(1, ctx, false, "  }\n");
       format_read_stream(1, ctx, false, "  }\n");
+      format_read_swapped_stream(1, ctx, false, "  }\n");
     }
 
     format_write_size_stream(1, ctx, true, position_return);
@@ -1223,6 +1291,8 @@ idl_retcode_t process_constructed(context_t* ctx, idl_node_t* node)
     format_write_stream(1, ctx, true, close_function);
     format_read_stream(1, ctx, true, position_return);
     format_read_stream(1, ctx, true, close_function);
+    format_read_swapped_stream(1, ctx, true, position_return);
+    format_read_swapped_stream(1, ctx, true, close_function);
 
     if (ctx->key_max_size_unlimited)
     {
@@ -1295,6 +1365,7 @@ idl_retcode_t process_case(context_t* ctx, idl_case_t* _case)
   format_write_stream(1, ctx, false, "  {\n");
   format_write_size_stream(1, ctx, false, "  {\n");
   format_read_stream(1, ctx, false, "  {\n");
+  format_read_swapped_stream(1, ctx, false, "  {\n");
   format_max_size_intermediate_stream(1, ctx, false, "{  //cases\n");
   format_max_size_intermediate_stream(1, ctx, false, "  size_t case_max = position;\n");
   ctx->depth++;
@@ -1310,6 +1381,8 @@ idl_retcode_t process_case(context_t* ctx, idl_case_t* _case)
   format_write_size_stream(1, ctx, false, union_case_ending);
   format_read_stream(1, ctx, false, "  }\n");
   format_read_stream(1, ctx, false, union_case_ending);
+  format_read_swapped_stream(1, ctx, false, "  }\n");
+  format_read_swapped_stream(1, ctx, false, union_case_ending);
 
   ctx->streamer_funcs = sfuncs;
   ctx->key_funcs = kfuncs;
@@ -1348,10 +1421,14 @@ idl_retcode_t process_typedef_definition(context_t* ctx, idl_typedef_t* node)
     format_max_size_stream(1, ctx, false, "  (void)obj;\n");
     format_read_stream(1, ctx, false, typedef_read_define "\n", tsname, tsname);
     format_read_stream(1, ctx, false, open_block);
+    format_read_swapped_stream(1, ctx, false, typedef_read_swapped_define "\n", tsname, tsname);
+    format_read_swapped_stream(1, ctx, false, open_block);
     format_key_write_stream(1, ctx, typedef_key_write_define "\n", tsname, tsname);
     format_key_write_stream(1, ctx, open_block);
     format_key_read_stream(1, ctx, typedef_key_read_define "\n", tsname, tsname);
     format_key_read_stream(1, ctx, open_block);
+    format_key_read_swapped_stream(1, ctx, typedef_key_read_swapped_define "\n", tsname, tsname);
+    format_key_read_swapped_stream(1, ctx, open_block);
     format_key_size_stream(1, ctx, typedef_key_size_define "\n", tsname, tsname);
     format_key_size_stream(1, ctx, open_block);
     format_key_max_size_stream(1, ctx, typedef_key_max_size_define "\n", tsname, tsname);
@@ -1362,8 +1439,10 @@ idl_retcode_t process_typedef_definition(context_t* ctx, idl_typedef_t* node)
     format_header_stream(1, ctx, typedef_write_size_define ";\n\n", tsname, tsname);
     format_header_stream(1, ctx, typedef_max_size_define ";\n\n", tsname, tsname);
     format_header_stream(1, ctx, typedef_read_define ";\n\n", tsname, tsname);
+    format_header_stream(1, ctx, typedef_read_swapped_define ";\n\n", tsname, tsname);
     format_header_stream(1, ctx, typedef_key_write_define ";\n\n", tsname, tsname);
     format_header_stream(1, ctx, typedef_key_read_define ";\n\n", tsname, tsname);
+    format_header_stream(1, ctx, typedef_key_read_swapped_define ";\n\n", tsname, tsname);
     format_header_stream(1, ctx, typedef_key_size_define ";\n\n", tsname, tsname);
     format_header_stream(1, ctx, typedef_key_max_size_define ";\n\n", tsname, tsname);
 
@@ -1401,6 +1480,8 @@ idl_retcode_t process_typedef_definition(context_t* ctx, idl_typedef_t* node)
     format_write_size_stream(1, ctx, true, close_function);
     format_read_stream(1, ctx, true, position_return);
     format_read_stream(1, ctx, true, close_function);
+    format_read_swapped_stream(1, ctx, true, position_return);
+    format_read_swapped_stream(1, ctx, true, close_function);
     format_max_size_stream(1, ctx, true, close_function);
 
     reset_function_contents(&ctx->streamer_funcs);
@@ -1456,6 +1537,7 @@ idl_retcode_t process_typedef_instance_impl(context_t* ctx, const char* accessor
   format_write_stream(1, ctx, false, typedef_write_call, ns, tdname, accessor);
   format_write_size_stream(1, ctx, false, typedef_write_size_call, ns, tdname, accessor);
   format_read_stream(1, ctx, false, typedef_read_call, ns, tdname, accessor);
+  format_read_swapped_stream(1, ctx, false, typedef_read_swapped_call, ns, tdname, accessor);
   if (ctx->in_union)
   {
     format_max_size_intermediate_stream(1, ctx, false, union_case_max_set "%stypedef_max_size_%s(%s, case_max);\n", ns, tdname, accessor);
@@ -1469,6 +1551,7 @@ idl_retcode_t process_typedef_instance_impl(context_t* ctx, const char* accessor
   {
     format_key_write_stream(1, ctx, typedef_key_write_call, ns, tdname, accessor);
     format_key_read_stream(1, ctx, typedef_key_read_call, ns, tdname, accessor);
+    format_key_read_swapped_stream(1, ctx, typedef_key_read_swapped_call, ns, tdname, accessor);
     format_key_size_stream(1, ctx, typedef_key_size_call, ns, tdname, accessor);
     if (ctx->in_union)
     {
@@ -1513,6 +1596,7 @@ idl_retcode_t process_case_label(context_t* ctx, idl_case_label_t* label)
       format_write_stream(1, ctx, false, union_case, buffer);
       format_write_size_stream(1, ctx, false, union_case, buffer);
       format_read_stream(1, ctx, false, union_case, buffer);
+      format_read_swapped_stream(1, ctx, false, union_case, buffer);
       free(buffer);
     }
   }
@@ -1532,6 +1616,7 @@ idl_retcode_t add_default_case(context_t* ctx)
   format_write_stream(1, ctx, false, default_case);
   format_write_size_stream(1, ctx, false, default_case);
   format_read_stream(1, ctx, false, default_case);
+  format_read_swapped_stream(1, ctx, false, default_case);
 
   return IDL_RETCODE_OK;
 }
@@ -1622,6 +1707,9 @@ idl_retcode_t process_string_impl(context_t* ctx, const char* accessor, idl_stri
   format_read_stream(1, ctx, is_key, read_str, accessor, ctx->depth, accessor);
   format_read_stream(1, ctx, is_key, seq_inc_1 entries_of_sequence_comment, ctx->depth);
 
+  format_read_swapped_stream(1, ctx, is_key, read_str, accessor, ctx->depth, accessor);
+  format_read_swapped_stream(1, ctx, is_key, seq_inc_1 entries_of_sequence_comment, ctx->depth);
+
   if (bound)
   {
     if (ctx->in_union)
@@ -1711,6 +1799,8 @@ idl_retcode_t process_sequence_impl(context_t* ctx, const char* accessor, idl_se
       format_write_stream(1, ctx, is_key, bool_write_seq, ctx->depth, accessor, accessor);
       format_read_stream(1, ctx, is_key, seq_read_resize, accessor, ctx->depth);
       format_read_stream(1, ctx, is_key, bool_read_seq, ctx->depth, accessor, accessor);
+      format_read_swapped_stream(1, ctx, is_key, seq_read_resize, accessor, ctx->depth);
+      format_read_swapped_stream(1, ctx, is_key, bool_read_seq, ctx->depth, accessor, accessor);
     }
     else
     {
@@ -1718,6 +1808,14 @@ idl_retcode_t process_sequence_impl(context_t* ctx, const char* accessor, idl_se
       format_write_stream(1, ctx, is_key, seq_incr entries_of_sequence_comment, ctx->depth, bytewidth);
       format_read_stream(1, ctx, is_key, primitive_read_seq, accessor, cast, cast, ctx->depth, accessor);
       format_read_stream(1, ctx, is_key, seq_incr entries_of_sequence_comment, ctx->depth, bytewidth);
+      format_read_swapped_stream(1, ctx, is_key, primitive_read_seq, accessor, cast, cast, ctx->depth, accessor);
+      if (bytewidth == 2 || bytewidth == 4 || bytewidth == 8)
+      {
+        format_read_swapped_stream(1, ctx, is_key, sequence_iterate, ctx->depth + 1, ctx->depth + 1, ctx->depth, ctx->depth + 1);
+        format_read_swapped_stream(1, ctx, is_key, swap_call_array , bytewidth * 8, accessor, ctx->depth + 1);
+        format_read_swapped_stream(1, ctx, is_key, "  " close_block);
+      }
+      format_read_swapped_stream(1, ctx, is_key, seq_incr entries_of_sequence_comment, ctx->depth, bytewidth);
     }
     format_write_size_stream(1, ctx, is_key, seq_incr entries_of_sequence_comment, ctx->depth, bytewidth);
     if (bound)
@@ -1730,11 +1828,13 @@ idl_retcode_t process_sequence_impl(context_t* ctx, const char* accessor, idl_se
   else
   {
     format_read_stream(1, ctx, is_key, seq_read_resize, accessor, ctx->depth);
+    format_read_swapped_stream(1, ctx, is_key, seq_read_resize, accessor, ctx->depth);
 
     //loop over
     format_write_stream(1, ctx, is_key, sequence_iterate, ctx->depth + 1, ctx->depth + 1, ctx->depth, ctx->depth + 1);
     format_write_size_stream(1, ctx, is_key, sequence_iterate, ctx->depth + 1, ctx->depth + 1, ctx->depth, ctx->depth + 1);
     format_read_stream(1, ctx, is_key, sequence_iterate, ctx->depth + 1, ctx->depth + 1, ctx->depth, ctx->depth + 1);
+    format_read_swapped_stream(1, ctx, is_key, sequence_iterate, ctx->depth + 1, ctx->depth + 1, ctx->depth, ctx->depth + 1);
     format_max_size_intermediate_stream(1, ctx, is_key, bound_iterate, ctx->depth + 1, ctx->depth + 1, bound, ctx->depth + 1);
     ctx->depth++;
 
@@ -1767,6 +1867,7 @@ idl_retcode_t process_sequence_impl(context_t* ctx, const char* accessor, idl_se
     format_write_size_stream(1, ctx, is_key, close_block);
     format_write_stream(1, ctx, is_key, close_block);
     format_read_stream(1, ctx, is_key, close_block);
+    format_read_swapped_stream(1, ctx, is_key, close_block);
     format_max_size_intermediate_stream(1, ctx, is_key, close_block);
 
     ctx->depth--;
@@ -1780,6 +1881,7 @@ void idl_streamers_generate(const idl_tree_t* tree, idl_streamer_output_t* str)
 {
   context_t* ctx = create_context("");
 
+  format_impl_stream(0, ctx, "#include \"org/eclipse/cyclonedds/topic/byteswapping.hpp\"\n");
   format_impl_stream(0, ctx, "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n");
   if (tree->files)
     ctx->parsed_file = tree->files->name;

--- a/src/idlcxx/tests/cpp11Backend.c
+++ b/src/idlcxx/tests/cpp11Backend.c
@@ -60,10 +60,12 @@
 "  size_t write_size(size_t offset) const;\n"\
 "  size_t max_size(size_t offset) const;\n"\
 "  size_t read_struct(const void* data, size_t position);\n"\
+"  size_t read_struct_swapped(const void* data, size_t position);\n"\
 "  size_t key_size(size_t position) const;\n"\
 "  size_t key_max_size(size_t position) const;\n"\
 "  size_t key_write(void* data, size_t position) const;\n"\
 "  size_t key_read(const void* data, size_t position);\n"\
+"  size_t key_read_swapped(const void* data, size_t position);\n"\
 "  bool key(ddsi_keyhash_t& hash) const;\n"
 
 #define IDL_OUTPUT_STRUCT_PRIM(struct_name,member_type,default_value,member_name) "" \

--- a/src/idlcxx/tests/generator/bounded_sequence_impl.cpp.in
+++ b/src/idlcxx/tests/generator/bounded_sequence_impl.cpp.in
@@ -1,3 +1,4 @@
+#include "org/eclipse/cyclonedds/topic/byteswapping.hpp"
 #include "org/eclipse/cyclonedds/topic/hash.hpp"
 
 size_t s::write_struct(void *data, size_t position) const
@@ -78,12 +79,32 @@ size_t s::key_read(const void *data, size_t position)
   return position;
 }
 
+size_t s::key_read_swapped(const void *data, size_t position)
+{
+  (void)data;
+  return position;
+}
+
 size_t s::read_struct(const void *data, size_t position)
 {
   position += (4 - (position&0x3))&0x3;  //alignment
   uint32_t _se0 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
   position += 4;  //moving position indicator
   mem().assign(reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position),reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position)+_se0); //reading bytes for member: mem()
+  position += _se0*4;  //entries of sequence
+  return position;
+}
+
+size_t s::read_struct_swapped(const void *data, size_t position)
+{
+  position += (4 - (position&0x3))&0x3;  //alignment
+  uint32_t _se0 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+  org::eclipse::cyclonedds::topic::bswap_32(&_se0);
+  position += 4;  //moving position indicator
+  mem().assign(reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position),reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position)+_se0); //reading bytes for member: mem()
+  for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    org::eclipse::cyclonedds::topic::bswap_32(&mem()[_i1]);
+  }
   position += _se0*4;  //entries of sequence
   return position;
 }

--- a/src/idlcxx/tests/generator/bounded_sequence_of_structs_impl.cpp.in
+++ b/src/idlcxx/tests/generator/bounded_sequence_of_structs_impl.cpp.in
@@ -1,3 +1,4 @@
+#include "org/eclipse/cyclonedds/topic/byteswapping.hpp"
 #include "org/eclipse/cyclonedds/topic/hash.hpp"
 
 size_t s_sub::write_struct(void *data, size_t position) const
@@ -182,6 +183,26 @@ size_t s::key_read(const void *data, size_t position)
   return position;
 }
 
+size_t s_sub::key_read_swapped(const void *data, size_t position)
+{
+  (void)data;
+  return position;
+}
+
+size_t s::key_read_swapped(const void *data, size_t position)
+{
+  (void)data;
+  position += (4 - (position&0x3))&0x3;  //alignment
+  uint32_t _se0 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+  org::eclipse::cyclonedds::topic::bswap_32(&_se0);
+  position += 4;  //moving position indicator
+  mem().resize(_se0);
+  for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    position = mem()[_i1].read_struct_swapped(data, position);
+  }
+  return position;
+}
+
 size_t s_sub::read_struct(const void *data, size_t position)
 {
   position += (4 - (position&0x3))&0x3;  //alignment
@@ -198,6 +219,28 @@ size_t s::read_struct(const void *data, size_t position)
   mem().resize(_se0);
   for (size_t _i1 = 0; _i1 < _se0; _i1++) {
     position = mem()[_i1].read_struct(data, position);
+  }
+  return position;
+}
+
+size_t s_sub::read_struct_swapped(const void *data, size_t position)
+{
+  position += (4 - (position&0x3))&0x3;  //alignment
+  l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()
+  org::eclipse::cyclonedds::topic::bswap_32(&l());
+  position += 4;  //moving position indicator
+  return position;
+}
+
+size_t s::read_struct_swapped(const void *data, size_t position)
+{
+  position += (4 - (position&0x3))&0x3;  //alignment
+  uint32_t _se0 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+  org::eclipse::cyclonedds::topic::bswap_32(&_se0);
+  position += 4;  //moving position indicator
+  mem().resize(_se0);
+  for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    position = mem()[_i1].read_struct_swapped(data, position);
   }
   return position;
 }

--- a/src/idlcxx/tests/generator/bounded_string_impl.cpp.in
+++ b/src/idlcxx/tests/generator/bounded_string_impl.cpp.in
@@ -1,3 +1,4 @@
+#include "org/eclipse/cyclonedds/topic/byteswapping.hpp"
 #include "org/eclipse/cyclonedds/topic/hash.hpp"
 
 size_t s::write_struct(void *data, size_t position) const
@@ -78,10 +79,27 @@ size_t s::key_read(const void *data, size_t position)
   return position;
 }
 
+size_t s::key_read_swapped(const void *data, size_t position)
+{
+  (void)data;
+  return position;
+}
+
 size_t s::read_struct(const void *data, size_t position)
 {
   position += (4 - (position&0x3))&0x3;  //alignment
   uint32_t _se0 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+  position += 4;  //moving position indicator
+  mem().assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+_se0-1); //reading bytes for member: mem()
+  position += _se0;  //entries of sequence
+  return position;
+}
+
+size_t s::read_struct_swapped(const void *data, size_t position)
+{
+  position += (4 - (position&0x3))&0x3;  //alignment
+  uint32_t _se0 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+  org::eclipse::cyclonedds::topic::bswap_32(&_se0);
   position += 4;  //moving position indicator
   mem().assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+_se0-1); //reading bytes for member: mem()
   position += _se0;  //entries of sequence

--- a/src/idlcxx/tests/generator/cross_call_impl.cpp.in
+++ b/src/idlcxx/tests/generator/cross_call_impl.cpp.in
@@ -1,3 +1,4 @@
+#include "org/eclipse/cyclonedds/topic/byteswapping.hpp"
 #include "org/eclipse/cyclonedds/topic/hash.hpp"
 
 namespace A_1
@@ -77,10 +78,25 @@ namespace A_1
       return position;
     }
 
+    size_t s_1::key_read_swapped(const void *data, size_t position)
+    {
+      (void)data;
+      return position;
+    }
+
     size_t s_1::read_struct(const void *data, size_t position)
     {
       position += (4 - (position&0x3))&0x3;  //alignment
       m_1() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: m_1()
+      position += 4;  //moving position indicator
+      return position;
+    }
+
+    size_t s_1::read_struct_swapped(const void *data, size_t position)
+    {
+      position += (4 - (position&0x3))&0x3;  //alignment
+      m_1() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: m_1()
+      org::eclipse::cyclonedds::topic::bswap_32(&m_1());
       position += 4;  //moving position indicator
       return position;
     }
@@ -160,9 +176,21 @@ namespace B_1
       return position;
     }
 
+    size_t s_2::key_read_swapped(const void *data, size_t position)
+    {
+      (void)data;
+      return position;
+    }
+
     size_t s_2::read_struct(const void *data, size_t position)
     {
       position = m_2().read_struct(data, position);
+      return position;
+    }
+
+    size_t s_2::read_struct_swapped(const void *data, size_t position)
+    {
+      position = m_2().read_struct_swapped(data, position);
       return position;
     }
 

--- a/src/idlcxx/tests/generator/keys_base_impl.cpp.in
+++ b/src/idlcxx/tests/generator/keys_base_impl.cpp.in
@@ -1,3 +1,4 @@
+#include "org/eclipse/cyclonedds/topic/byteswapping.hpp"
 #include "org/eclipse/cyclonedds/topic/hash.hpp"
 
 size_t s::write_struct(void *data, size_t position) const
@@ -87,12 +88,33 @@ size_t s::key_read(const void *data, size_t position)
   return position;
 }
 
+size_t s::key_read_swapped(const void *data, size_t position)
+{
+  (void)data;
+  position += (4 - (position&0x3))&0x3;  //alignment
+  l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()
+  org::eclipse::cyclonedds::topic::bswap_32(&l());
+  position += 4;  //moving position indicator
+  return position;
+}
+
 size_t s::read_struct(const void *data, size_t position)
 {
   o() = *reinterpret_cast<const uint8_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: o()
   position += 1;  //moving position indicator
   position += (4 - (position&0x3))&0x3;  //alignment
   l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()
+  position += 4;  //moving position indicator
+  return position;
+}
+
+size_t s::read_struct_swapped(const void *data, size_t position)
+{
+  o() = *reinterpret_cast<const uint8_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: o()
+  position += 1;  //moving position indicator
+  position += (4 - (position&0x3))&0x3;  //alignment
+  l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()
+  org::eclipse::cyclonedds::topic::bswap_32(&l());
   position += 4;  //moving position indicator
   return position;
 }

--- a/src/idlcxx/tests/generator/keys_struct_explicit_impl.cpp.in
+++ b/src/idlcxx/tests/generator/keys_struct_explicit_impl.cpp.in
@@ -1,3 +1,4 @@
+#include "org/eclipse/cyclonedds/topic/byteswapping.hpp"
 #include "org/eclipse/cyclonedds/topic/hash.hpp"
 
 size_t s::write_struct(void *data, size_t position) const
@@ -181,6 +182,27 @@ size_t ss::key_read(const void *data, size_t position)
   return position;
 }
 
+size_t s::key_read_swapped(const void *data, size_t position)
+{
+  (void)data;
+  position += (4 - (position&0x3))&0x3;  //alignment
+  l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()
+  org::eclipse::cyclonedds::topic::bswap_32(&l());
+  position += 4;  //moving position indicator
+  return position;
+}
+
+size_t ss::key_read_swapped(const void *data, size_t position)
+{
+  (void)data;
+  position = s_().key_read_swapped(data, position);
+  position += (4 - (position&0x3))&0x3;  //alignment
+  l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()
+  org::eclipse::cyclonedds::topic::bswap_32(&l());
+  position += 4;  //moving position indicator
+  return position;
+}
+
 size_t s::read_struct(const void *data, size_t position)
 {
   o() = *reinterpret_cast<const uint8_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: o()
@@ -198,6 +220,29 @@ size_t ss::read_struct(const void *data, size_t position)
   position = s_().read_struct(data, position);
   position += (4 - (position&0x3))&0x3;  //alignment
   l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()
+  position += 4;  //moving position indicator
+  return position;
+}
+
+size_t s::read_struct_swapped(const void *data, size_t position)
+{
+  o() = *reinterpret_cast<const uint8_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: o()
+  position += 1;  //moving position indicator
+  position += (4 - (position&0x3))&0x3;  //alignment
+  l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()
+  org::eclipse::cyclonedds::topic::bswap_32(&l());
+  position += 4;  //moving position indicator
+  return position;
+}
+
+size_t ss::read_struct_swapped(const void *data, size_t position)
+{
+  o() = *reinterpret_cast<const uint8_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: o()
+  position += 1;  //moving position indicator
+  position = s_().read_struct_swapped(data, position);
+  position += (4 - (position&0x3))&0x3;  //alignment
+  l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()
+  org::eclipse::cyclonedds::topic::bswap_32(&l());
   position += 4;  //moving position indicator
   return position;
 }

--- a/src/idlcxx/tests/generator/keys_struct_implicit_impl.cpp.in
+++ b/src/idlcxx/tests/generator/keys_struct_implicit_impl.cpp.in
@@ -1,3 +1,4 @@
+#include "org/eclipse/cyclonedds/topic/byteswapping.hpp"
 #include "org/eclipse/cyclonedds/topic/hash.hpp"
 
 size_t s::write_struct(void *data, size_t position) const
@@ -169,6 +170,23 @@ size_t ss::key_read(const void *data, size_t position)
   return position;
 }
 
+size_t s::key_read_swapped(const void *data, size_t position)
+{
+  (void)data;
+  return position;
+}
+
+size_t ss::key_read_swapped(const void *data, size_t position)
+{
+  (void)data;
+  position = s_().read_struct_swapped(data, position);
+  position += (4 - (position&0x3))&0x3;  //alignment
+  l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()
+  org::eclipse::cyclonedds::topic::bswap_32(&l());
+  position += 4;  //moving position indicator
+  return position;
+}
+
 size_t s::read_struct(const void *data, size_t position)
 {
   o() = *reinterpret_cast<const uint8_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: o()
@@ -186,6 +204,29 @@ size_t ss::read_struct(const void *data, size_t position)
   position = s_().read_struct(data, position);
   position += (4 - (position&0x3))&0x3;  //alignment
   l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()
+  position += 4;  //moving position indicator
+  return position;
+}
+
+size_t s::read_struct_swapped(const void *data, size_t position)
+{
+  o() = *reinterpret_cast<const uint8_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: o()
+  position += 1;  //moving position indicator
+  position += (4 - (position&0x3))&0x3;  //alignment
+  l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()
+  org::eclipse::cyclonedds::topic::bswap_32(&l());
+  position += 4;  //moving position indicator
+  return position;
+}
+
+size_t ss::read_struct_swapped(const void *data, size_t position)
+{
+  o() = *reinterpret_cast<const uint8_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: o()
+  position += 1;  //moving position indicator
+  position = s_().read_struct_swapped(data, position);
+  position += (4 - (position&0x3))&0x3;  //alignment
+  l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()
+  org::eclipse::cyclonedds::topic::bswap_32(&l());
   position += 4;  //moving position indicator
   return position;
 }

--- a/src/idlcxx/tests/generator/keys_typedef_header.cpp.in
+++ b/src/idlcxx/tests/generator/keys_typedef_header.cpp.in
@@ -6,9 +6,13 @@ size_t typedef_max_size_td_1(const td_1 &obj, size_t position);
 
 size_t typedef_read_td_1(td_1 &obj, const void* data, size_t position);
 
+size_t typedef_read_swapped_td_1(td_1 &obj, const void* data, size_t position);
+
 size_t typedef_key_write_td_1(const td_1 &obj, void *data, size_t position);
 
 size_t typedef_key_read_td_1(td_1 &obj, const void *data, size_t position);
+
+size_t typedef_key_read_swapped_td_1(td_1 &obj, const void *data, size_t position);
 
 size_t typedef_key_size_td_1(const td_1 &obj, size_t position);
 

--- a/src/idlcxx/tests/generator/keys_typedef_impl.cpp.in
+++ b/src/idlcxx/tests/generator/keys_typedef_impl.cpp.in
@@ -1,3 +1,4 @@
+#include "org/eclipse/cyclonedds/topic/byteswapping.hpp"
 #include "org/eclipse/cyclonedds/topic/hash.hpp"
 
 size_t typedef_write_td_1(const td_1 &obj, void* data, size_t position)
@@ -141,6 +142,27 @@ size_t s::key_read(const void *data, size_t position)
   return position;
 }
 
+size_t typedef_key_read_swapped_td_1(td_1 &obj, const void *data, size_t position)
+{
+  position += (4 - (position&0x3))&0x3;  //alignment
+  uint32_t _se0 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+  org::eclipse::cyclonedds::topic::bswap_32(&_se0);
+  position += 4;  //moving position indicator
+  obj.assign(reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position),reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position)+_se0); //reading bytes for member: obj
+  for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    org::eclipse::cyclonedds::topic::bswap_32(&obj[_i1]);
+  }
+  position += _se0*4;  //entries of sequence
+  return position;
+}
+
+size_t s::key_read_swapped(const void *data, size_t position)
+{
+  (void)data;
+  position = typedef_key_read_swapped_td_1(t(), data, position);
+  return position;
+}
+
 size_t typedef_read_td_1(td_1 &obj, const void* data, size_t position)
 {
   position += (4 - (position&0x3))&0x3;  //alignment
@@ -156,6 +178,28 @@ size_t s::read_struct(const void *data, size_t position)
   o() = *reinterpret_cast<const uint8_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: o()
   position += 1;  //moving position indicator
   position = typedef_read_td_1(t(), data, position);
+  return position;
+}
+
+size_t typedef_read_swapped_td_1(td_1 &obj, const void* data, size_t position)
+{
+  position += (4 - (position&0x3))&0x3;  //alignment
+  uint32_t _se0 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+  org::eclipse::cyclonedds::topic::bswap_32(&_se0);
+  position += 4;  //moving position indicator
+  obj.assign(reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position),reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position)+_se0); //reading bytes for member: obj
+  for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    org::eclipse::cyclonedds::topic::bswap_32(&obj[_i1]);
+  }
+  position += _se0*4;  //entries of sequence
+  return position;
+}
+
+size_t s::read_struct_swapped(const void *data, size_t position)
+{
+  o() = *reinterpret_cast<const uint8_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: o()
+  position += 1;  //moving position indicator
+  position = typedef_read_swapped_td_1(t(), data, position);
   return position;
 }
 

--- a/src/idlcxx/tests/generator/keys_union_implicit_impl.cpp.in
+++ b/src/idlcxx/tests/generator/keys_union_implicit_impl.cpp.in
@@ -1,3 +1,4 @@
+#include "org/eclipse/cyclonedds/topic/byteswapping.hpp"
 #include "org/eclipse/cyclonedds/topic/hash.hpp"
 
 size_t u::write_struct(void *data, size_t position) const
@@ -226,6 +227,24 @@ size_t ss::key_read(const void *data, size_t position)
   return position;
 }
 
+size_t u::key_read_swapped(const void *data, size_t position)
+{
+  (void)data;
+  clear();
+  return position;
+}
+
+size_t ss::key_read_swapped(const void *data, size_t position)
+{
+  (void)data;
+  position = u().read_struct_swapped(data, position);
+  position += (4 - (position&0x3))&0x3;  //alignment
+  l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()
+  org::eclipse::cyclonedds::topic::bswap_32(&l());
+  position += 4;  //moving position indicator
+  return position;
+}
+
 size_t u::read_struct(const void *data, size_t position)
 {
   clear();
@@ -274,6 +293,63 @@ size_t ss::read_struct(const void *data, size_t position)
   position = u().read_struct(data, position);
   position += (4 - (position&0x3))&0x3;  //alignment
   l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()
+  position += 4;  //moving position indicator
+  return position;
+}
+
+size_t u::read_struct_swapped(const void *data, size_t position)
+{
+  clear();
+  position += (4 - (position&0x3))&0x3;  //alignment
+  _d() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: _d()
+  org::eclipse::cyclonedds::topic::bswap_32(&_d());
+  position += 4;  //moving position indicator
+  switch (_d())
+  {
+    case 0:
+    case 1:
+    {
+      o() = *reinterpret_cast<const uint8_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: o()
+      position += 1;  //moving position indicator
+    }
+    break;
+    case 2:
+    case 3:
+    {
+      l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()
+      org::eclipse::cyclonedds::topic::bswap_32(&l());
+      position += 4;  //moving position indicator
+    }
+    break;
+    case 4:
+    case 5:
+    {
+      uint32_t _se2 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+      org::eclipse::cyclonedds::topic::bswap_32(&_se2);
+      position += 4;  //moving position indicator
+      str().assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+_se2-1); //reading bytes for member: str()
+      position += _se2;  //entries of sequence
+    }
+    break;
+    default:
+    {
+      f() = *reinterpret_cast<const float*>(static_cast<const char*>(data)+position);  //reading bytes for member: f()
+      org::eclipse::cyclonedds::topic::bswap_32(&f());
+      position += 4;  //moving position indicator
+    }
+    break;
+  }
+  return position;
+}
+
+size_t ss::read_struct_swapped(const void *data, size_t position)
+{
+  o() = *reinterpret_cast<const uint8_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: o()
+  position += 1;  //moving position indicator
+  position = u().read_struct_swapped(data, position);
+  position += (4 - (position&0x3))&0x3;  //alignment
+  l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()
+  org::eclipse::cyclonedds::topic::bswap_32(&l());
   position += 4;  //moving position indicator
   return position;
 }

--- a/src/idlcxx/tests/generator/sequence_recursive_header.cpp.in
+++ b/src/idlcxx/tests/generator/sequence_recursive_header.cpp.in
@@ -6,9 +6,13 @@ size_t typedef_max_size_recseq(const recseq &obj, size_t position);
 
 size_t typedef_read_recseq(recseq &obj, const void* data, size_t position);
 
+size_t typedef_read_swapped_recseq(recseq &obj, const void* data, size_t position);
+
 size_t typedef_key_write_recseq(const recseq &obj, void *data, size_t position);
 
 size_t typedef_key_read_recseq(recseq &obj, const void *data, size_t position);
+
+size_t typedef_key_read_swapped_recseq(recseq &obj, const void *data, size_t position);
 
 size_t typedef_key_size_recseq(const recseq &obj, size_t position);
 

--- a/src/idlcxx/tests/generator/sequence_recursive_impl.cpp.in
+++ b/src/idlcxx/tests/generator/sequence_recursive_impl.cpp.in
@@ -1,3 +1,4 @@
+#include "org/eclipse/cyclonedds/topic/byteswapping.hpp"
 #include "org/eclipse/cyclonedds/topic/hash.hpp"
 
 size_t typedef_write_recseq(const recseq &obj, void* data, size_t position)
@@ -137,6 +138,35 @@ size_t typedef_key_read_recseq(recseq &obj, const void *data, size_t position)
   return position;
 }
 
+size_t typedef_key_read_swapped_recseq(recseq &obj, const void *data, size_t position)
+{
+  position += (4 - (position&0x3))&0x3;  //alignment
+  uint32_t _se0 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+  org::eclipse::cyclonedds::topic::bswap_32(&_se0);
+  position += 4;  //moving position indicator
+  obj.resize(_se0);
+  for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    uint32_t _se1 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+    org::eclipse::cyclonedds::topic::bswap_32(&_se1);
+    position += 4;  //moving position indicator
+    obj[_i1].resize(_se1);
+    for (size_t _i2 = 0; _i2 < _se1; _i2++) {
+      uint32_t _se2 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+      org::eclipse::cyclonedds::topic::bswap_32(&_se2);
+      position += 4;  //moving position indicator
+      obj[_i1][_i2].resize(_se2);
+      for (size_t _i3 = 0; _i3 < _se2; _i3++) {
+        uint32_t _se3 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+        org::eclipse::cyclonedds::topic::bswap_32(&_se3);
+        position += 4;  //moving position indicator
+        obj[_i1][_i2][_i3].assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+_se3-1); //reading bytes for member: obj[_i1][_i2][_i3]
+        position += _se3;  //entries of sequence
+      }
+    }
+  }
+  return position;
+}
+
 size_t typedef_read_recseq(recseq &obj, const void* data, size_t position)
 {
   position += (4 - (position&0x3))&0x3;  //alignment
@@ -153,6 +183,35 @@ size_t typedef_read_recseq(recseq &obj, const void* data, size_t position)
       obj[_i1][_i2].resize(_se2);
       for (size_t _i3 = 0; _i3 < _se2; _i3++) {
         uint32_t _se3 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+        position += 4;  //moving position indicator
+        obj[_i1][_i2][_i3].assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+_se3-1); //reading bytes for member: obj[_i1][_i2][_i3]
+        position += _se3;  //entries of sequence
+      }
+    }
+  }
+  return position;
+}
+
+size_t typedef_read_swapped_recseq(recseq &obj, const void* data, size_t position)
+{
+  position += (4 - (position&0x3))&0x3;  //alignment
+  uint32_t _se0 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+  org::eclipse::cyclonedds::topic::bswap_32(&_se0);
+  position += 4;  //moving position indicator
+  obj.resize(_se0);
+  for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    uint32_t _se1 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+    org::eclipse::cyclonedds::topic::bswap_32(&_se1);
+    position += 4;  //moving position indicator
+    obj[_i1].resize(_se1);
+    for (size_t _i2 = 0; _i2 < _se1; _i2++) {
+      uint32_t _se2 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+      org::eclipse::cyclonedds::topic::bswap_32(&_se2);
+      position += 4;  //moving position indicator
+      obj[_i1][_i2].resize(_se2);
+      for (size_t _i3 = 0; _i3 < _se2; _i3++) {
+        uint32_t _se3 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+        org::eclipse::cyclonedds::topic::bswap_32(&_se3);
         position += 4;  //moving position indicator
         obj[_i1][_i2][_i3].assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+_se3-1); //reading bytes for member: obj[_i1][_i2][_i3]
         position += _se3;  //entries of sequence

--- a/src/idlcxx/tests/generator/struct_inheritance_impl.cpp.in
+++ b/src/idlcxx/tests/generator/struct_inheritance_impl.cpp.in
@@ -1,3 +1,4 @@
+#include "org/eclipse/cyclonedds/topic/byteswapping.hpp"
 #include "org/eclipse/cyclonedds/topic/hash.hpp"
 
 size_t I::write_struct(void *data, size_t position) const
@@ -149,6 +150,19 @@ size_t s::key_read(const void *data, size_t position)
   return position;
 }
 
+size_t I::key_read_swapped(const void *data, size_t position)
+{
+  (void)data;
+  return position;
+}
+
+size_t s::key_read_swapped(const void *data, size_t position)
+{
+  (void)data;
+  position = dynamic_cast<I&>(*this).key_read_swapped(data, position);
+  return position;
+}
+
 size_t I::read_struct(const void *data, size_t position)
 {
   position += (4 - (position&0x3))&0x3;  //alignment
@@ -162,6 +176,25 @@ size_t s::read_struct(const void *data, size_t position)
   position = dynamic_cast<I&>(*this).read_struct(data, position);
   position += (4 - (position&0x3))&0x3;  //alignment
   new_member() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: new_member()
+  position += 4;  //moving position indicator
+  return position;
+}
+
+size_t I::read_struct_swapped(const void *data, size_t position)
+{
+  position += (4 - (position&0x3))&0x3;  //alignment
+  inherited_member() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: inherited_member()
+  org::eclipse::cyclonedds::topic::bswap_32(&inherited_member());
+  position += 4;  //moving position indicator
+  return position;
+}
+
+size_t s::read_struct_swapped(const void *data, size_t position)
+{
+  position = dynamic_cast<I&>(*this).read_struct_swapped(data, position);
+  position += (4 - (position&0x3))&0x3;  //alignment
+  new_member() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: new_member()
+  org::eclipse::cyclonedds::topic::bswap_32(&new_member());
   position += 4;  //moving position indicator
   return position;
 }

--- a/src/idlcxx/tests/generator/typedef_resolution_header.cpp.in
+++ b/src/idlcxx/tests/generator/typedef_resolution_header.cpp.in
@@ -9,9 +9,13 @@ namespace M
 
   size_t typedef_read_td_6(td_6 &obj, const void* data, size_t position);
 
+  size_t typedef_read_swapped_td_6(td_6 &obj, const void* data, size_t position);
+
   size_t typedef_key_write_td_6(const td_6 &obj, void *data, size_t position);
 
   size_t typedef_key_read_td_6(td_6 &obj, const void *data, size_t position);
+
+  size_t typedef_key_read_swapped_td_6(td_6 &obj, const void *data, size_t position);
 
   size_t typedef_key_size_td_6(const td_6 &obj, size_t position);
 

--- a/src/idlcxx/tests/generator/typedef_resolution_impl.cpp.in
+++ b/src/idlcxx/tests/generator/typedef_resolution_impl.cpp.in
@@ -1,3 +1,4 @@
+#include "org/eclipse/cyclonedds/topic/byteswapping.hpp"
 #include "org/eclipse/cyclonedds/topic/hash.hpp"
 
 namespace M
@@ -71,12 +72,40 @@ namespace M
     return position;
   }
 
+  size_t typedef_key_read_swapped_td_6(td_6 &obj, const void *data, size_t position)
+  {
+    position += (4 - (position&0x3))&0x3;  //alignment
+    uint32_t _se1 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+    org::eclipse::cyclonedds::topic::bswap_32(&_se1);
+    position += 4;  //moving position indicator
+    obj.assign(reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position),reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position)+_se1); //reading bytes for member: obj
+    for (size_t _i2 = 0; _i2 < _se1; _i2++) {
+      org::eclipse::cyclonedds::topic::bswap_32(&obj[_i2]);
+    }
+    position += _se1*4;  //entries of sequence
+    return position;
+  }
+
   size_t typedef_read_td_6(td_6 &obj, const void* data, size_t position)
   {
     position += (4 - (position&0x3))&0x3;  //alignment
     uint32_t _se1 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
     position += 4;  //moving position indicator
     obj.assign(reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position),reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position)+_se1); //reading bytes for member: obj
+    position += _se1*4;  //entries of sequence
+    return position;
+  }
+
+  size_t typedef_read_swapped_td_6(td_6 &obj, const void* data, size_t position)
+  {
+    position += (4 - (position&0x3))&0x3;  //alignment
+    uint32_t _se1 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+    org::eclipse::cyclonedds::topic::bswap_32(&_se1);
+    position += 4;  //moving position indicator
+    obj.assign(reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position),reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position)+_se1); //reading bytes for member: obj
+    for (size_t _i2 = 0; _i2 < _se1; _i2++) {
+      org::eclipse::cyclonedds::topic::bswap_32(&obj[_i2]);
+    }
     position += _se1*4;  //entries of sequence
     return position;
   }
@@ -167,6 +196,12 @@ namespace N
     return position;
   }
 
+  size_t s::key_read_swapped(const void *data, size_t position)
+  {
+    (void)data;
+    return position;
+  }
+
   size_t s::read_struct(const void *data, size_t position)
   {
     position += (4 - (position&0x3))&0x3;  //alignment
@@ -177,6 +212,22 @@ namespace N
     mem().resize(_se1);
     for (size_t _i2 = 0; _i2 < _se1; _i2++) {
       position = M::typedef_read_td_6(mem()[_i2], data, position);
+    }
+    return position;
+  }
+
+  size_t s::read_struct_swapped(const void *data, size_t position)
+  {
+    position += (4 - (position&0x3))&0x3;  //alignment
+    mem_simple() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: mem_simple()
+    org::eclipse::cyclonedds::topic::bswap_32(&mem_simple());
+    position += 4;  //moving position indicator
+    uint32_t _se1 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+    org::eclipse::cyclonedds::topic::bswap_32(&_se1);
+    position += 4;  //moving position indicator
+    mem().resize(_se1);
+    for (size_t _i2 = 0; _i2 < _se1; _i2++) {
+      position = M::typedef_read_swapped_td_6(mem()[_i2], data, position);
     }
     return position;
   }

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -113,6 +113,7 @@ void create_funcs_base(idl_ostream_t * ostr, size_t n, bool ns)
   const char* al = als[ns];
   size_t width = cxx_width[n];
 
+  format_ostream_indented(0, ostr, "#include \"org/eclipse/cyclonedds/topic/byteswapping.hpp\"\n");
   format_ostream_indented(0, ostr, "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n");
 
   if (ns)
@@ -221,6 +222,12 @@ void create_funcs_base(idl_ostream_t * ostr, size_t n, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_read_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
   format_ostream_indented(ns * 2, ostr, "size_t s::read_struct(const void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   if (width > 1)
@@ -239,6 +246,26 @@ void create_funcs_base(idl_ostream_t * ostr, size_t n, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
+  format_ostream_indented(ns * 2, ostr, "size_t s::read_struct_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  if (width > 1)
+  {
+    if (width == 2)
+    {
+      format_ostream_indented(ns * 2, ostr, "  position += position&0x1;  //alignment\n");
+    }
+    else
+    {
+      format_ostream_indented(ns * 2, ostr, "  position += (%d - (position&%#x))&%#x;  //alignment\n", width, width - 1, width - 1);
+    }
+  }
+  format_ostream_indented(ns * 2, ostr, "  mem() = *reinterpret_cast<const %s*>(static_cast<const char*>(data)+position);  //reading bytes for member: mem()\n", tn);
+  if (width >= 2)
+    format_ostream_indented(ns * 2, ostr, "  org::eclipse::cyclonedds::topic::bswap_%d(&mem());\n", width*8);
+  format_ostream_indented(ns * 2, ostr, "  position += %d;  //moving position indicator\n", width);
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
   if (ns)
   {
     format_ostream_indented(0, ostr, "} //end namespace N\n\n");
@@ -249,6 +276,7 @@ void create_funcs_instance(idl_ostream_t* ostr, const char* in, bool ns)
 {
   const char* al = als[ns];
 
+  format_ostream_indented(0, ostr, "#include \"org/eclipse/cyclonedds/topic/byteswapping.hpp\"\n");
   format_ostream_indented(0, ostr, "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n");
 
   if (ns)
@@ -392,6 +420,18 @@ void create_funcs_instance(idl_ostream_t* ostr, const char* in, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
+  format_ostream_indented(ns * 2, ostr, "size_t I::key_read_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_read_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
   format_ostream_indented(ns * 2, ostr, "size_t I::read_struct(const void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
@@ -406,6 +446,21 @@ void create_funcs_instance(idl_ostream_t* ostr, const char* in, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
+  format_ostream_indented(ns * 2, ostr, "size_t I::read_struct_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()\n");
+  format_ostream_indented(ns * 2, ostr, "  org::eclipse::cyclonedds::topic::bswap_32(&l());\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::read_struct_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position = %s().read_struct_swapped(data, position);\n", in);
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
   if (ns)
   {
     format_ostream_indented(0, ostr, "} //end namespace N\n\n");
@@ -417,6 +472,7 @@ void create_funcs_string(idl_ostream_t* ostr, const char* in, bool ns)
 {
   const char* al = als[ns];
 
+  format_ostream_indented(0, ostr, "#include \"org/eclipse/cyclonedds/topic/byteswapping.hpp\"\n");
   format_ostream_indented(0, ostr, "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n");
 
   if (ns)
@@ -501,10 +557,27 @@ void create_funcs_string(idl_ostream_t* ostr, const char* in, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_read_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
   format_ostream_indented(ns * 2, ostr, "size_t s::read_struct(const void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  uint32_t %s = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence\n", se);
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  %s().assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+%s-1); //reading bytes for member: %s()\n", in, se, in);
+  format_ostream_indented(ns * 2, ostr, "  position += %s;  //entries of sequence\n", se);
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::read_struct_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  uint32_t %s = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence\n", se);
+  format_ostream_indented(ns * 2, ostr, "  org::eclipse::cyclonedds::topic::bswap_32(&%s);\n", se);
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  %s().assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+%s-1); //reading bytes for member: %s()\n", in, se, in);
   format_ostream_indented(ns * 2, ostr, "  position += %s;  //entries of sequence\n", se);
@@ -524,6 +597,7 @@ void create_funcs_sequence(idl_ostream_t* ostr, const char* seq_name, size_t n, 
   const char* se = ses[ns];
   const char* al = als[ns];
 
+  format_ostream_indented(0, ostr, "#include \"org/eclipse/cyclonedds/topic/byteswapping.hpp\"\n");
   format_ostream_indented(0, ostr, "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n");
 
   if (ns)
@@ -623,6 +697,12 @@ void create_funcs_sequence(idl_ostream_t* ostr, const char* seq_name, size_t n, 
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_read_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
   format_ostream_indented(ns * 2, ostr, "size_t s::read_struct(const void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
@@ -645,6 +725,36 @@ void create_funcs_sequence(idl_ostream_t* ostr, const char* seq_name, size_t n, 
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
+  format_ostream_indented(ns * 2, ostr, "size_t s::read_struct_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  uint32_t %s = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence\n", se);
+  format_ostream_indented(ns * 2, ostr, "  org::eclipse::cyclonedds::topic::bswap_32(&%s);\n", se);
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  if (width > 4)
+  {
+    format_ostream_indented(ns * 2, ostr, "  position += (%d - (position&%#x))&%#x;  //alignment\n", width, width - 1, width - 1);
+  }
+  if (n == 2)
+  {
+    format_ostream_indented(ns * 2, ostr, "  %s().resize(%s);\n", seq_name, se);
+    format_ostream_indented(ns * 2, ostr, "  for (size_t _b = 0; _b < %s; _b++) %s()[_b] = (*(static_cast<const char*>(data)+position++) ? 0x1 : 0x0); //reading bytes for member: %s()\n", se, seq_name, seq_name);
+  }
+  else
+  {
+    format_ostream_indented(ns * 2, ostr, "  %s().assign(reinterpret_cast<const %s*>(static_cast<const char*>(data)+position),reinterpret_cast<const %s*>(static_cast<const char*>(data)+position)+%s); //reading bytes for member: %s()\n", seq_name, cast, cast, se, seq_name);
+    if (width >= 2)
+    {
+      int i = ns ? 2 : 1;
+      format_ostream_indented(ns * 2, ostr, "  for (size_t _i%d = 0; _i%d < %s; _i%d++) {\n", i, i, se, i);
+      format_ostream_indented(ns * 2, ostr, "    org::eclipse::cyclonedds::topic::bswap_%d(&%s()[_i%d]);\n", width * 8, seq_name, i);
+      format_ostream_indented(ns * 2, ostr, "  }\n");
+    }
+    format_ostream_indented(ns * 2, ostr, "  position += %s*%d;  //entries of sequence\n", se, width);
+  }
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
   if (ns)
   {
     format_ostream_indented(0, ostr, "} //end namespace N\n\n");
@@ -656,6 +766,7 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   const char* se = ses[ns+2];
   const char* al = als[ns];
 
+  format_ostream_indented(0, ostr, "#include \"org/eclipse/cyclonedds/topic/byteswapping.hpp\"\n");
   format_ostream_indented(0, ostr, "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n");
 
   if (ns)
@@ -795,6 +906,13 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_read_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  clear();\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
   format_ostream_indented(ns * 2, ostr, "size_t s::read_struct(const void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  clear();\n");
@@ -836,6 +954,51 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
+  format_ostream_indented(ns * 2, ostr, "size_t s::read_struct_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  clear();\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  _d() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: _d()\n");
+  format_ostream_indented(ns * 2, ostr, "  org::eclipse::cyclonedds::topic::bswap_32(&_d());\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  switch (_d())\n");
+  format_ostream_indented(ns * 2, ostr, "  {\n");
+  format_ostream_indented(ns * 2, ostr, "    case 0:\n");
+  format_ostream_indented(ns * 2, ostr, "    case 1:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      o() = *reinterpret_cast<const uint8_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: o()\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 1;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "    case 2:\n");
+  format_ostream_indented(ns * 2, ostr, "    case 3:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()\n");
+  format_ostream_indented(ns * 2, ostr, "      org::eclipse::cyclonedds::topic::bswap_32(&l());\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "    case 4:\n");
+  format_ostream_indented(ns * 2, ostr, "    case 5:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      uint32_t %s = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence\n", se);
+  format_ostream_indented(ns * 2, ostr, "      org::eclipse::cyclonedds::topic::bswap_32(&%s);\n",se);
+  format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "      str().assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+%s-1); //reading bytes for member: str()\n", se);
+  format_ostream_indented(ns * 2, ostr, "      position += %s;  //entries of sequence\n", se);
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "    default:\n");
+  format_ostream_indented(ns * 2, ostr, "    {\n");
+  format_ostream_indented(ns * 2, ostr, "      f() = *reinterpret_cast<const float*>(static_cast<const char*>(data)+position);  //reading bytes for member: f()\n");
+  format_ostream_indented(ns * 2, ostr, "      org::eclipse::cyclonedds::topic::bswap_32(&f());\n");
+  format_ostream_indented(ns * 2, ostr, "      position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "    }\n");
+  format_ostream_indented(ns * 2, ostr, "    break;\n");
+  format_ostream_indented(ns * 2, ostr, "  }\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
   if (ns)
   {
     format_ostream_indented(0, ostr, "} //end namespace N\n\n");
@@ -845,6 +1008,7 @@ void generate_union_funcs(idl_ostream_t* ostr, bool ns)
 void generate_enum_funcs(idl_ostream_t* ostr, bool ns)
 {
   const char* al = als[ns];
+  format_ostream_indented(0, ostr, "#include \"org/eclipse/cyclonedds/topic/byteswapping.hpp\"\n");
   format_ostream_indented(0, ostr, "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n");
 
   if (ns)
@@ -923,10 +1087,25 @@ void generate_enum_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_read_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
   format_ostream_indented(ns * 2, ostr, "size_t s::read_struct(const void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  mem() = *reinterpret_cast<const %sE*>(static_cast<const char*>(data)+position);  //reading bytes for member: mem()\n", ns ? "N::" : "");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::read_struct_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  mem() = *reinterpret_cast<const %sE*>(static_cast<const char*>(data)+position);  //reading bytes for member: mem()\n", ns ? "N::" : "");
+  format_ostream_indented(ns * 2, ostr, "  org::eclipse::cyclonedds::topic::bswap_32(&mem());\n");
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
@@ -941,6 +1120,7 @@ void generate_enum_funcs(idl_ostream_t* ostr, bool ns)
 void generate_array_base_funcs(idl_ostream_t* ostr, bool ns)
 {
   const char* al = als[ns];
+  format_ostream_indented(0, ostr, "#include \"org/eclipse/cyclonedds/topic/byteswapping.hpp\"\n");
   format_ostream_indented(0, ostr, "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n");
 
   if (ns)
@@ -1023,12 +1203,33 @@ void generate_array_base_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_read_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
   format_ostream_indented(ns * 2, ostr, "size_t s::read_struct(const void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
   format_ostream_indented(ns * 2, ostr, "  memcpy(mem().data(),static_cast<const char*>(data)+position,24);  //reading bytes for member: mem()\n");
   format_ostream_indented(ns * 2, ostr, "  position += 24;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  mem2() = *reinterpret_cast<const float*>(static_cast<const char*>(data)+position);  //reading bytes for member: mem2()\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::read_struct_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  memcpy(mem().data(),static_cast<const char*>(data)+position,24);  //reading bytes for member: mem()\n");
+  int i = ns ? 2 : 1;
+  format_ostream_indented(ns * 2, ostr, "  for (size_t _i%d = 0; _i%d < 6; _i%d++)  {\n", i, i, i);
+  format_ostream_indented(ns * 2, ostr, "    org::eclipse::cyclonedds::topic::bswap_32(&mem()[_i%d]);\n", i);
+  format_ostream_indented(ns * 2, ostr, "  }\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 24;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  mem2() = *reinterpret_cast<const float*>(static_cast<const char*>(data)+position);  //reading bytes for member: mem2()\n");
+  format_ostream_indented(ns * 2, ostr, "  org::eclipse::cyclonedds::topic::bswap_32(&mem2());\n");
   format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
@@ -1042,6 +1243,7 @@ void generate_array_base_funcs(idl_ostream_t* ostr, bool ns)
 
 void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
 {
+  format_ostream_indented(0, ostr, "#include \"org/eclipse/cyclonedds/topic/byteswapping.hpp\"\n");
   format_ostream_indented(0, ostr, "#include \"org/eclipse/cyclonedds/topic/hash.hpp\"\n\n");
 
   if (ns)
@@ -1197,6 +1399,18 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 
+  format_ostream_indented(ns * 2, ostr, "size_t I::key_read_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::key_read_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  (void)data;\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
   format_ostream_indented(ns * 2, ostr, "size_t I::read_struct(const void *data, size_t position)\n");
   format_ostream_indented(ns * 2, ostr, "{\n");
   format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
@@ -1211,6 +1425,24 @@ void generate_array_instance_funcs(idl_ostream_t* ostr, bool ns)
   format_ostream_indented(ns * 2, ostr, "    position = mem()[%s].read_struct(data, position);\n", it);
   format_ostream_indented(ns * 2, ostr, "  }\n");
   format_ostream_indented(ns * 2, ostr, "  position = mem2().read_struct(data, position);\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t I::read_struct_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  position += (4 - (position&0x3))&0x3;  //alignment\n");
+  format_ostream_indented(ns * 2, ostr, "  l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()\n");
+  format_ostream_indented(ns * 2, ostr, "  org::eclipse::cyclonedds::topic::bswap_32(&l());\n");
+  format_ostream_indented(ns * 2, ostr, "  position += 4;  //moving position indicator\n");
+  format_ostream_indented(ns * 2, ostr, "  return position;\n");
+  format_ostream_indented(ns * 2, ostr, "}\n\n");
+
+  format_ostream_indented(ns * 2, ostr, "size_t s::read_struct_swapped(const void *data, size_t position)\n");
+  format_ostream_indented(ns * 2, ostr, "{\n");
+  format_ostream_indented(ns * 2, ostr, "  for (size_t %s = 0; %s < 6; %s++)  {\n", it, it, it);
+  format_ostream_indented(ns * 2, ostr, "    position = mem()[%s].read_struct_swapped(data, position);\n", it);
+  format_ostream_indented(ns * 2, ostr, "  }\n");
+  format_ostream_indented(ns * 2, ostr, "  position = mem2().read_struct_swapped(data, position);\n");
   format_ostream_indented(ns * 2, ostr, "  return position;\n");
   format_ostream_indented(ns * 2, ostr, "}\n\n");
 


### PR DESCRIPTION
Byteswapping functionality is handled through specialised
generated struct and key read functions which are the same
as non-swapping functions, except they also call a byte-swap
function specified in
src/ddscxx/include/org/eclipse/cyclonedds/topic/byteswapping.hpp
for primitive fields of lengths of multiple bytes
For complex members the swap calls are done recursively
The data topic checks whether the byte ordering on the data is
the same for received data, if it is, it uses the non-swapping
read function, if it is not, it uses the swapping read function

Signed-off-by: Martijn Reicher <martijn.reicher@adlinktech.com>