### PR TITLE
Fix bug of re-alignment not being done after non-base members

### DIFF
--- a/src/idlcxx/tests/CMakeLists.txt
+++ b/src/idlcxx/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ set(xxd_input
   ${generator_dir}/keys_typedef_impl.cpp.in
   ${generator_dir}/keys_typedef_header.cpp.in
   ${generator_dir}/keys_union_implicit_impl.cpp.in
+  ${generator_dir}/re_alignment_impl.cpp.in
   ${generator_dir}/sequence_recursive_header.cpp.in
   ${generator_dir}/sequence_recursive_impl.cpp.in
   ${generator_dir}/struct_inheritance_impl.cpp.in

--- a/src/idlcxx/tests/generator/re_alignment_impl.cpp.in
+++ b/src/idlcxx/tests/generator/re_alignment_impl.cpp.in
@@ -1,0 +1,97 @@
+#include "org/eclipse/cyclonedds/topic/hash.hpp"
+
+size_t s::write_struct(void *data, size_t position) const
+{
+  size_t _al0 = (4 - (position&0x3))&0x3;  //alignment
+  memset(static_cast<char*>(data)+position,0x0,_al0);  //setting alignment bytes to 0x0
+  position += _al0;  //moving position indicator
+  uint32_t _se0 = static_cast<uint32_t>(str().size()+1);  //number of entries in the sequence
+  *reinterpret_cast<uint32_t*>(static_cast<char*>(data) + position) = _se0;  //writing entries for member: str()
+  position += 4;  //moving position indicator
+  memcpy(static_cast<char*>(data)+position,str().data(),_se0*1); //writing bytes for member: str()
+  position += _se0;  //entries of sequence
+  _al0 = (4 - (position&0x3))&0x3;  //alignment
+  memset(static_cast<char*>(data)+position,0x0,_al0);  //setting alignment bytes to 0x0
+  position += _al0;  //moving position indicator
+  *reinterpret_cast<int32_t*>(static_cast<char*>(data)+position) = l();  //writing bytes for member: l()
+  position += 4;  //moving position indicator
+  return position;
+}
+
+size_t s::write_size(size_t position) const
+{
+  position += (4 - (position&0x3))&0x3;  //alignment
+  uint32_t _se0 = static_cast<uint32_t>(str().size()+1);  //number of entries in the sequence
+  position += 4;  //bytes for sequence entries
+  position += _se0;  //entries of sequence
+  position += (4 - (position&0x3))&0x3;  //alignment
+  position += 4;  //bytes for member: l()
+  return position;
+}
+
+size_t s::max_size(size_t position) const
+{
+  (void)position;
+  return UINT_MAX;
+}
+
+size_t s::key_size(size_t position) const
+{
+  return position;
+}
+
+size_t s::key_max_size(size_t position) const
+{
+  return position;
+}
+
+size_t s::key_write(void *data, size_t position) const
+{
+  (void)data;
+  return position;
+}
+
+bool s::key(ddsi_keyhash_t &hash) const
+{
+  size_t sz = key_size(0);
+  size_t padding = 16 - sz%16;
+  if (sz != 0 && padding == 16) padding = 0;
+  std::vector<unsigned char> buffer(sz+padding);
+  memset(buffer.data()+sz,0x0,padding);
+  key_write(buffer.data(),0);
+  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;
+  if (fptr == NULL)
+  {
+    if (key_max_size(0) <= 16)
+    {
+      //bind to unmodified function which just copies buffer into the keyhash
+      fptr = &org::eclipse::cyclonedds::topic::simple_key;
+    }
+    else
+    {
+      //bind to MD5 hash function
+      fptr = &org::eclipse::cyclonedds::topic::complex_key;
+    }
+  }
+  return (*fptr)(buffer,hash);
+}
+
+size_t s::key_read(const void *data, size_t position)
+{
+  (void)data;
+  return position;
+}
+
+size_t s::read_struct(const void *data, size_t position)
+{
+  position += (4 - (position&0x3))&0x3;  //alignment
+  uint32_t _se0 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+  position += 4;  //moving position indicator
+  str().assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+_se0-1); //reading bytes for member: str()
+  position += _se0;  //entries of sequence
+  position += (4 - (position&0x3))&0x3;  //alignment
+  l() = *reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: l()
+  position += 4;  //moving position indicator
+  return position;
+}
+

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -29,6 +29,7 @@ extern const unsigned char sequence_recursive_impl_cpp_in[];
 extern const unsigned char struct_inheritance_impl_cpp_in[];
 extern const unsigned char typedef_resolution_header_cpp_in[];
 extern const unsigned char typedef_resolution_impl_cpp_in[];
+extern const unsigned char re_alignment_impl_cpp_in[];
 
 #include "idlcxx/streamer_generator.h"
 #include "idl/processor.h"
@@ -1824,6 +1825,27 @@ void test_sequence_recursive()
   idl_delete_tree(tree);
 }
 
+void test_re_alignment()
+{
+  const char* str =
+    "struct s {\n"\
+    "string str;\n"\
+    "long l;\n"\
+    "};\n";
+
+  idl_tree_t* tree = NULL;
+  idl_parse_string(str, IDL_FLAG_ANNOTATIONS, &tree);
+
+  idl_streamer_output_t* generated = create_idl_streamer_output();
+  idl_streamers_generate(tree, generated);
+
+  CU_ASSERT_STRING_EQUAL(re_alignment_impl_cpp_in, get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+  CU_ASSERT_STRING_EQUAL("", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
+
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
+}
+
 CU_Test(streamer_generator, base_types_namespace_absent)
 {
   for (size_t i = 0; i < sizeof(cxx_width) / sizeof(size_t); i++)
@@ -1966,4 +1988,9 @@ CU_Test(streamer_generator, key_typedef)
 CU_Test(streamer_generator, sequence_recursive)
 {
   test_sequence_recursive();
+}
+
+CU_Test(streamer_generator, re_alignment)
+{
+  test_re_alignment();
 }


### PR DESCRIPTION
The re-alignment of writing data was not being done after
writing members containing sequences of lengths not known
at compile time

Signed-off-by: Martijn Reicher <martijn.reicher@adlinktech.com>