### PR TITLE
Fix issue with casting topicdescriptor to topic

### DIFF
--- a/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
@@ -488,8 +488,8 @@ dds::sub::detail::DataReader<T>::common_constructor(
 
     org::eclipse::cyclonedds::sub::qos::DataReaderQosDelegate drQos = qos_.delegate();
 
-    dds_entity_t ddsc_sub = static_cast<dds_entity_t>((sub_.delegate()->get_ddsc_entity()));
-    dds_entity_t ddsc_top = static_cast<dds::topic::Topic<T> >(this->AnyDataReaderDelegate::td_).delegate()->get_ddsc_entity();
+    dds_entity_t ddsc_sub = sub_.delegate()->get_ddsc_entity();
+    dds_entity_t ddsc_top = this->AnyDataReaderDelegate::td_.delegate()->get_ddsc_entity();
 
     // get and validate the ddsc qos
     drQos.check();


### PR DESCRIPTION
Remove the unnecessary static_cast to a TopicDescription
to a Topic type

Signed-off-by: Martijn Reicher <martijn.reicher@adlinktech.com>