### PR TITLE
Fix for lifetime of entities not matching the attached callback funct…

### DIFF
--- a/src/ddscxx/CMakeLists.txt
+++ b/src/ddscxx/CMakeLists.txt
@@ -34,6 +34,7 @@ set(sources
     src/org/eclipse/cyclonedds/core/InstanceHandleDelegate.cpp
     src/org/eclipse/cyclonedds/core/EntitySet.cpp
     src/org/eclipse/cyclonedds/core/MiscUtils.cpp
+    src/org/eclipse/cyclonedds/core/DeferredDestruction.cpp
     src/org/eclipse/cyclonedds/core/cond/ConditionDelegate.cpp
     src/org/eclipse/cyclonedds/core/cond/GuardConditionDelegate.cpp
     src/org/eclipse/cyclonedds/core/cond/StatusConditionDelegate.cpp

--- a/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
@@ -19,6 +19,7 @@
 /*
  * OMG PSM class declaration
  */
+#include <org/eclipse/cyclonedds/core/DeferredDestruction.hpp>
 #include <dds/sub/detail/DataReader.hpp>
 #include <dds/sub/Query.hpp>
 #include <dds/sub/detail/SamplesHolder.hpp>
@@ -1341,42 +1342,63 @@ template <typename T>
 void dds::sub::detail::DataReader<T>::on_requested_deadline_missed(dds_entity_t,
         org::eclipse::cyclonedds::core::RequestedDeadlineMissedStatusDelegate &sd)
 {
-    dds::core::status::RequestedDeadlineMissedStatus s;
-    s.delegate() = sd;
+    auto& dd = org::eclipse::cyclonedds::core::DeferredDestruction::get_instance();
 
-    dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+    {
+        dds::core::status::RequestedDeadlineMissedStatus s;
+        s.delegate() = sd;
 
-    dds::sub::DataReaderListener<T> *l =
-        reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
-    l->on_requested_deadline_missed(dr, s);
+        dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+        dd.emplace(dr);
+
+        dds::sub::DataReaderListener<T> *l =
+            reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
+        l->on_requested_deadline_missed(dr, s);
+    }
+
+    dd.commit();
 }
 
 template <typename T>
 void dds::sub::detail::DataReader<T>::on_requested_incompatible_qos(dds_entity_t,
         org::eclipse::cyclonedds::core::RequestedIncompatibleQosStatusDelegate &sd)
 {
-    dds::core::status::RequestedIncompatibleQosStatus s;
-    s.delegate() = sd;
+    auto& dd = org::eclipse::cyclonedds::core::DeferredDestruction::get_instance();
 
-    dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+    {
+        dds::core::status::RequestedIncompatibleQosStatus s;
+        s.delegate() = sd;
 
-    dds::sub::DataReaderListener<T> *l =
-        reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
-    l->on_requested_incompatible_qos(dr, s);
+        dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+        dd.emplace(dr);
+
+        dds::sub::DataReaderListener<T> *l =
+            reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
+        l->on_requested_incompatible_qos(dr, s);
+    }
+
+    dd.commit();
 }
 
 template <typename T>
 void dds::sub::detail::DataReader<T>::on_sample_rejected(dds_entity_t,
              org::eclipse::cyclonedds::core::SampleRejectedStatusDelegate &sd)
 {
-    dds::core::status::SampleRejectedStatus s;
-    s.delegate() = sd;
+    auto& dd = org::eclipse::cyclonedds::core::DeferredDestruction::get_instance();
 
-    dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+    {
+        dds::core::status::SampleRejectedStatus s;
+        s.delegate() = sd;
 
-    dds::sub::DataReaderListener<T> *l =
+        dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+        dd.emplace(dr);
+
+        dds::sub::DataReaderListener<T>* l =
             reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
-    l->on_sample_rejected(dr, s);
+        l->on_sample_rejected(dr, s);
+    }
+
+    dd.commit();
 }
 
 
@@ -1384,52 +1406,80 @@ template <typename T>
 void dds::sub::detail::DataReader<T>::on_liveliness_changed(dds_entity_t,
              org::eclipse::cyclonedds::core::LivelinessChangedStatusDelegate &sd)
 {
-    dds::core::status::LivelinessChangedStatus s;
-    s.delegate() = sd;
+    auto& dd = org::eclipse::cyclonedds::core::DeferredDestruction::get_instance();
 
-    dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+    {
+        dds::core::status::LivelinessChangedStatus s;
+        s.delegate() = sd;
 
-    dds::sub::DataReaderListener<T> *l =
+        dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+        dd.emplace(dr);
+
+        dds::sub::DataReaderListener<T>* l =
             reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
-    l->on_liveliness_changed(dr, s);
+        l->on_liveliness_changed(dr, s);
+    }
+
+    dd.commit();
 }
 
 template <typename T>
 void dds::sub::detail::DataReader<T>::on_data_available(dds_entity_t)
 {
-    dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+    auto &dd = org::eclipse::cyclonedds::core::DeferredDestruction::get_instance();
 
-    dds::sub::DataReaderListener<T> *l =
-        reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
-    l->on_data_available(dr);
+    {
+        dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+        dd.emplace(dr);
+
+        dds::sub::DataReaderListener<T>* l =
+            reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
+        l->on_data_available(dr);
+    }
+
+    dd.commit();
 }
 
 template <typename T>
 void dds::sub::detail::DataReader<T>::on_subscription_matched(dds_entity_t,
         org::eclipse::cyclonedds::core::SubscriptionMatchedStatusDelegate &sd)
 {
-    dds::core::status::SubscriptionMatchedStatus s;
-    s.delegate() = sd;
+    auto& dd = org::eclipse::cyclonedds::core::DeferredDestruction::get_instance();
 
-    dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+    {
+        dds::core::status::SubscriptionMatchedStatus s;
+        s.delegate() = sd;
 
-    dds::sub::DataReaderListener<T> *l =
-        reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
-    l->on_subscription_matched(dr, s);
+        dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+        dd.emplace(dr);
+
+        dds::sub::DataReaderListener<T>* l =
+            reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
+        l->on_subscription_matched(dr, s);
+    }
+
+    dd.commit();
 }
 
 template <typename T>
 void dds::sub::detail::DataReader<T>::on_sample_lost(dds_entity_t,
         org::eclipse::cyclonedds::core::SampleLostStatusDelegate &sd)
 {
-    dds::core::status::SampleLostStatus s;
-    s.delegate() = sd;
+    auto& dd = org::eclipse::cyclonedds::core::DeferredDestruction::get_instance();
 
-    dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+    {
+        dds::core::status::SampleLostStatus s;
+        s.delegate() = sd;
 
-    dds::sub::DataReaderListener<T> *l =
-        reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
-    l->on_sample_lost(dr, s);
+        dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+        dd.emplace(dr);
+
+        dds::sub::DataReaderListener<T> *l =
+            reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
+        l->on_sample_lost(dr, s);
+    }
+
+    dd.commit();
 }
 
 // End of implementation

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/DeferredDestruction.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/DeferredDestruction.hpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+
+ /**
+  * @file
+  */
+
+#ifndef __DEFERRED_DESTRUCTION__
+#define __DEFERRED_DESTRUCTION__
+
+#include <dds/core/Entity.hpp>
+
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <list>
+#include <memory>
+
+namespace org
+{
+namespace eclipse
+{
+namespace cyclonedds
+{
+namespace core
+{
+
+/**
+* @brief
+* This class takes care of the deferred destruction of entities.
+*
+* Typically it is used to allow for an entity to go out of scope
+* while other entities may still have shared pointers referencing
+* this entity. This causes issues when the close() function is
+* invoked, giving an assert(false) failure.
+*
+* Typical usage:
+* @code{.cpp}
+* auto& dd = org::eclipse::cyclonedds::core::DeferredDestruction::get_instance();
+*
+* {
+*     dds::core::status::RequestedDeadlineMissedStatus s;
+*      s.delegate() = sd;
+*
+*     //this is the entity whose destruction needs to be deferred
+*     dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+*     //here it is added to deferred destruction
+*     dd.emplace(dr);
+
+*     dds::sub::DataReaderListener<T> *l =
+*         reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
+*     l->on_requested_deadline_missed(dr, s);
+*
+*     //dr goes out of scope here, but its destruction is deferred
+* }
+*
+* //its true destruction can only happen here
+* dd.commit();
+* @endcode
+*/
+class DeferredDestruction
+{
+public:
+
+    /**
+    * Destructor.
+    */
+    ~DeferredDestruction();
+
+    /**
+    * Commit function.
+    *
+    * Will cause an additional managed entity to have reached its end of life.
+    * Will signal the cleanup thread if the number of end of life entities equals
+    * the number of administered entities, allowing it to proceed with cleanup.
+    * This function should be balanced with an entity being added through
+    * emplace.
+    */
+    void commit();
+
+    /**
+    * Emplacement function.
+    *
+    * Will provisionally add an entity for deferred destruction.
+    * This function should be balanced with either an invocation of commit(), causing
+    * the entity to have its destruction deferred, or erase(), removing the entity
+    * from the deferred destruction.
+    *
+    * @param e The entity to have its destruction deferred
+    *
+    * @return std::list<dds::core::Entity>::iterator The stored entry in the list.
+    */
+    std::list<dds::core::Entity>::iterator emplace(const dds::core::Entity& e);
+
+    /**
+    * Erasure function.
+    *
+    * Will remove the supplied entry from deferred destruction.
+    * Can only be used on iterators received from emplace()
+    *
+    * @param it The entity to remove from the container.
+    */
+    void erase(std::list<dds::core::Entity>::iterator it);
+
+    /**
+    * Instance retrieval/creation function.
+    *
+    * Will check whether an instance already exists in the shared pointer ptr,
+    * if there is not, one is created and assigned to ptr.
+    *
+    * @return DeferredDestruction& The stored singleton instance.
+    */
+    static DeferredDestruction& get_instance();
+
+private:
+    std::list<dds::core::Entity> m_entities;
+    std::mutex access_mutex;
+    static std::mutex creation_mutex;
+    std::thread cleanup_thread;
+    std::condition_variable cv;
+    uint32_t n_committed = 0;
+    bool terminated = false;
+
+    static std::shared_ptr<DeferredDestruction> ptr;
+
+    /**
+    * Constructor.
+    *
+    * Made private due to the class using a singleton type implementation.
+    */
+    DeferredDestruction();
+
+    /**
+    * Background cleanup function.
+    *
+    * The cleanup_thread will run this function on the singleton instance.
+    * Keeps calling expire() as long as terminated is not set to true.
+    */
+    void cleanup();
+
+    /**
+    * Cleanup waiting/worker function.
+    *
+    * Will halt until a notification is received on cv.
+    * If the number of entities in m_entities is equal to the number committed (n_committed),
+    * m_entities is emptied and n_committed is set to 0.
+    */
+    void expire();
+
+    /**
+    * Termination function.
+    *
+    * Will cause the function in cleanup_thread to complete, allowing the object
+    * to be destructed.
+    */
+    void terminate();
+};
+
+}
+}
+}
+}
+
+#endif // __DEFERRED_DESTRUCTION__

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/DeferredDestruction.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/DeferredDestruction.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+
+ /**
+  * @file
+  */
+
+#include <org/eclipse/cyclonedds/core/DeferredDestruction.hpp>
+
+using org::eclipse::cyclonedds::core::DeferredDestruction;
+
+std::shared_ptr<DeferredDestruction>
+  DeferredDestruction::ptr;
+std::mutex
+  DeferredDestruction::creation_mutex;
+
+DeferredDestruction::DeferredDestruction() : cleanup_thread(&DeferredDestruction::cleanup, this)
+{
+
+}
+
+DeferredDestruction::~DeferredDestruction()
+{
+    terminate();
+    cleanup_thread.join();
+}
+
+DeferredDestruction& DeferredDestruction::get_instance()
+{
+    if (!ptr)
+    {
+        std::unique_lock<std::mutex> lk(DeferredDestruction::creation_mutex);
+        ptr = std::shared_ptr<DeferredDestruction>(new DeferredDestruction());
+    }
+    return *ptr;
+}
+
+void DeferredDestruction::cleanup()
+{
+    while (!terminated)
+        expire();
+}
+
+void DeferredDestruction::commit()
+{
+    std::unique_lock<std::mutex> lk(access_mutex);
+    ++n_committed;
+
+    /* signal the cleanup thread that it may empty the list */
+    if (m_entities.size() == n_committed)
+        cv.notify_one();
+}
+
+std::list<dds::core::Entity>::iterator DeferredDestruction::emplace(const dds::core::Entity& e)
+{
+    std::unique_lock<std::mutex> lk(access_mutex);
+    m_entities.emplace(m_entities.end(), e);
+    return (m_entities.end())--;
+}
+
+void DeferredDestruction::erase(std::list<dds::core::Entity>::iterator it)
+{
+    std::unique_lock<std::mutex> lk(access_mutex);
+    m_entities.erase(it);
+}
+
+void DeferredDestruction::expire()
+{
+    std::unique_lock<std::mutex> lk(access_mutex);
+
+    /* wait for the signal to say it is okay to empty the list, while loop is for spurious wakes */
+    while ((n_committed != m_entities.size() || n_committed == 0) && !terminated)
+        cv.wait(lk);
+
+    n_committed = 0;
+    m_entities.clear();
+}
+
+void DeferredDestruction::terminate()
+{
+    std::unique_lock<std::mutex> lk(access_mutex);
+    terminated = true;
+    cv.notify_one();
+}


### PR DESCRIPTION
…ions

Listeners on DataReader classes causing the
org::eclipse::cyclonedds::core::EntityDelegate::prevent_callbacks()
function to assert(false) when all references to it have expired
but there are still callbacks referencing it.
This is done by adding these entities to a deffered destructor class,
which handles the end-of-life of these entities outside the thread
where they have callbacks working on them.

Signed-off-by: Martijn Reicher <martijn.reicher@adlinktech.com>