### PR TITLE
Fix atomic initialization of the sample pointer

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -57,7 +57,7 @@ class ddscxx_serdata : public ddsi_serdata {
   std::unique_ptr<unsigned char[]> m_data{ nullptr };
   ddsi_keyhash_t m_key;
   bool m_key_md5_hashed = false;
-  std::atomic<T *> m_t = nullptr;
+  std::atomic<T *> m_t{ nullptr };
 
 public:
   bool hash_populated = false;


### PR DESCRIPTION
Fixes the initialization of the atomic sample pointer.

Without the direct initialization, we get the following error when compiling the HelloWorld example

```
use of deleted function ‘std::atomic<_Tp*>::atomic(const std::atomic<_Tp*>&) [with _Tp = HelloWorldData::Msg]’
   : ddsi_serdata{}
                  ^
```
