### PR TITLE
Fix for cyclonedds-cxx/idlcxx issue #65

### DIFF
--- a/src/idlcxx/src/streamer_generator.c
+++ b/src/idlcxx/src/streamer_generator.c
@@ -227,6 +227,7 @@ struct context
   bool key_max_size_unlimited;
   bool max_size_unlimited;
   const char* parsed_file;
+  int entryalignment;
 };
 
 static void reset_alignment(context_t* ctx, bool is_key);
@@ -524,12 +525,18 @@ void start_array(context_t* ctx, uint64_t entries, bool is_key, bool* locals)
   format_read_stream(1, ctx, is_key, array_iterate, ctx->depth + 1, ctx->depth + 1, entries, ctx->depth + 1);
   format_max_size_intermediate_stream(1, ctx, is_key, array_iterate, ctx->depth + 1, ctx->depth + 1, entries, ctx->depth + 1);
 
+  //set first array entry alignment to -1
+  ctx->entryalignment = -1;
+
   ctx->depth++;
 }
 
 void stop_array(context_t* ctx, bool is_key, bool* locals)
 {
   load_locals(ctx, locals);
+
+  //check alignment between the last entity for this entry in the array and the first entity of the next entry in the array
+  check_alignment(ctx, ctx->entryalignment, is_key);
 
   format_write_size_stream(1, ctx, is_key, close_block);
   format_write_stream(1, ctx, is_key, close_block);
@@ -780,6 +787,13 @@ idl_retcode_t write_instance_funcs(context_t* ctx, const char* write_accessor, c
 idl_retcode_t check_alignment(context_t* ctx, int bytewidth, bool is_key)
 {
   assert(ctx);
+
+  if (bytewidth == -1)
+    return IDL_RETCODE_OK;
+
+  //this happens when the an array or sequence is started, we "lock in" the first entity of each entry
+  if (ctx->entryalignment < 1)
+    ctx->entryalignment = bytewidth;
 
   if (ctx->streamer_funcs.currentalignment == bytewidth &&
       (!is_key ||
@@ -1704,6 +1718,8 @@ idl_retcode_t process_sequence_impl(context_t* ctx, const char* accessor, idl_se
   }
   else
   {
+    ctx->entryalignment = -1;
+
     format_read_stream(1, ctx, is_key, seq_read_resize, accessor, ctx->depth);
 
     //loop over
@@ -1737,6 +1753,9 @@ idl_retcode_t process_sequence_impl(context_t* ctx, const char* accessor, idl_se
       process_typedef_instance_impl(ctx, entryaccess, ispec, is_key);
     }
     free(entryaccess);
+
+    //check alignment between the last entity for this entry in the sequence and the first entity of the next entry in the sequence
+    check_alignment(ctx, ctx->entryalignment, is_key);
 
     //close loop
     format_write_size_stream(1, ctx, is_key, close_block);

--- a/src/idlcxx/tests/CMakeLists.txt
+++ b/src/idlcxx/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(xxd_input
   ${generator_dir}/keys_typedef_header.cpp.in
   ${generator_dir}/keys_union_implicit_impl.cpp.in
   ${generator_dir}/re_alignment_impl.cpp.in
+  ${generator_dir}/re_alignment_2_impl.cpp.in
   ${generator_dir}/sequence_recursive_header.cpp.in
   ${generator_dir}/sequence_recursive_impl.cpp.in
   ${generator_dir}/struct_inheritance_impl.cpp.in

--- a/src/idlcxx/tests/CMakeLists.txt
+++ b/src/idlcxx/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(xxd_input
   ${generator_dir}/keys_union_implicit_impl.cpp.in
   ${generator_dir}/re_alignment_impl.cpp.in
   ${generator_dir}/re_alignment_2_impl.cpp.in
+  ${generator_dir}/re_alignment_3_impl.cpp.in
   ${generator_dir}/sequence_recursive_header.cpp.in
   ${generator_dir}/sequence_recursive_impl.cpp.in
   ${generator_dir}/struct_inheritance_impl.cpp.in

--- a/src/idlcxx/tests/generator/re_alignment_2_impl.cpp.in
+++ b/src/idlcxx/tests/generator/re_alignment_2_impl.cpp.in
@@ -1,0 +1,112 @@
+#include "org/eclipse/cyclonedds/topic/hash.hpp"
+
+size_t s::write_struct(void *data, size_t position) const
+{
+  size_t _al0 = (4 - (position&0x3))&0x3;  //alignment
+  memset(static_cast<char*>(data)+position,0x0,_al0);  //setting alignment bytes to 0x0
+  position += _al0;  //moving position indicator
+  uint32_t _se0 = static_cast<uint32_t>(str().size()+1);  //number of entries in the sequence
+  *reinterpret_cast<uint32_t*>(static_cast<char*>(data) + position) = _se0;  //writing entries for member: str()
+  position += 4;  //moving position indicator
+  memcpy(static_cast<char*>(data)+position,str().data(),_se0*1); //writing bytes for member: str()
+  position += _se0;  //entries of sequence
+  _al0 = (4 - (position&0x3))&0x3;  //alignment
+  memset(static_cast<char*>(data)+position,0x0,_al0);  //setting alignment bytes to 0x0
+  position += _al0;  //moving position indicator
+  *reinterpret_cast<uint32_t*>(static_cast<char*>(data)+position) = u_l_1();  //writing bytes for member: u_l_1()
+  position += 4;  //moving position indicator
+  *reinterpret_cast<uint8_t*>(static_cast<char*>(data)+position) = o();  //writing bytes for member: o()
+  position += 1;  //moving position indicator
+  _al0 = (4 - (position&0x3))&0x3;  //alignment
+  memset(static_cast<char*>(data)+position,0x0,_al0);  //setting alignment bytes to 0x0
+  position += _al0;  //moving position indicator
+  *reinterpret_cast<uint32_t*>(static_cast<char*>(data)+position) = u_l_2();  //writing bytes for member: u_l_2()
+  position += 4;  //moving position indicator
+  return position;
+}
+
+size_t s::write_size(size_t position) const
+{
+  position += (4 - (position&0x3))&0x3;  //alignment
+  uint32_t _se0 = static_cast<uint32_t>(str().size()+1);  //number of entries in the sequence
+  position += 4;  //bytes for sequence entries
+  position += _se0;  //entries of sequence
+  position += (4 - (position&0x3))&0x3;  //alignment
+  position += 4;  //bytes for member: u_l_1()
+  position += 1;  //bytes for member: o()
+  position += (4 - (position&0x3))&0x3;  //alignment
+  position += 4;  //bytes for member: u_l_2()
+  return position;
+}
+
+size_t s::max_size(size_t position) const
+{
+  (void)position;
+  return UINT_MAX;
+}
+
+size_t s::key_size(size_t position) const
+{
+  return position;
+}
+
+size_t s::key_max_size(size_t position) const
+{
+  return position;
+}
+
+size_t s::key_write(void *data, size_t position) const
+{
+  (void)data;
+  return position;
+}
+
+bool s::key(ddsi_keyhash_t &hash) const
+{
+  size_t sz = key_size(0);
+  size_t padding = 16 - sz%16;
+  if (sz != 0 && padding == 16) padding = 0;
+  std::vector<unsigned char> buffer(sz+padding);
+  memset(buffer.data()+sz,0x0,padding);
+  key_write(buffer.data(),0);
+  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;
+  if (fptr == NULL)
+  {
+    if (key_max_size(0) <= 16)
+    {
+      //bind to unmodified function which just copies buffer into the keyhash
+      fptr = &org::eclipse::cyclonedds::topic::simple_key;
+    }
+    else
+    {
+      //bind to MD5 hash function
+      fptr = &org::eclipse::cyclonedds::topic::complex_key;
+    }
+  }
+  return (*fptr)(buffer,hash);
+}
+
+size_t s::key_read(const void *data, size_t position)
+{
+  (void)data;
+  return position;
+}
+
+size_t s::read_struct(const void *data, size_t position)
+{
+  position += (4 - (position&0x3))&0x3;  //alignment
+  uint32_t _se0 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+  position += 4;  //moving position indicator
+  str().assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+_se0-1); //reading bytes for member: str()
+  position += _se0;  //entries of sequence
+  position += (4 - (position&0x3))&0x3;  //alignment
+  u_l_1() = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: u_l_1()
+  position += 4;  //moving position indicator
+  o() = *reinterpret_cast<const uint8_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: o()
+  position += 1;  //moving position indicator
+  position += (4 - (position&0x3))&0x3;  //alignment
+  u_l_2() = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //reading bytes for member: u_l_2()
+  position += 4;  //moving position indicator
+  return position;
+}
+

--- a/src/idlcxx/tests/generator/re_alignment_3_impl.cpp.in
+++ b/src/idlcxx/tests/generator/re_alignment_3_impl.cpp.in
@@ -1,0 +1,146 @@
+#include "org/eclipse/cyclonedds/topic/hash.hpp"
+
+size_t s::write_struct(void *data, size_t position) const
+{
+  for (size_t _i1 = 0; _i1 < 3; _i1++)  {
+    size_t _al1 = (4 - (position&0x3))&0x3;  //alignment
+    memset(static_cast<char*>(data)+position,0x0,_al1);  //setting alignment bytes to 0x0
+    position += _al1;  //moving position indicator
+    uint32_t _se1 = static_cast<uint32_t>(string_arr()[_i1].size()+1);  //number of entries in the sequence
+    *reinterpret_cast<uint32_t*>(static_cast<char*>(data) + position) = _se1;  //writing entries for member: string_arr()[_i1]
+    position += 4;  //moving position indicator
+    memcpy(static_cast<char*>(data)+position,string_arr()[_i1].data(),_se1*1); //writing bytes for member: string_arr()[_i1]
+    position += _se1;  //entries of sequence
+    size_t _al1 = (4 - (position&0x3))&0x3;  //alignment
+    memset(static_cast<char*>(data)+position,0x0,_al1);  //setting alignment bytes to 0x0
+    position += _al1;  //moving position indicator
+  }
+  uint32_t _se0 = static_cast<uint32_t>(string_seq().size());  //number of entries in the sequence
+  *reinterpret_cast<uint32_t*>(static_cast<char*>(data) + position) = _se0;  //writing entries for member: string_seq()
+  position += 4;  //moving position indicator
+  for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    uint32_t _se1 = static_cast<uint32_t>(string_seq()[_i1].size()+1);  //number of entries in the sequence
+    *reinterpret_cast<uint32_t*>(static_cast<char*>(data) + position) = _se1;  //writing entries for member: string_seq()[_i1]
+    position += 4;  //moving position indicator
+    memcpy(static_cast<char*>(data)+position,string_seq()[_i1].data(),_se1*1); //writing bytes for member: string_seq()[_i1]
+    position += _se1;  //entries of sequence
+    size_t _al1 = (4 - (position&0x3))&0x3;  //alignment
+    memset(static_cast<char*>(data)+position,0x0,_al1);  //setting alignment bytes to 0x0
+    position += _al1;  //moving position indicator
+  }
+  _al0 = (4 - (position&0x3))&0x3;  //alignment
+  memset(static_cast<char*>(data)+position,0x0,_al0);  //setting alignment bytes to 0x0
+  position += _al0;  //moving position indicator
+  _se0 = static_cast<uint32_t>(long_seq().size());  //number of entries in the sequence
+  *reinterpret_cast<uint32_t*>(static_cast<char*>(data) + position) = _se0;  //writing entries for member: long_seq()
+  position += 4;  //moving position indicator
+  if (0 < long_seq().size()) memcpy(static_cast<char*>(data)+position,long_seq().data(),_se0*4); //writing bytes for member: long_seq()
+  position += _se0*4;  //entries of sequence
+  return position;
+}
+
+size_t s::write_size(size_t position) const
+{
+  for (size_t _i1 = 0; _i1 < 3; _i1++)  {
+    position += (4 - (position&0x3))&0x3;  //alignment
+    uint32_t _se1 = static_cast<uint32_t>(string_arr()[_i1].size()+1);  //number of entries in the sequence
+    position += 4;  //bytes for sequence entries
+    position += _se1;  //entries of sequence
+    position += (4 - (position&0x3))&0x3;  //alignment
+  }
+  uint32_t _se0 = static_cast<uint32_t>(string_seq().size());  //number of entries in the sequence
+  position += 4;  //bytes for sequence entries
+  for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    uint32_t _se1 = static_cast<uint32_t>(string_seq()[_i1].size()+1);  //number of entries in the sequence
+    position += 4;  //bytes for sequence entries
+    position += _se1;  //entries of sequence
+    position += (4 - (position&0x3))&0x3;  //alignment
+  }
+  position += (4 - (position&0x3))&0x3;  //alignment
+  _se0 = static_cast<uint32_t>(long_seq().size());  //number of entries in the sequence
+  position += 4;  //bytes for sequence entries
+  position += _se0*4;  //entries of sequence
+  return position;
+}
+
+size_t s::max_size(size_t position) const
+{
+  (void)position;
+  return UINT_MAX;
+}
+
+size_t s::key_size(size_t position) const
+{
+  return position;
+}
+
+size_t s::key_max_size(size_t position) const
+{
+  return position;
+}
+
+size_t s::key_write(void *data, size_t position) const
+{
+  (void)data;
+  return position;
+}
+
+bool s::key(ddsi_keyhash_t &hash) const
+{
+  size_t sz = key_size(0);
+  size_t padding = 16 - sz%16;
+  if (sz != 0 && padding == 16) padding = 0;
+  std::vector<unsigned char> buffer(sz+padding);
+  memset(buffer.data()+sz,0x0,padding);
+  key_write(buffer.data(),0);
+  static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t &) = NULL;
+  if (fptr == NULL)
+  {
+    if (key_max_size(0) <= 16)
+    {
+      //bind to unmodified function which just copies buffer into the keyhash
+      fptr = &org::eclipse::cyclonedds::topic::simple_key;
+    }
+    else
+    {
+      //bind to MD5 hash function
+      fptr = &org::eclipse::cyclonedds::topic::complex_key;
+    }
+  }
+  return (*fptr)(buffer,hash);
+}
+
+size_t s::key_read(const void *data, size_t position)
+{
+  (void)data;
+  return position;
+}
+
+size_t s::read_struct(const void *data, size_t position)
+{
+  for (size_t _i1 = 0; _i1 < 3; _i1++)  {
+    position += (4 - (position&0x3))&0x3;  //alignment
+    uint32_t _se1 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+    position += 4;  //moving position indicator
+    string_arr()[_i1].assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+_se1-1); //reading bytes for member: string_arr()[_i1]
+    position += _se1;  //entries of sequence
+    position += (4 - (position&0x3))&0x3;  //alignment
+  }
+  uint32_t _se0 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+  position += 4;  //moving position indicator
+  string_seq().resize(_se0);
+  for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    uint32_t _se1 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+    position += 4;  //moving position indicator
+    string_seq()[_i1].assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+_se1-1); //reading bytes for member: string_seq()[_i1]
+    position += _se1;  //entries of sequence
+    position += (4 - (position&0x3))&0x3;  //alignment
+  }
+  position += (4 - (position&0x3))&0x3;  //alignment
+  _se0 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
+  position += 4;  //moving position indicator
+  long_seq().assign(reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position),reinterpret_cast<const int32_t*>(static_cast<const char*>(data)+position)+_se0); //reading bytes for member: long_seq()
+  position += _se0*4;  //entries of sequence
+  return position;
+}
+

--- a/src/idlcxx/tests/generator/re_alignment_3_impl.cpp.in
+++ b/src/idlcxx/tests/generator/re_alignment_3_impl.cpp.in
@@ -11,22 +11,22 @@ size_t s::write_struct(void *data, size_t position) const
     position += 4;  //moving position indicator
     memcpy(static_cast<char*>(data)+position,string_arr()[_i1].data(),_se1*1); //writing bytes for member: string_arr()[_i1]
     position += _se1;  //entries of sequence
-    size_t _al1 = (4 - (position&0x3))&0x3;  //alignment
-    memset(static_cast<char*>(data)+position,0x0,_al1);  //setting alignment bytes to 0x0
-    position += _al1;  //moving position indicator
   }
+  size_t _al0 = (4 - (position&0x3))&0x3;  //alignment
+  memset(static_cast<char*>(data)+position,0x0,_al0);  //setting alignment bytes to 0x0
+  position += _al0;  //moving position indicator
   uint32_t _se0 = static_cast<uint32_t>(string_seq().size());  //number of entries in the sequence
   *reinterpret_cast<uint32_t*>(static_cast<char*>(data) + position) = _se0;  //writing entries for member: string_seq()
   position += 4;  //moving position indicator
   for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    size_t _al1 = (4 - (position&0x3))&0x3;  //alignment
+    memset(static_cast<char*>(data)+position,0x0,_al1);  //setting alignment bytes to 0x0
+    position += _al1;  //moving position indicator
     uint32_t _se1 = static_cast<uint32_t>(string_seq()[_i1].size()+1);  //number of entries in the sequence
     *reinterpret_cast<uint32_t*>(static_cast<char*>(data) + position) = _se1;  //writing entries for member: string_seq()[_i1]
     position += 4;  //moving position indicator
     memcpy(static_cast<char*>(data)+position,string_seq()[_i1].data(),_se1*1); //writing bytes for member: string_seq()[_i1]
     position += _se1;  //entries of sequence
-    size_t _al1 = (4 - (position&0x3))&0x3;  //alignment
-    memset(static_cast<char*>(data)+position,0x0,_al1);  //setting alignment bytes to 0x0
-    position += _al1;  //moving position indicator
   }
   _al0 = (4 - (position&0x3))&0x3;  //alignment
   memset(static_cast<char*>(data)+position,0x0,_al0);  //setting alignment bytes to 0x0
@@ -46,15 +46,15 @@ size_t s::write_size(size_t position) const
     uint32_t _se1 = static_cast<uint32_t>(string_arr()[_i1].size()+1);  //number of entries in the sequence
     position += 4;  //bytes for sequence entries
     position += _se1;  //entries of sequence
-    position += (4 - (position&0x3))&0x3;  //alignment
   }
+  position += (4 - (position&0x3))&0x3;  //alignment
   uint32_t _se0 = static_cast<uint32_t>(string_seq().size());  //number of entries in the sequence
   position += 4;  //bytes for sequence entries
   for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    position += (4 - (position&0x3))&0x3;  //alignment
     uint32_t _se1 = static_cast<uint32_t>(string_seq()[_i1].size()+1);  //number of entries in the sequence
     position += 4;  //bytes for sequence entries
     position += _se1;  //entries of sequence
-    position += (4 - (position&0x3))&0x3;  //alignment
   }
   position += (4 - (position&0x3))&0x3;  //alignment
   _se0 = static_cast<uint32_t>(long_seq().size());  //number of entries in the sequence
@@ -124,17 +124,17 @@ size_t s::read_struct(const void *data, size_t position)
     position += 4;  //moving position indicator
     string_arr()[_i1].assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+_se1-1); //reading bytes for member: string_arr()[_i1]
     position += _se1;  //entries of sequence
-    position += (4 - (position&0x3))&0x3;  //alignment
   }
+  position += (4 - (position&0x3))&0x3;  //alignment
   uint32_t _se0 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
   position += 4;  //moving position indicator
   string_seq().resize(_se0);
   for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    position += (4 - (position&0x3))&0x3;  //alignment
     uint32_t _se1 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
     position += 4;  //moving position indicator
     string_seq()[_i1].assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+_se1-1); //reading bytes for member: string_seq()[_i1]
     position += _se1;  //entries of sequence
-    position += (4 - (position&0x3))&0x3;  //alignment
   }
   position += (4 - (position&0x3))&0x3;  //alignment
   _se0 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence

--- a/src/idlcxx/tests/generator/sequence_recursive_impl.cpp.in
+++ b/src/idlcxx/tests/generator/sequence_recursive_impl.cpp.in
@@ -9,30 +9,30 @@ size_t typedef_write_recseq(const recseq &obj, void* data, size_t position)
   *reinterpret_cast<uint32_t*>(static_cast<char*>(data) + position) = _se0;  //writing entries for member: obj
   position += 4;  //moving position indicator
   for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    size_t _al1 = (4 - (position&0x3))&0x3;  //alignment
+    memset(static_cast<char*>(data)+position,0x0,_al1);  //setting alignment bytes to 0x0
+    position += _al1;  //moving position indicator
     uint32_t _se1 = static_cast<uint32_t>(obj[_i1].size());  //number of entries in the sequence
     *reinterpret_cast<uint32_t*>(static_cast<char*>(data) + position) = _se1;  //writing entries for member: obj[_i1]
     position += 4;  //moving position indicator
     for (size_t _i2 = 0; _i2 < _se1; _i2++) {
+      size_t _al2 = (4 - (position&0x3))&0x3;  //alignment
+      memset(static_cast<char*>(data)+position,0x0,_al2);  //setting alignment bytes to 0x0
+      position += _al2;  //moving position indicator
       uint32_t _se2 = static_cast<uint32_t>(obj[_i1][_i2].size());  //number of entries in the sequence
       *reinterpret_cast<uint32_t*>(static_cast<char*>(data) + position) = _se2;  //writing entries for member: obj[_i1][_i2]
       position += 4;  //moving position indicator
       for (size_t _i3 = 0; _i3 < _se2; _i3++) {
+        size_t _al3 = (4 - (position&0x3))&0x3;  //alignment
+        memset(static_cast<char*>(data)+position,0x0,_al3);  //setting alignment bytes to 0x0
+        position += _al3;  //moving position indicator
         uint32_t _se3 = static_cast<uint32_t>(obj[_i1][_i2][_i3].size()+1);  //number of entries in the sequence
         *reinterpret_cast<uint32_t*>(static_cast<char*>(data) + position) = _se3;  //writing entries for member: obj[_i1][_i2][_i3]
         position += 4;  //moving position indicator
         memcpy(static_cast<char*>(data)+position,obj[_i1][_i2][_i3].data(),_se3*1); //writing bytes for member: obj[_i1][_i2][_i3]
         position += _se3;  //entries of sequence
-        size_t _al3 = (4 - (position&0x3))&0x3;  //alignment
-        memset(static_cast<char*>(data)+position,0x0,_al3);  //setting alignment bytes to 0x0
-        position += _al3;  //moving position indicator
       }
-      size_t _al2 = (4 - (position&0x3))&0x3;  //alignment
-      memset(static_cast<char*>(data)+position,0x0,_al2);  //setting alignment bytes to 0x0
-      position += _al2;  //moving position indicator
     }
-    size_t _al1 = (4 - (position&0x3))&0x3;  //alignment
-    memset(static_cast<char*>(data)+position,0x0,_al1);  //setting alignment bytes to 0x0
-    position += _al1;  //moving position indicator
   }
   return position;
 }
@@ -43,20 +43,20 @@ size_t typedef_write_size_recseq(const recseq &obj, size_t position)
   uint32_t _se0 = static_cast<uint32_t>(obj.size());  //number of entries in the sequence
   position += 4;  //bytes for sequence entries
   for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    position += (4 - (position&0x3))&0x3;  //alignment
     uint32_t _se1 = static_cast<uint32_t>(obj[_i1].size());  //number of entries in the sequence
     position += 4;  //bytes for sequence entries
     for (size_t _i2 = 0; _i2 < _se1; _i2++) {
+      position += (4 - (position&0x3))&0x3;  //alignment
       uint32_t _se2 = static_cast<uint32_t>(obj[_i1][_i2].size());  //number of entries in the sequence
       position += 4;  //bytes for sequence entries
       for (size_t _i3 = 0; _i3 < _se2; _i3++) {
+        position += (4 - (position&0x3))&0x3;  //alignment
         uint32_t _se3 = static_cast<uint32_t>(obj[_i1][_i2][_i3].size()+1);  //number of entries in the sequence
         position += 4;  //bytes for sequence entries
         position += _se3;  //entries of sequence
-        position += (4 - (position&0x3))&0x3;  //alignment
       }
-      position += (4 - (position&0x3))&0x3;  //alignment
     }
-    position += (4 - (position&0x3))&0x3;  //alignment
   }
   return position;
 }
@@ -74,20 +74,20 @@ size_t typedef_key_size_recseq(const recseq &obj, size_t position)
   uint32_t _se0 = static_cast<uint32_t>(obj.size());  //number of entries in the sequence
   position += 4;  //bytes for sequence entries
   for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    position += (4 - (position&0x3))&0x3;  //alignment
     uint32_t _se1 = static_cast<uint32_t>(obj[_i1].size());  //number of entries in the sequence
     position += 4;  //bytes for sequence entries
     for (size_t _i2 = 0; _i2 < _se1; _i2++) {
+      position += (4 - (position&0x3))&0x3;  //alignment
       uint32_t _se2 = static_cast<uint32_t>(obj[_i1][_i2].size());  //number of entries in the sequence
       position += 4;  //bytes for sequence entries
       for (size_t _i3 = 0; _i3 < _se2; _i3++) {
+        position += (4 - (position&0x3))&0x3;  //alignment
         uint32_t _se3 = static_cast<uint32_t>(obj[_i1][_i2][_i3].size()+1);  //number of entries in the sequence
         position += 4;  //bytes for sequence entries
         position += _se3;  //entries of sequence
-        position += (4 - (position&0x3))&0x3;  //alignment
       }
-      position += (4 - (position&0x3))&0x3;  //alignment
     }
-    position += (4 - (position&0x3))&0x3;  //alignment
   }
   return position;
 }
@@ -108,30 +108,30 @@ size_t typedef_key_write_recseq(const recseq &obj, void *data, size_t position)
   *reinterpret_cast<uint32_t*>(static_cast<char*>(data) + position) = _se0;  //writing entries for member: obj
   position += 4;  //moving position indicator
   for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    size_t _al1 = (4 - (position&0x3))&0x3;  //alignment
+    memset(static_cast<char*>(data)+position,0x0,_al1);  //setting alignment bytes to 0x0
+    position += _al1;  //moving position indicator
     uint32_t _se1 = static_cast<uint32_t>(obj[_i1].size());  //number of entries in the sequence
     *reinterpret_cast<uint32_t*>(static_cast<char*>(data) + position) = _se1;  //writing entries for member: obj[_i1]
     position += 4;  //moving position indicator
     for (size_t _i2 = 0; _i2 < _se1; _i2++) {
+      size_t _al2 = (4 - (position&0x3))&0x3;  //alignment
+      memset(static_cast<char*>(data)+position,0x0,_al2);  //setting alignment bytes to 0x0
+      position += _al2;  //moving position indicator
       uint32_t _se2 = static_cast<uint32_t>(obj[_i1][_i2].size());  //number of entries in the sequence
       *reinterpret_cast<uint32_t*>(static_cast<char*>(data) + position) = _se2;  //writing entries for member: obj[_i1][_i2]
       position += 4;  //moving position indicator
       for (size_t _i3 = 0; _i3 < _se2; _i3++) {
+        size_t _al3 = (4 - (position&0x3))&0x3;  //alignment
+        memset(static_cast<char*>(data)+position,0x0,_al3);  //setting alignment bytes to 0x0
+        position += _al3;  //moving position indicator
         uint32_t _se3 = static_cast<uint32_t>(obj[_i1][_i2][_i3].size()+1);  //number of entries in the sequence
         *reinterpret_cast<uint32_t*>(static_cast<char*>(data) + position) = _se3;  //writing entries for member: obj[_i1][_i2][_i3]
         position += 4;  //moving position indicator
         memcpy(static_cast<char*>(data)+position,obj[_i1][_i2][_i3].data(),_se3*1); //writing bytes for member: obj[_i1][_i2][_i3]
         position += _se3;  //entries of sequence
-        size_t _al3 = (4 - (position&0x3))&0x3;  //alignment
-        memset(static_cast<char*>(data)+position,0x0,_al3);  //setting alignment bytes to 0x0
-        position += _al3;  //moving position indicator
       }
-      size_t _al2 = (4 - (position&0x3))&0x3;  //alignment
-      memset(static_cast<char*>(data)+position,0x0,_al2);  //setting alignment bytes to 0x0
-      position += _al2;  //moving position indicator
     }
-    size_t _al1 = (4 - (position&0x3))&0x3;  //alignment
-    memset(static_cast<char*>(data)+position,0x0,_al1);  //setting alignment bytes to 0x0
-    position += _al1;  //moving position indicator
   }
   return position;
 }
@@ -143,23 +143,23 @@ size_t typedef_key_read_recseq(recseq &obj, const void *data, size_t position)
   position += 4;  //moving position indicator
   obj.resize(_se0);
   for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    position += (4 - (position&0x3))&0x3;  //alignment
     uint32_t _se1 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
     position += 4;  //moving position indicator
     obj[_i1].resize(_se1);
     for (size_t _i2 = 0; _i2 < _se1; _i2++) {
+      position += (4 - (position&0x3))&0x3;  //alignment
       uint32_t _se2 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
       position += 4;  //moving position indicator
       obj[_i1][_i2].resize(_se2);
       for (size_t _i3 = 0; _i3 < _se2; _i3++) {
+        position += (4 - (position&0x3))&0x3;  //alignment
         uint32_t _se3 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
         position += 4;  //moving position indicator
         obj[_i1][_i2][_i3].assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+_se3-1); //reading bytes for member: obj[_i1][_i2][_i3]
         position += _se3;  //entries of sequence
-        position += (4 - (position&0x3))&0x3;  //alignment
       }
-      position += (4 - (position&0x3))&0x3;  //alignment
     }
-    position += (4 - (position&0x3))&0x3;  //alignment
   }
   return position;
 }
@@ -171,23 +171,23 @@ size_t typedef_read_recseq(recseq &obj, const void* data, size_t position)
   position += 4;  //moving position indicator
   obj.resize(_se0);
   for (size_t _i1 = 0; _i1 < _se0; _i1++) {
+    position += (4 - (position&0x3))&0x3;  //alignment
     uint32_t _se1 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
     position += 4;  //moving position indicator
     obj[_i1].resize(_se1);
     for (size_t _i2 = 0; _i2 < _se1; _i2++) {
+      position += (4 - (position&0x3))&0x3;  //alignment
       uint32_t _se2 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
       position += 4;  //moving position indicator
       obj[_i1][_i2].resize(_se2);
       for (size_t _i3 = 0; _i3 < _se2; _i3++) {
+        position += (4 - (position&0x3))&0x3;  //alignment
         uint32_t _se3 = *reinterpret_cast<const uint32_t*>(static_cast<const char*>(data)+position);  //number of entries in the sequence
         position += 4;  //moving position indicator
         obj[_i1][_i2][_i3].assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+_se3-1); //reading bytes for member: obj[_i1][_i2][_i3]
         position += _se3;  //entries of sequence
-        position += (4 - (position&0x3))&0x3;  //alignment
       }
-      position += (4 - (position&0x3))&0x3;  //alignment
     }
-    position += (4 - (position&0x3))&0x3;  //alignment
   }
   return position;
 }

--- a/src/idlcxx/tests/generator/sequence_recursive_impl.cpp.in
+++ b/src/idlcxx/tests/generator/sequence_recursive_impl.cpp.in
@@ -22,8 +22,17 @@ size_t typedef_write_recseq(const recseq &obj, void* data, size_t position)
         position += 4;  //moving position indicator
         memcpy(static_cast<char*>(data)+position,obj[_i1][_i2][_i3].data(),_se3*1); //writing bytes for member: obj[_i1][_i2][_i3]
         position += _se3;  //entries of sequence
+        size_t _al3 = (4 - (position&0x3))&0x3;  //alignment
+        memset(static_cast<char*>(data)+position,0x0,_al3);  //setting alignment bytes to 0x0
+        position += _al3;  //moving position indicator
       }
+      size_t _al2 = (4 - (position&0x3))&0x3;  //alignment
+      memset(static_cast<char*>(data)+position,0x0,_al2);  //setting alignment bytes to 0x0
+      position += _al2;  //moving position indicator
     }
+    size_t _al1 = (4 - (position&0x3))&0x3;  //alignment
+    memset(static_cast<char*>(data)+position,0x0,_al1);  //setting alignment bytes to 0x0
+    position += _al1;  //moving position indicator
   }
   return position;
 }
@@ -43,8 +52,11 @@ size_t typedef_write_size_recseq(const recseq &obj, size_t position)
         uint32_t _se3 = static_cast<uint32_t>(obj[_i1][_i2][_i3].size()+1);  //number of entries in the sequence
         position += 4;  //bytes for sequence entries
         position += _se3;  //entries of sequence
+        position += (4 - (position&0x3))&0x3;  //alignment
       }
+      position += (4 - (position&0x3))&0x3;  //alignment
     }
+    position += (4 - (position&0x3))&0x3;  //alignment
   }
   return position;
 }
@@ -71,8 +83,11 @@ size_t typedef_key_size_recseq(const recseq &obj, size_t position)
         uint32_t _se3 = static_cast<uint32_t>(obj[_i1][_i2][_i3].size()+1);  //number of entries in the sequence
         position += 4;  //bytes for sequence entries
         position += _se3;  //entries of sequence
+        position += (4 - (position&0x3))&0x3;  //alignment
       }
+      position += (4 - (position&0x3))&0x3;  //alignment
     }
+    position += (4 - (position&0x3))&0x3;  //alignment
   }
   return position;
 }
@@ -106,8 +121,17 @@ size_t typedef_key_write_recseq(const recseq &obj, void *data, size_t position)
         position += 4;  //moving position indicator
         memcpy(static_cast<char*>(data)+position,obj[_i1][_i2][_i3].data(),_se3*1); //writing bytes for member: obj[_i1][_i2][_i3]
         position += _se3;  //entries of sequence
+        size_t _al3 = (4 - (position&0x3))&0x3;  //alignment
+        memset(static_cast<char*>(data)+position,0x0,_al3);  //setting alignment bytes to 0x0
+        position += _al3;  //moving position indicator
       }
+      size_t _al2 = (4 - (position&0x3))&0x3;  //alignment
+      memset(static_cast<char*>(data)+position,0x0,_al2);  //setting alignment bytes to 0x0
+      position += _al2;  //moving position indicator
     }
+    size_t _al1 = (4 - (position&0x3))&0x3;  //alignment
+    memset(static_cast<char*>(data)+position,0x0,_al1);  //setting alignment bytes to 0x0
+    position += _al1;  //moving position indicator
   }
   return position;
 }
@@ -131,8 +155,11 @@ size_t typedef_key_read_recseq(recseq &obj, const void *data, size_t position)
         position += 4;  //moving position indicator
         obj[_i1][_i2][_i3].assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+_se3-1); //reading bytes for member: obj[_i1][_i2][_i3]
         position += _se3;  //entries of sequence
+        position += (4 - (position&0x3))&0x3;  //alignment
       }
+      position += (4 - (position&0x3))&0x3;  //alignment
     }
+    position += (4 - (position&0x3))&0x3;  //alignment
   }
   return position;
 }
@@ -156,8 +183,11 @@ size_t typedef_read_recseq(recseq &obj, const void* data, size_t position)
         position += 4;  //moving position indicator
         obj[_i1][_i2][_i3].assign(static_cast<const char*>(data)+position,static_cast<const char*>(data)+position+_se3-1); //reading bytes for member: obj[_i1][_i2][_i3]
         position += _se3;  //entries of sequence
+        position += (4 - (position&0x3))&0x3;  //alignment
       }
+      position += (4 - (position&0x3))&0x3;  //alignment
     }
+    position += (4 - (position&0x3))&0x3;  //alignment
   }
   return position;
 }

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -31,6 +31,7 @@ extern const unsigned char typedef_resolution_header_cpp_in[];
 extern const unsigned char typedef_resolution_impl_cpp_in[];
 extern const unsigned char re_alignment_impl_cpp_in[];
 extern const unsigned char re_alignment_2_impl_cpp_in[];
+extern const unsigned char re_alignment_3_impl_cpp_in[];
 
 #include "idlcxx/streamer_generator.h"
 #include "idl/processor.h"
@@ -1871,6 +1872,28 @@ void test_re_alignment_2()
   idl_delete_tree(tree);
 }
 
+void test_re_alignment_3()
+{
+  const char* str =
+    "struct s {\n"\
+    "string string_arr[3];  //expect re-alignment between sequence entries\n"\
+    "sequence<string> string_seq;  //expect re-alignment between sequence entries\n"\
+    "sequence<long> long_seq;  //do not expect re-alignment between sequence entries\n"\
+    "};\n";
+
+  idl_tree_t* tree = NULL;
+  idl_parse_string(str, IDL_FLAG_ANNOTATIONS, &tree);
+
+  idl_streamer_output_t* generated = create_idl_streamer_output();
+  idl_streamers_generate(tree, generated);
+
+  CU_ASSERT_STRING_EQUAL(re_alignment_3_impl_cpp_in, get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+  CU_ASSERT_STRING_EQUAL("", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
+
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
+}
+
 CU_Test(streamer_generator, base_types_namespace_absent)
 {
   for (size_t i = 0; i < sizeof(cxx_width) / sizeof(size_t); i++)
@@ -2023,4 +2046,9 @@ CU_Test(streamer_generator, re_alignment)
 CU_Test(streamer_generator, re_alignment_2)
 {
   test_re_alignment_2();
+}
+
+CU_Test(streamer_generator, re_alignment_3)
+{
+  test_re_alignment_3();
 }

--- a/src/idlcxx/tests/streamer_generator.c
+++ b/src/idlcxx/tests/streamer_generator.c
@@ -30,6 +30,7 @@ extern const unsigned char struct_inheritance_impl_cpp_in[];
 extern const unsigned char typedef_resolution_header_cpp_in[];
 extern const unsigned char typedef_resolution_impl_cpp_in[];
 extern const unsigned char re_alignment_impl_cpp_in[];
+extern const unsigned char re_alignment_2_impl_cpp_in[];
 
 #include "idlcxx/streamer_generator.h"
 #include "idl/processor.h"
@@ -1847,6 +1848,29 @@ void test_re_alignment()
   idl_delete_tree(tree);
 }
 
+void test_re_alignment_2()
+{
+  const char* str =
+    "struct s {\n"\
+    "string str; \n"\
+    "unsigned long u_l_1;\n"\
+    "octet o; \n"\
+    "unsigned long u_l_2;\n"\
+    "};\n";
+
+  idl_tree_t* tree = NULL;
+  idl_parse_string(str, IDL_FLAG_ANNOTATIONS, &tree);
+
+  idl_streamer_output_t* generated = create_idl_streamer_output();
+  idl_streamers_generate(tree, generated);
+
+  CU_ASSERT_STRING_EQUAL(re_alignment_2_impl_cpp_in, get_ostream_buffer(get_idl_streamer_impl_buf(generated)));
+  CU_ASSERT_STRING_EQUAL("", get_ostream_buffer(get_idl_streamer_head_buf(generated)));
+
+  destruct_idl_streamer_output(generated);
+  idl_delete_tree(tree);
+}
+
 CU_Test(streamer_generator, base_types_namespace_absent)
 {
   for (size_t i = 0; i < sizeof(cxx_width) / sizeof(size_t); i++)
@@ -1994,4 +2018,9 @@ CU_Test(streamer_generator, sequence_recursive)
 CU_Test(streamer_generator, re_alignment)
 {
   test_re_alignment();
+}
+
+CU_Test(streamer_generator, re_alignment_2)
+{
+  test_re_alignment_2();
 }


### PR DESCRIPTION
Removed "unknown" alignment state of -1 bytes, the "unknown"
alignment state is now 1 bytes
Re-alignment calculation+padding is now always done when the
alignment size increases, the new alignment is always set
Removed accumulated alignment calculation, since its gains
did not outweigh the increase in complexity

Signed-off-by: Martijn Reicher <martijn.reicher@adlinktech.com>