### PR TITLE
Update to use ddsi_sertype

### DIFF
--- a/src/ddscxx/include/dds/topic/detail/ContentFilteredTopic.hpp
+++ b/src/ddscxx/include/dds/topic/detail/ContentFilteredTopic.hpp
@@ -270,7 +270,7 @@ public:
     {
         topic.delegate()->incrNrDependents();
         this->myParticipant.delegate()->add_cfTopic(*this);
-        this->ser_topic_ = topic->get_ser_topic();
+        this->ser_type_ = topic->get_ser_type();
     }
 
     virtual ~ContentFilteredTopic()
@@ -444,9 +444,14 @@ private:
     {
         /* Make a private copy of the topic so my filter doesn't bother the original topic. */
         dds_qos_t* ddsc_qos = myTopic.qos()->ddsc_qos();
-        ddsi_sertopic *st = org::eclipse::cyclonedds::topic::TopicTraits<T>::getSerTopic(myTopic.name());
+        ddsi_sertype *st = org::eclipse::cyclonedds::topic::TopicTraits<T>::getSerType(myTopic.name());
+#if DDS_HAS_DDSI_SERTYPE
+        dds_entity_t cfTopic = dds_create_topic_sertype(
+            myTopic.domain_participant().delegate()->get_ddsc_entity(), myTopic.name().c_str(), &st, ddsc_qos, NULL, NULL);
+#else
         dds_entity_t cfTopic = dds_create_topic_generic(
             myTopic.domain_participant().delegate()->get_ddsc_entity(), &st, ddsc_qos, NULL, NULL);
+#endif
         dds_delete_qos(ddsc_qos);
         this->set_ddsc_entity(cfTopic);
 

--- a/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
@@ -25,6 +25,10 @@
 
 #include <dds/dds.h>
 
+#if ! DDS_HAS_DDSI_SERTYPE
+typedef ddsi_sertopic ddsi_sertype;
+#endif
+
 #define MAX_TOPIC_NAME_LEN 1024
 
 // Implementation
@@ -173,10 +177,15 @@ dds::topic::detail::Topic<T>::Topic(const dds::domain::DomainParticipant& dp,
     dds_qos_t* ddsc_qos = tQos.ddsc_qos();
     dds_entity_t ddsc_par = dp.delegate()->get_ddsc_entity();
 
-    ser_topic_ = org::eclipse::cyclonedds::topic::TopicTraits<T>::getSerTopic(name);
+    ser_type_ = org::eclipse::cyclonedds::topic::TopicTraits<T>::getSerType(name);
 
+#if DDS_HAS_DDSI_SERTYPE
+    dds_entity_t ddsc_topic = dds_create_topic_sertype(
+      ddsc_par, name.c_str(), &ser_type_, ddsc_qos, NULL, NULL);
+#else
     dds_entity_t ddsc_topic = dds_create_topic_generic(
-      ddsc_par, &ser_topic_, ddsc_qos, NULL, NULL);
+      ddsc_par, &ser_type_, ddsc_qos, NULL, NULL);
+#endif
 
     dds_delete_qos(ddsc_qos);
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.hpp
@@ -30,6 +30,10 @@
 
 #include <org/eclipse/cyclonedds/topic/CDRBlob.hpp>
 
+#if ! DDS_HAS_DDSI_SERTYPE
+typedef ddsi_sertopic ddsi_sertype;
+#endif
+
 namespace dds { namespace pub {
 template <typename DELEGATE>
 class TAnyDataWriter;

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.hpp
@@ -21,6 +21,10 @@
 #include <dds/domain/DomainParticipant.hpp>
 #include <org/eclipse/cyclonedds/core/ObjectDelegate.hpp>
 
+#if ! DDS_HAS_DDSI_SERTYPE
+typedef ddsi_sertopic ddsi_sertype;
+#endif
+
 namespace org
 {
 namespace eclipse
@@ -70,14 +74,14 @@ public:
 
     //@todo virtual c_value *reader_parameters() const = 0;
 
-    ddsi_sertopic *get_ser_topic() const;
+    ddsi_sertype *get_ser_type() const;
 
 protected:
     dds::domain::DomainParticipant myParticipant;
     std::string myTopicName;
     std::string myTypeName;
     uint32_t nrDependents;
-    struct ddsi_sertopic *ser_topic_;
+    ddsi_sertype *ser_type_;
 };
 
 }

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicTraits.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicTraits.hpp
@@ -21,6 +21,10 @@
 #include <string.h>
 #include <org/eclipse/cyclonedds/topic/DataRepresentation.hpp>
 
+#if ! DDS_HAS_DDSI_SERTYPE
+typedef ddsi_sertopic ddsi_sertype;
+#endif
+
 namespace org
 {
 namespace eclipse
@@ -63,7 +67,7 @@ public:
         return "ExampleName";
     }
 
-    static ddsi_sertopic *getSerTopic(const std::string& topic_name)
+    static ddsi_sertype *getSerType(const std::string& topic_name)
     {
         (void)topic_name;
         return NULL;

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
@@ -108,7 +108,7 @@ AnyDataWriterDelegate::write_cdr(
 
     /* Now create a dedicated ser_data that contains both encoding and payload as contiguous memory. */
     ser_data = ddsi_serdata_from_ser_iov(
-        td_->get_ser_topic(),
+        td_->get_ser_type(),
         static_cast<ddsi_serdata_kind>(data->kind()),
         2,
         blob_holders,

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.cpp
@@ -35,7 +35,7 @@ TopicDescriptionDelegate::TopicDescriptionDelegate(
       myTopicName(name),
       myTypeName(type_name),
       nrDependents(0),
-      ser_topic_(NULL)
+      ser_type_(NULL)
 {
 }
 
@@ -85,10 +85,10 @@ TopicDescriptionDelegate::hasDependents() const
     return (nrDependents > 0);
 }
 
-ddsi_sertopic *
-TopicDescriptionDelegate::get_ser_topic() const
+ddsi_sertype *
+TopicDescriptionDelegate::get_ser_type() const
 {
-    return ser_topic_;
+    return ser_type_;
 }
 
 

--- a/src/idlcxx/src/backendCpp11Trait.c
+++ b/src/idlcxx/src/backendCpp11Trait.c
@@ -92,11 +92,11 @@ generate_traits(idl_backend_ctx ctx, const idl_node_t *node)
   idl_file_out_printf(ctx, "return \"%s\";\n", &struct_name[2] /* Skip preceeding "::" according to convention. */);
   idl_indent_decr(ctx);
   idl_file_out_printf(ctx, "}\n\n");
-  idl_file_out_printf(ctx, "static ddsi_sertopic *getSerTopic(const std::string& topic_name)\n");
+  idl_file_out_printf(ctx, "static ddsi_sertype *getSerType(const std::string& topic_name)\n");
   idl_file_out_printf(ctx, "{\n");
   idl_indent_incr(ctx);
-  idl_file_out_printf(ctx, "auto *st = new ddscxx_sertopic<%s>(topic_name.c_str(), getTypeName());\n", struct_name);
-  idl_file_out_printf(ctx, "return static_cast<ddsi_sertopic*>(st);\n");
+  idl_file_out_printf(ctx, "auto *st = new ddscxx_sertype<%s>(topic_name.c_str(), getTypeName());\n", struct_name);
+  idl_file_out_printf(ctx, "return static_cast<ddsi_sertype*>(st);\n");
   idl_indent_decr(ctx);
   idl_file_out_printf(ctx, "}\n\n");
   idl_file_out_printf(ctx, "static size_t getSampleSize()\n");


### PR DESCRIPTION
With conditional compilation for continued support of `ddsi_sertopic`.

I suppose there are tricks in C++ to make this nicer and avoid any pollution of the global namespace. Suggestions are welcome!