### PR TITLE
Fixes for unions and bounded sequences

### DIFF
--- a/src/idlcxx/src/streamer_generator.c
+++ b/src/idlcxx/src/streamer_generator.c
@@ -1504,20 +1504,51 @@ idl_retcode_t process_case_label(context_t* ctx, idl_case_label_t* label)
     char* buffer = NULL;
     idl_constval_t* cv = (idl_constval_t*)ce;
 
-    if (idl_is_masked(ce, IDL_INTEGER_TYPE))
+    switch (ce->mask % (IDL_BASE_TYPE * 2))
     {
-      if (idl_asprintf(&buffer, "%lu", cv->value.ullng) == -1)
+    case IDL_INT8:
+      if (idl_asprintf(&buffer, "%" PRId8, cv->value.int8) == -1)
         return IDL_RETCODE_NO_MEMORY;
-    }
-    else if (idl_is_masked(ce, IDL_BOOL))
-    {
-      if ((idl_strdup(cv->value.bln ? "true" : "false")) == 0)
+      break;
+    case IDL_OCTET:
+    case IDL_UINT8:
+      if (idl_asprintf(&buffer, "%" PRIu8, cv->value.uint8) == -1)
         return IDL_RETCODE_NO_MEMORY;
-    }
-    else if (idl_is_masked(ce, IDL_CHAR))
-    {
-      if (idl_asprintf(&buffer, "\'%s\'", cv->value.str) == -1)
+      break;
+    case IDL_INT16:
+      if (idl_asprintf(&buffer, "%" PRId16, cv->value.int16) == -1)
         return IDL_RETCODE_NO_MEMORY;
+      break;
+    case IDL_UINT16:
+      if (idl_asprintf(&buffer, "%" PRIu16, cv->value.uint16) == -1)
+        return IDL_RETCODE_NO_MEMORY;
+      break;
+    case IDL_INT32:
+      if (idl_asprintf(&buffer, "%" PRId32, cv->value.int32) == -1)
+        return IDL_RETCODE_NO_MEMORY;
+      break;
+    case IDL_UINT32:
+      if (idl_asprintf(&buffer, "%" PRIu32, cv->value.uint32) == -1)
+        return IDL_RETCODE_NO_MEMORY;
+      break;
+    case IDL_INT64:
+      if (idl_asprintf(&buffer, "%" PRId64, cv->value.int64) == -1)
+        return IDL_RETCODE_NO_MEMORY;
+      break;
+    case IDL_UINT64:
+      if (idl_asprintf(&buffer, "%" PRIu64, cv->value.uint64) == -1)
+        return IDL_RETCODE_NO_MEMORY;
+      break;
+    case IDL_BOOL:
+      if ((buffer = idl_strdup(cv->value.bln ? "true" : "false")) == NULL)
+        return IDL_RETCODE_NO_MEMORY;
+      break;
+    case IDL_CHAR:
+      if (idl_asprintf(&buffer, "\'%c\'", cv->value.chr) == -1)
+        return IDL_RETCODE_NO_MEMORY;
+      break;
+    default:
+      assert(0);
     }
 
     if (buffer)

--- a/src/idlcxx/src/streamer_generator.c
+++ b/src/idlcxx/src/streamer_generator.c
@@ -118,6 +118,7 @@ if (key) {format_key_read_stream(indent,ctx, __VA_ARGS__);}
 #define bound_iterate "  for (size_t _i%d = 0; _i%d < %"PRIu64"; _i%d++) {\n"
 #define seq_read_resize "  %s.resize("seqentries");\n"
 #define seq_length_exception "  if ("seqentries" > %"PRIu64") throw dds::core::InvalidArgumentError(\"attempt to assign entries to bounded member %s in excess of maximum length %"PRIu64"\");\n"
+#define seq_read_past_bound_resize "  if ("seqentries" > %"PRIu64") %s.resize(%"PRIu64");\n"
 #define seq_incr position_incr seqentries"*%d;"
 #define seq_inc_1 position_incr seqentries ";"
 #define max_size_incr_checked_multiple max_size_check primitive_incr_pos entries_of_sequence_comment
@@ -1816,6 +1817,11 @@ idl_retcode_t process_sequence_impl(context_t* ctx, const char* accessor, idl_se
 
     ctx->depth--;
     load_locals(ctx, locals);
+  }
+
+  if (bound)
+  {
+    format_read_stream(1, ctx, is_key, seq_read_past_bound_resize, ctx->depth, bound, accessor, bound);
   }
 
   reset_alignment(ctx, is_key);

--- a/src/idlcxx/tests/generator/bounded_sequence_impl.cpp.in
+++ b/src/idlcxx/tests/generator/bounded_sequence_impl.cpp.in
@@ -85,6 +85,7 @@ size_t s::read_struct(const void *data, size_t position)
   position += 4;  //moving position indicator
   mem().assign(reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position),reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position)+_se0); //reading bytes for member: mem()
   position += _se0*4;  //entries of sequence
+  if (_se0 > 20) mem().resize(20);
   return position;
 }
 

--- a/src/idlcxx/tests/generator/bounded_sequence_of_structs_impl.cpp.in
+++ b/src/idlcxx/tests/generator/bounded_sequence_of_structs_impl.cpp.in
@@ -179,6 +179,7 @@ size_t s::key_read(const void *data, size_t position)
   for (size_t _i1 = 0; _i1 < _se0; _i1++) {
     position = mem()[_i1].read_struct(data, position);
   }
+  if (_se0 > 20) mem().resize(20);
   return position;
 }
 
@@ -199,6 +200,7 @@ size_t s::read_struct(const void *data, size_t position)
   for (size_t _i1 = 0; _i1 < _se0; _i1++) {
     position = mem()[_i1].read_struct(data, position);
   }
+  if (_se0 > 20) mem().resize(20);
   return position;
 }
 

--- a/src/idlcxx/tests/generator/keys_union_implicit_impl.cpp.in
+++ b/src/idlcxx/tests/generator/keys_union_implicit_impl.cpp.in
@@ -9,6 +9,7 @@ size_t u::write_struct(void *data, size_t position) const
   position += 4;  //moving position indicator
   switch (_d())
   {
+    case -12345:
     case 0:
     case 1:
     {
@@ -62,6 +63,7 @@ size_t u::write_size(size_t position) const
   position += 4;  //bytes for member: _d()
   switch (_d())
   {
+    case -12345:
     case 0:
     case 1:
     {
@@ -234,6 +236,7 @@ size_t u::read_struct(const void *data, size_t position)
   position += 4;  //moving position indicator
   switch (_d())
   {
+    case -12345:
     case 0:
     case 1:
     {

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -1706,6 +1706,7 @@ void test_keys_union_implicit()
 {
   const char* str =
   "union u switch (long) {\n"\
+    "case -12345:\n"\
     "case 0:\n"\
     "case 1: octet o;\n"\
     "case 2:\n"\


### PR DESCRIPTION
- Fixed case indices not being generated for idl unions
- Fixed reading items beyond the bound for bounded sequences
- Fixed issue with take_cdr causing segmentation violations with take_cdr on empty keyless topics