### PR TITLE
Add support for Azure Pipelines and fix static analyzer warnings

### DIFF
--- a/.azure/codecov.yml
+++ b/.azure/codecov.yml
@@ -1,0 +1,79 @@
+#
+# Copyright(c) 2021 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+#
+# Azure Pipeline specifically for building and submitting to Codecov
+#
+
+trigger: none
+pr: none
+
+schedules:
+  - cron: "0 12 * * 0"
+    branches:
+      include: [ master ]
+    always: false
+
+strategy:
+  matrix:
+    'Ubuntu 20.04 LTS with GCC 10 (Debug, x86_64)':
+      image: ubuntu-20.04
+      cc: gcc-10
+      cxx: g++-10
+      coverage: on
+
+pool:
+  vmImage: $(image)
+
+steps:
+  - template: /.azure/templates/build-test.yml
+  - bash: |
+      set -e -x
+      cd build
+      slug=$(echo "${BUILD_REPOSITORY_URI}" | sed -nE 's#.*/([^/]+/[^\]+)#\1#p')
+      commit="${BUILD_SOURCEVERSION}"
+      if [ -n "$pr" ] && [ "$pr" != false ]; then
+        mc=$(git show --no-patch --format="%P" 2>/dev/null || echo "")
+        if [[ "$mc" =~ ^[a-z0-9]{40}[[:space:]][a-z0-9]{40}$ ]]; then
+          mc=$(echo "$mc" | cut -d ' ' -f2)
+          commit=$mc
+        fi
+      fi
+      query=$(curl -Gso /dev/null -w "%{url_effective}" "" \
+        --data-urlencode "package=cmake-codecov.io" \
+        --data-urlencode "token=${token}" \
+        --data-urlencode "branch=${BUILD_SOURCEBRANCH#/refs/heads/}" \
+        --data-urlencode "commit=${commit}" \
+        --data-urlencode "build=${BUILD_BUILDNUMBER}" \
+        --data-urlencode "build_url=${SYSTEM_TEAMFOUNDATIONSERVERURI}${SYSTEM_TEAMPROJECT}/_build/results?buildId=${BUILD_BUILDID}" \
+        --data-urlencode "tag=" \
+        --data-urlencode "slug=${slug}" \
+        --data-urlencode "service=azure_pipelines" \
+        --data-urlencode "flags=" \
+        --data-urlencode "pr=${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-$SYSTEM_PULLREQUEST_PULLREQUESTID}" \
+        --data-urlencode "job=${BUILD_BUILDID}" \
+        --data-urlencode "project=${SYSTEM_TEAMPROJECT}" \
+        --data-urlencode "server_uri=${SYSTEM_TEAMFOUNDATIONSERVERURI}" \
+        2>/dev/null | cut -c 3- | sed -e 's/%0A//')
+      cmake --build . --target codecov
+      code=$(curl -X POST -w "%{http_code}" \
+        --data-binary @"codecov.tar.gz" \
+        --retry 5 --retry-delay 2 --connect-timeout 2 \
+        -H 'Content-Type: text/plain' \
+        -H 'Content-Encoding: gzip' \
+        -H 'X-Content-Encoding: gzip' \
+        -H 'Accept: text/plain' \
+        "https://codecov.io/upload/v2?$query")
+      [[ "${code}" =~ "success" ]] || (echo "cURL exited with ${code}" 1>&2 && exit 1)
+    name: submit_to_codecov
+    env:
+      token: $(CODECOV_TOKEN)

--- a/.azure/coverity-scan.yml
+++ b/.azure/coverity-scan.yml
@@ -1,0 +1,103 @@
+#
+# Copyright(c) 2021 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+#
+# Azure Pipeline specifically for building and submitting to Coverity Scan
+#
+
+trigger: none
+pr: none
+
+schedules:
+  - cron: "0 12 * * 0"
+    branches:
+      include: [ master ]
+    always: false
+
+strategy:
+  matrix:
+    'Ubuntu 20.04 LTS with GCC 10 (Debug, x86_64)':
+      image: ubuntu-20.04
+      cc: gcc-10
+      cxx: g++-10
+
+pool:
+  vmImage: $(image)
+
+steps:
+  ## Fetch version number to ensure up-to-date cache
+  - bash: |
+      set -e
+      slug=$(echo "${BUILD_REPOSITORY_URI}" | sed -nE 's#.*/([^/]+/[^\]+)#\1#p')
+      headers=$(basename $(mktemp "$(pwd)/curl.XXXXXXXX"))
+      code=$(curl -X HEAD -s -S -F project="${slug}" \
+                                -F token="${token}" \
+                                -o /dev/null -D ${headers} -w '%{http_code}' \
+                                "https://scan.coverity.com/download/cxx/linux64")
+      [ "${code}" != "200" ] && echo "cURL exited with ${code}" 1>&2 && exit 1
+      file=$(sed -n -E 's/.*filename="([^"]+)".*/\1/p' ${headers})
+      echo "###vso[task.setvariable variable=cov_archive;]${file}"
+      echo "###vso[task.setvariable variable=cov_analysis;]$(pwd)/cov-analysis"
+      echo "###vso[task.setvariable variable=PATH;]$(pwd)/cov-analysis/bin:${PATH}"
+      rm -f ${headers}
+    name: setup_coverity
+    env:
+      token: $(COVERITY_SCAN_TOKEN)
+  - task: Cache@2
+    inputs:
+      key: coverity | 1 | "$(cov_archive)"
+      path: $(cov_analysis)
+      cacheHitVar: coverity_cached
+    name: cache_coverity
+  ## Download Coverity on cache miss
+  - bash: |
+      set -e
+      slug=$(echo "${BUILD_REPOSITORY_URI}" | sed -nE 's#.*/([^/]+/[^\]+)#\1#p')
+      headers=$(basename $(mktemp "$(pwd)/tmp.XXXXXXXX"))
+      code=$(curl -s -S -F project="${slug}" \
+                        -F token="${token}" \
+                        -O -J -D ${headers} -w '%{http_code}' \
+                        "https://scan.coverity.com/download/cxx/linux64")
+      [ "${code}" != "200" ] && echo "cURL exited with ${code}" 1>&2 && exit 1
+      file=$(sed -n -E 's/^.*filename="([^"]+)".*$/\1/p' ${headers})
+      tar -xzf ${file} -C .
+      dir=$(find . -type d -name "cov-analysis*" | head -1)
+      mv "${dir}" "${COV_ANALYSIS}"
+      rm -f ${headers} "${file}"
+    name: install_coverity
+    condition: ne(variables['coverity_cached'], 'true')
+    env:
+      token: $(COVERITY_SCAN_TOKEN)
+  - bash: |
+      set -e -x
+      echo "###vso[task.setvariable variable=scan_build;]cov-build --dir $(pwd)/cov-int"
+      cov-configure --template --compiler ${CC} --comptype gcc
+    name: configure_coverity
+  - template: /.azure/templates/build-test.yml
+  ## Submit to Coverity Scan
+  - bash: |
+      set -e -x
+      slug=$(echo "${BUILD_REPOSITORY_URI}" | sed -nE 's#.*/([^/]+/[^\]+)#\1#p')
+      tar -czf analysis-results.tgz cov-int
+      code=$(curl -s -S -F project="${slug}" \
+                        -F token="${token}" \
+                        -F file=@analysis-results.tgz \
+                        -F version=$(git rev-parse --short HEAD) \
+                        -F description="Azure Pipelines build" \
+                        -F email="${COVERITY_SCAN_EMAIL:=cyclonedds-inbox@eclipse.org}" \
+                        -w '%{http_code}' \
+                        "https://scan.coverity.com/builds")
+      [[ "${code}" =~ "success" ]] || (echo "cURL exited with ${code}" 1>&2 && exit 1)
+      rm -f analysis-results.tgz
+    name: submit_to_coverity_scan
+    env:
+      token: $(COVERITY_SCAN_TOKEN)

--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -1,0 +1,124 @@
+#
+# Copyright(c) 2021 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+#
+# Template with basic build and test instructions to be included by pipelines.
+#
+
+steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.8'
+    name: install_python
+  # Set defaults from steps to share them among pipelines
+  - bash: |
+      [[ -n "${ARCH}" ]] || \
+        echo "###vso[task.setvariable variable=arch;]x86_64"
+      [[ -n "${BUILD_TYPE}" ]] || \
+        echo "###vso[task.setvariable variable=build_type;]Debug"
+    name: setup
+  - bash: |
+      echo "###vso[task.setvariable variable=pip_cache;]${HOME}/.cache/pip"
+      echo "###vso[task.setvariable variable=conan_cache;]${HOME}/.conan/data"
+      echo "###vso[task.setvariable variable=PATH;]$(python3 -m site --user-base)/bin:${PATH}"
+      echo "###vso[task.setvariable variable=build_tool_options;]-j 4"
+      sudo apt-get install -y clang-tools clang-tidy
+    condition: eq(variables['Agent.OS'], 'Linux')
+    name: setup_linux
+  - bash: |
+      echo "###vso[task.setvariable variable=pip_cache;]${HOME}/Library/Caches/pip"
+      echo "###vso[task.setvariable variable=conan_cache;]${HOME}/.conan/data"
+      echo "###vso[task.setvariable variable=PATH;]$(python3 -m site --user-base)/bin:${PATH}"
+      echo "###vso[task.setvariable variable=build_tool_options;]-j 4"
+      sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
+      brew install bison
+    condition: eq(variables['Agent.OS'], 'Darwin')
+    name: setup_macos
+  # Use PowerShell rather than Bash to ensure Windows-style paths
+  - pwsh: |
+      $python_bin = python -m site --user-base
+      Write-Host "###vso[task.setvariable variable=pip_cache;]${env:LOCALAPPDATA}\\pip\\Cache"
+      Write-Host "###vso[task.setvariable variable=conan_cache;]${env:USERPROFILE}\\.conan\\data"
+      Write-Host "###vso[task.setvariable variable=PATH;]$python_bin\\bin;${env:PATH}"
+      # Visual Studio is most likely used on Windows agents
+      if (${env:GENERATOR} -match "2019" -and -not ${env:PLATFORM}) {
+        # Make sure platform matches arch if not specified
+        if (${env:ARCH} -match "arm*") {
+          Write-Host "###vso[task.setvariable variable=platform;]ARM"
+        } elseif (${env:ARCH} -eq "x86") {
+          Write-Host "###vso[task.setvariable variable=platform;]x86"
+        } else {
+          Write-Host "###vso[task.setvariable variable=platform;]x64"
+        }
+      }
+      Write-Host "###vso[task.setvariable variable=build_tool_options;]-nologo -verbosity:minimal -maxcpucount:4 -p:CL_MPCount=4"
+      choco install winflexbison3
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
+    name: setup_windows
+  - task: Cache@2
+    inputs:
+      key: pip | 1 | $(Agent.OS)
+      path: $(pip_cache)
+    name: cache_pip
+  - task: Cache@2
+    inputs:
+      key: conan | 1 | $(Agent.OS) | $(arch) | $(build_type)
+      path: $(conan_cache)
+    name: cache_conan
+  - bash: |
+      set -e -x
+      pip install conan --user
+      conan profile new default --detect
+    name: install_conan
+  - bash: |
+      set -e -x
+      git clone --single-branch \
+                --branch "${CYCLONEDDS_BRANCH:-master}" \
+                "${CYCLONEDDS_REPOSITORY:-https://github.com/eclipse-cyclonedds/cyclonedds.git}" \
+                cyclonedds
+      mkdir cyclonedds/build
+      cd cyclonedds/build
+      conan install -b missing -s arch=${ARCH} -s build_type=${BUILD_TYPE} ..
+      cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+            -DCMAKE_INSTALL_PREFIX=install \
+            -DSANITIZER=${SANITIZER:-none} \
+            ${GENERATOR:+-G} "${GENERATOR}" -A "${PLATFORM}" -T "${TOOLSET}" ..
+      cmake --build . --config ${BUILD_TYPE} --target install -- ${BUILD_TOOL_OPTIONS}
+    name: install_cyclonedds
+  - bash: |
+      set -e -x
+      mkdir build
+      cd build
+      conan install -b missing -s arch=${ARCH} -s build_type=${BUILD_TYPE} ..
+      cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+            -DCMAKE_INSTALL_PREFIX=install \
+            -DCMAKE_PREFIX_PATH=${BUILD_SOURCESDIRECTORY}/cyclonedds/build/install \
+            -DANALYZER=${ANALYZER:-off} \
+            -DSANITIZER=${SANITIZER:-none} \
+            -DENABLE_COVERAGE=${COVERAGE:-off} \
+            -DBUILD_TESTING=on \
+            -DBUILD_EXAMPLES=on \
+            -DWERROR=on \
+            ${GENERATOR:+-G} "${GENERATOR}" -A "${PLATFORM}" -T "${TOOLSET}" ..
+      ${SCAN_BUILD} cmake --build . --config ${BUILD_TYPE} --target install -- ${BUILD_TOOL_OPTIONS}
+    name: script
+  - bash: |
+      set -e -x
+      cd build
+      ctest -j 4 --output-on-failure -T test -C ${BUILD_TYPE}
+      INSTALLPREFIX="$(pwd)/install"
+      mkdir helloworld
+      cd helloworld
+      cmake -DCMAKE_PREFIX_PATH="${BUILD_SOURCESDIRECTORY}/cyclonedds/build/install;${BUILD_SOURCESDIRECTORY}/build/install" \
+            -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+            ${GENERATOR:+-G} "${GENERATOR}" "${INSTALLPREFIX}/share/CycloneDDS-CXX/helloworld"
+    name: test

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - src/ddscxx/tests/*.cpp
+  - src/idlcxx/tests/*.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ if(USE_SANITIZER)
 endif()
 
 find_package(codecov)
+include(Codecov)
 
 # Build all executables and libraries into the top-level /bin and /lib folders.
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ if(ANALYZER)
     # Clang-Tidy is an extensible tool that offers more than static analysis.
     # https://clang.llvm.org/extra/clang-tidy/checks/list.html
     message(STATUS "Enabling analyzer: clang-tidy")
-    set(CMAKE_C_CLANG_TIDY "clang-tidy;-checks=-*,clang-analyzer-*,-clang-analyzer-security.insecureAPI.strcpy")
+    set(CMAKE_C_CLANG_TIDY "clang-tidy;-checks=-*,clang-analyzer-*,-clang-analyzer-security.insecureAPI.strcpy,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling")
     if(WERROR)
       set(CMAKE_C_CLANG_TIDY "${CMAKE_C_CLANG_TIDY};--warnings-as-errors=*")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,8 @@ if(USE_SANITIZER)
   endforeach()
 endif()
 
+find_package(codecov)
+
 # Build all executables and libraries into the top-level /bin and /lib folders.
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,11 +118,46 @@ endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
 
-# Make it easy to enable Clang and GCC analyzers
-if(USE_SANITIZER)
-  string(REGEX REPLACE " " "" USE_SANITIZER "${USE_SANITIZER}")
-  string(REGEX REPLACE "[,;]+" ";" USE_SANITIZER "${USE_SANITIZER}")
-  foreach(san ${USE_SANITIZER})
+# Make it easy to enable MSVC, Clang's/gcc's analyzers
+set(ANALYZER "" CACHE STRING "Analyzer to enable on the build.")
+if(ANALYZER)
+  # GCC and Visual Studio offer builtin analyzers. Clang supports static
+  # analysis through separate tools, e.g. Clang-Tidy, which can be used in
+  # conjunction with other compilers too. Specifying -DANALYZER=on enables
+  # the builtin analyzer for the compiler, enabling clang-tidy in case of
+  # Clang. Specifying -DANALYZER=clang-tidy always enables clang-tidy.
+  string(REPLACE " " "" ANALYZER "${ANALYZER}")
+  string(TOLOWER "${ANALYZER}" ANALYZER)
+  if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND ANALYZER STREQUAL "on")
+    set(ANALYZER "clang-tidy")
+  endif()
+
+  if(ANALYZER STREQUAL "clang-tidy")
+    # Clang-Tidy is an extensible tool that offers more than static analysis.
+    # https://clang.llvm.org/extra/clang-tidy/checks/list.html
+    message(STATUS "Enabling analyzer: clang-tidy")
+    set(CMAKE_C_CLANG_TIDY "clang-tidy;-checks=-*,clang-analyzer-*,-clang-analyzer-security.insecureAPI.strcpy")
+    if(WERROR)
+      set(CMAKE_C_CLANG_TIDY "${CMAKE_C_CLANG_TIDY};--warnings-as-errors=*")
+    endif()
+  elseif(ANALYZER STREQUAL "on")
+    if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+      if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "10")
+        message(STATUS "Enabling analyzer: GCC")
+        # -Wanalyzer-malloc-leak generates lots of false positives
+        add_compile_options(-fanalyzer -Wno-analyzer-malloc-leak)
+      endif()
+    elseif(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+      message(STATUS "Enabling analyzer: MSVC")
+      add_compile_options(/analyze:stacksize 524288)
+    endif()
+  endif()
+endif()
+set(SANITIZER "" CACHE STRING "Sanitizers to enable on the build.")
+if(SANITIZER)
+  string(REGEX REPLACE " " "" SANITIZER "${SANITIZER}")
+  string(REGEX REPLACE "[,;]+" ";" SANITIZER "${SANITIZER}")
+  foreach(san ${SANITIZER})
     if(san STREQUAL "address")
       add_compile_options("-fno-omit-frame-pointer")
       add_link_options("-fno-omit-frame-pointer")

--- a/README.md
+++ b/README.md
@@ -122,15 +122,6 @@ that the CI build infrastructure also uses. In that case, install Conan and do:
 in the build directory prior to running `cmake`. This will automatically
 download and/or build Google Test.
 
-The Google Test Conan package is hosted in the Bincrafters Bintray repository.
-In case this repository was not added to your Conan remotes list yet (and the
-above mentioned install command failed because it could not find the
-Google Test package), you can add the Bintray repository by:
-
-    $ conan remote add <REMOTE> https://api.bintray.com/conan/bincrafters/public-conan
-
-Replace `<REMOTE>` with a name that identifies the repository (e.g. `bincrafters`).
-
 For Windows, depending on the generator, you might also need to add switches
 to select the architecture and build type, e.g.,
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ tier-1 middleware for the Robot Operating System [ROS 2][6].
 
 [![Build Status](https://travis-ci.com/eclipse-cyclonedds/cyclonedds-cxx.svg?branch=master)](https://travis-ci.com/eclipse-cyclonedds/cyclonedds-cxx)
 [![Coverity Status](https://scan.coverity.com/projects/21579/badge.svg)](https://scan.coverity.com/projects/eclipse-cyclonedds-cyclonedds-cxx)
+[![Codecov](https://codecov.io/gh/eclipse-cyclonedds/cyclonedds-cxx/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/github/eclipse-cyclonedds/cyclonedds-cxx?branch=master)
 
 # Getting Started
 

--- a/README.md
+++ b/README.md
@@ -32,16 +32,11 @@ following installed on your host:
  * [Git](https://git-scm.com/) version control system;
  * [CMake](https://cmake.org/download/), version 3.7 or later;
  * [Eclipse Cyclone DDS](https://github.com/eclipse-cyclonedds/cyclonedds/)
- * [CXX Idl compiler](https://github.com/ADLINK-IST/idlpp-cxx/)
 
-*Eclipse Cyclone DDS* and the *CXX Idl compiler* have dependencies of their
-own, most notably Java and Apache Maven. To build and install the respective
-projects, please consult their build instructions. Ensure both projects are
-installed into locations convenient for you by specifying
+*Eclipse Cyclone DDS* has dependencies of its own, most notably Bison. To
+build and install it, please consult the build instructions. Ensure the
+project is installed into a location convenient for you by specifying
 `CMAKE_INSTALL_PREFIX`.
-
-> The *CXX Idl compiler* is a temporary dependency, a new IDL compiler for
-> both Eclipse Cyclone DDS and Eclipse Cyclone DDS CXX is in the works.
 
 To obtain the C++ binding for Cyclone DDS, do
 
@@ -61,7 +56,7 @@ hand, and Windows on the other. For Linux or macOS:
 
     $ cd build
     $ cmake -DCMAKE_INSTALL_PREFIX=<install-location> \
-            -DCMAKE_PREFIX_PATH="<idlpp-cxx-install-location>;<cyclonedds-install-location>" \
+            -DCMAKE_PREFIX_PATH="<cyclonedds-install-location>" \
             ..
     $ cmake --build .
 
@@ -70,7 +65,7 @@ and for Windows:
     $ cd build
     $ cmake -G "<generator-name>" \
             -DCMAKE_INSTALL_PREFIX=<install-location> \
-            -DCMAKE_PREFIX_PATH="<idlpp-cxx-install-location>;<cyclonedds-install-location>" \
+            -DCMAKE_PREFIX_PATH="<cyclonedds-install-location>" \
             ..
     $ cmake --build .
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ tier-1 middleware for the Robot Operating System [ROS 2][6].
 [5]: https://github.com/EclipseFdn/iot.eclipse.org/issues/new?template=adopter_request.md
 [6]: https://index.ros.org/doc/ros2/
 
-[![Build Status](https://travis-ci.com/eclipse-cyclonedds/cyclonedds-cxx.svg?branch=master)](https://travis-ci.com/eclipse-cyclonedds/cyclonedds-cxx)
+[![Build Status](https://dev.azure.com/eclipse-cyclonedds/cyclonedds-cxx/_apis/build/status/Pull%20requests?branchName=master)](https://dev.azure.com/eclipse-cyclonedds/cyclonedds-cxx/_build/latest?definitionId=4&branchName=master)
 [![Coverity Status](https://scan.coverity.com/projects/21579/badge.svg)](https://scan.coverity.com/projects/eclipse-cyclonedds-cyclonedds-cxx)
 [![Codecov](https://codecov.io/gh/eclipse-cyclonedds/cyclonedds-cxx/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/github/eclipse-cyclonedds/cyclonedds-cxx?branch=master)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ tier-1 middleware for the Robot Operating System [ROS 2][6].
 [![Build Status](https://dev.azure.com/eclipse-cyclonedds/cyclonedds-cxx/_apis/build/status/Pull%20requests?branchName=master)](https://dev.azure.com/eclipse-cyclonedds/cyclonedds-cxx/_build/latest?definitionId=4&branchName=master)
 [![Coverity Status](https://scan.coverity.com/projects/21579/badge.svg)](https://scan.coverity.com/projects/eclipse-cyclonedds-cyclonedds-cxx)
 [![Codecov](https://codecov.io/gh/eclipse-cyclonedds/cyclonedds-cxx/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/github/eclipse-cyclonedds/cyclonedds-cxx?branch=master)
+[![License](https://img.shields.io/badge/License-EPL%202.0-blue)](https://choosealicense.com/licenses/epl-2.0/)
+[![License](https://img.shields.io/badge/License-EDL%201.0-blue)](https://choosealicense.com/licenses/edl-1.0/)
 
 # Getting Started
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,78 @@
+#
+# Copyright(c) 2021 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+trigger: [ '*' ]
+pr: [ '*' ]
+
+strategy:
+  matrix:
+    'Ubuntu 20.04 LTS with GCC 10 (Debug, x86_64)':
+      image: ubuntu-20.04
+      analyzer: on
+      sanitizer: address
+      cc: gcc-10
+      cxx: g++-10
+    'Ubuntu 20.04 LTS with GCC 10 (Release, x86_64)':
+      image: ubuntu-20.04
+      build_type: Release
+      cc: gcc-10
+      cxx: g++-10
+    'Ubuntu 18.04 LTS with GCC 7 (Debug, x86_64)':
+      image: ubuntu-18.04
+      conanfile: conanfile102.txt
+      cc: gcc-7
+      gxx: g++-7
+    'Ubuntu 20.04 LTS with Clang 10 (Debug, x86_64)':
+      image: ubuntu-20.04
+      analyzer: on
+      sanitizer: address
+      cc: clang-10
+      cxx: clang++-10
+    'Ubuntu 20.04 LTS with Clang 10 (Release, x86_64)':
+      image: ubuntu-20.04
+      build_type: Release
+      cc: clang-10
+      cxx: clang++-10
+    'macOS 10.15 with Clang 12 (Debug, x86_64)':
+      image: macOS-10.15
+      sanitizer: address
+      cc: clang
+      cxx: clang++
+    'macOS 10.15 with Clang 12 (Release, x86_64)':
+      image: macOS-10.15
+      build_type: Release
+      cc: clang
+      cxx: clang++
+    # disabled for now because 32-bit packages are missing
+    #'Windows 2019 with Visual Studio 2019 (Visual Studio 2017, Debug, x86)':
+    #  arch: x86
+    #  image: windows-2019
+    #  conanfile: conanfile102.txt
+    #  generator: 'Visual Studio 16 2019'
+    #  toolkit: v141
+    'Windows 2019 with Visual Studio 2019 (Debug, x86_64)':
+      image: windows-2019
+      analyzer: on
+      generator: 'Visual Studio 16 2019'
+    'Windows 2019 with Visual Studio 2019 (Release, x86_64)':
+      image: windows-2019
+      build_type: Release
+      generator: 'Visual Studio 16 2019'
+
+pool:
+  vmImage: $(image)
+
+variables:
+  cyclonedds_uri: '<CycloneDDS><Domain><Internal><EnableExpensiveChecks>rhc,whc</EnableExpensiveChecks><LivelinessMonitoring>true</LivelinessMonitoring></Internal><Tracing><Verbosity>config</Verbosity><OutputFile>stderr</OutputFile></Tracing></Domain></CycloneDDS>'
+
+steps:
+  - template: /.azure/templates/build-test.yml

--- a/cmake/Modules/Codecov.cmake
+++ b/cmake/Modules/Codecov.cmake
@@ -1,0 +1,45 @@
+#
+# Copyright(c) 2020 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+# This module is meant to be used in conjuntion with CMake-codecov
+# https://github.com/RWTH-HPC/CMake-codecov
+#
+# A codecov target is added if ENABLE_COVERAGE is on.
+# Generate a codecov.io submission file with cmake --build . --target codecov.
+# Submit the file to codecov.io by putting the proper commands in .travis.yml.
+# See https://codecov.io/bash for details.
+
+if(ENABLE_COVERAGE)
+  if(NOT TARGET gcov)
+    add_custom_target(gcov)
+  endif()
+  if(NOT TARGET codecov)
+    set(CODECOV_FILE codecov.dump)
+    set(CODECOV_ARCHIVE codecov.tar.gz)
+    add_custom_target(codecov)
+    add_dependencies(codecov gcov)
+    add_custom_command(
+      TARGET codecov
+      POST_BUILD
+      BYPRODUCTS
+        "${CMAKE_BINARY_DIR}/${CODECOV_FILE}"
+        "${CMAKE_BINARY_DIR}/${CODECOV_ARCHIVE}"
+      COMMAND ${CMAKE_COMMAND} ARGS
+        -DPROJECT_ROOT="${CMAKE_SOURCE_DIR}"
+        -DCODECOV_FILE="${CODECOV_FILE}"
+        -P ${CMAKE_CURRENT_LIST_DIR}/Codecov/codecov.cmake
+      COMMAND ${CMAKE_COMMAND} ARGS
+        -E tar czf ${CODECOV_ARCHIVE} -- ${CODECOV_FILE}
+        COMMENT "Generating ${CODECOV_ARCHIVE}"
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+  endif()
+endif()

--- a/cmake/Modules/Codecov/codecov.cmake
+++ b/cmake/Modules/Codecov/codecov.cmake
@@ -1,0 +1,135 @@
+#
+# Copyright(c) 2020 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+# CMake script to produce a codecov.io submission file.
+# Should be compatible with https://codecov.io/bash.
+
+if(NOT PROJECT_ROOT)
+  message(FATAL_ERROR "PROJECT_ROOT is not set")
+endif()
+
+if(NOT CODECOV_FILE)
+  message(FATAL_ERROR "CODECOV_FILE is not set")
+endif()
+
+function(read_adjustments ROOT SOURCEFILE ADJUSTMENTS)
+  file(READ "${SOURCEFILE}" _source)
+  # replace semicolons by colons
+  string(REPLACE ";"  ":" _source "${_source}")
+  # replace newlines by semicolons
+  # space is inserted to ensure blank lines are picked up
+  string(REPLACE "\n" " ;" _source "${_source}")
+
+  # include matching lines in adjustments
+  set(_line_number 0)
+  foreach(_line ${_source})
+    math(EXPR _line_number "${_line_number} + 1")
+    # empty_line='^[[:space:]]*$'
+    if(_line MATCHES "^[ \t]*$")
+      list(APPEND _adjustments ${_line_number})
+    # syntax_bracket='^[[:space:]]*[\{\}][[:space:]]*(//.*)?$'
+    elseif(_line MATCHES "^[ \t]*[{}][ \t]*(//.*)?")
+      list(APPEND _adjustments ${_line_number})
+    # //LCOV_EXCL
+    elseif(_line MATCHES "// LCOV_EXCL")
+      list(APPEND _adjustments ${_line_number})
+    endif()
+  endforeach()
+
+  if(_adjustments)
+    string(REPLACE ";" "," _adjustments "${_adjustments}")
+    set(${ADJUSTMENTS} "${SOURCEFILE}:${_adjustments}\n" PARENT_SCOPE)
+  endif()
+endfunction()
+
+function(read_and_reduce_gcov ROOT GCOVFILE SOURCEFILE GCOV)
+  file(READ "${GCOVFILE}" _gcov)
+  # grab first line
+  string(REGEX MATCH "^[^\n]*" _source "${_gcov}")
+
+  # reduce gcov
+  # 1. remove source code
+  # 2. remove ending bracket lines
+  # 3. remove whitespace
+  string(REGEX REPLACE " *([^ \n:]*): *([^ \n:]*):?[^\n]*" "\\1:\\2:" _gcov "${_gcov}")
+  # 4. remove contextual lines
+  string(REGEX REPLACE "-+[^\n]*\n" "" _gcov "${_gcov}")
+  # 5. remove function names
+
+  string(REPLACE "${ROOT}" "" _path "${GCOVFILE}")
+  string(REGEX REPLACE "^/+" "" _path "${_path}")
+  string(PREPEND _gcov "# path=${_path}.reduced\n${_source}\n")
+  string(APPEND _gcov "<<<<<< EOF\n")
+
+  # capture source file
+  string(REGEX REPLACE "^.*:Source:(.*)$" "\\1" _source "${_source}")
+
+  set(${SOURCEFILE} "${_source}" PARENT_SCOPE)
+  set(${GCOV} "${_gcov}" PARENT_SCOPE)
+endfunction()
+
+set(project_dir "${PROJECT_ROOT}")
+set(build_dir "${CMAKE_CURRENT_BINARY_DIR}")
+
+# Codecov supports .codecov.yml files to configure the service. The location
+# of the first .codecov.yml found by the bash uploader is in included in the
+# the list of files submitted to the service.
+file(GLOB_RECURSE yaml_files RELATIVE "${PROJECT_ROOT}" "${PROJECT_ROOT}/*codecov.y*ml")
+if(yaml_files)
+  list(GET yaml_files 0 yaml_file)
+endif()
+
+set(network_block "${yaml_file}\n")
+set(gcov_block "")
+set(adjustments_block "")
+
+# Codecov uses "git ls-files" and falls back to find, but having no
+# dependencies is preferred (for now). Globbing rules are very likely to
+# produce the same result
+file(GLOB_RECURSE source_files "${PROJECT_ROOT}/*.[hH]"
+                               "${PROJECT_ROOT}/*.[Cc]"
+                               "${PROJECT_ROOT}/*.[Hh][Pp][Pp]"
+                               "${PROJECT_ROOT}/*.[Cc][Pp][Pp]"
+                               "${PROJECT_ROOT}/*.[Cc][Xx][Xx]")
+
+file(GLOB_RECURSE gcov_files "${CMAKE_CURRENT_BINARY_DIR}/*.gcov")
+foreach(gcov_file ${gcov_files})
+  read_and_reduce_gcov("${PROJECT_ROOT}" "${gcov_file}" source_file gcov)
+  list(APPEND source_files "${source_file}")
+  string(APPEND gcov_block "${gcov}")
+endforeach()
+
+list(REMOVE_DUPLICATES source_files)
+foreach(source_file ${source_files})
+  # ignore any files located in the build directory
+  string(FIND "${source_file}" "${build_dir}/" in_build_dir)
+  if(in_build_dir GREATER_EQUAL 0)
+    continue()
+  endif()
+  # ignore paths with /CMakeFiles/
+  if(source_file MATCHES "/CMakeFiles/")
+    continue()
+  endif()
+  read_adjustments("${PROJECT_ROOT}" "${source_file}" adjustments)
+  string(APPEND adjustments_block "${adjustments}")
+  string(REPLACE "${PROJECT_ROOT}" "" source_file "${source_file}")
+  string(REGEX REPLACE "^/+" "" source_file "${source_file}")
+  string(APPEND network_block "${source_file}\n")
+endforeach()
+
+string(PREPEND adjustments_block "# path=fixes\n")
+string(APPEND  adjustments_block "<<<<<< EOF")
+string(APPEND network_block "<<<<<< network\n")
+
+file(WRITE  ${CODECOV_FILE} "${network_block}")
+file(APPEND ${CODECOV_FILE} "${gcov_block}")
+file(APPEND ${CODECOV_FILE} "${adjustments_block}")

--- a/cmake/Modules/FindGcov.cmake
+++ b/cmake/Modules/FindGcov.cmake
@@ -1,0 +1,182 @@
+# This file is part of CMake-codecov.
+#
+# Copyright 2015-2017 RWTH Aachen University, Federal Republic of Germany
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the University of California, Berkeley nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Written by Alexander Haase, alexander.haase@rwth-aachen.de
+#
+
+
+# include required Modules
+include(FindPackageHandleStandardArgs)
+
+
+# Search for gcov binary.
+set(CMAKE_REQUIRED_QUIET_SAVE ${CMAKE_REQUIRED_QUIET})
+set(CMAKE_REQUIRED_QUIET ${codecov_FIND_QUIETLY})
+
+get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+foreach (LANG ${ENABLED_LANGUAGES})
+	# Gcov evaluation is dependent on the used compiler. Check gcov support for
+	# each compiler that is used. If gcov binary was already found for this
+	# compiler, do not try to find it again.
+	if (NOT GCOV_${CMAKE_${LANG}_COMPILER_ID}_BIN)
+		get_filename_component(COMPILER_PATH "${CMAKE_${LANG}_COMPILER}" PATH)
+
+		if ("${CMAKE_${LANG}_COMPILER_ID}" STREQUAL "GNU")
+			# Some distributions like OSX (homebrew) ship gcov with the compiler
+			# version appended as gcov-x. To find this binary we'll build the
+			# suggested binary name with the compiler version.
+			string(REGEX MATCH "^[0-9]+" GCC_VERSION
+				"${CMAKE_${LANG}_COMPILER_VERSION}")
+
+			find_program(GCOV_BIN NAMES gcov-${GCC_VERSION} gcov
+				HINTS ${COMPILER_PATH})
+
+		elseif ("${CMAKE_${LANG}_COMPILER_ID}" STREQUAL "Clang")
+			# Some distributions like Debian ship llvm-cov with the compiler
+			# version appended as llvm-cov-x.y. To find this binary we'll build
+			# the suggested binary name with the compiler version.
+			string(REGEX MATCH "^[0-9]+.[0-9]+" LLVM_VERSION
+				"${CMAKE_${LANG}_COMPILER_VERSION}")
+
+			# llvm-cov prior version 3.5 seems to be not working with coverage
+			# evaluation tools, but these versions are compatible with the gcc
+			# gcov tool.
+			if(LLVM_VERSION VERSION_GREATER 3.4)
+				find_program(LLVM_COV_BIN NAMES "llvm-cov-${LLVM_VERSION}"
+					"llvm-cov" HINTS ${COMPILER_PATH})
+				mark_as_advanced(LLVM_COV_BIN)
+
+				if (LLVM_COV_BIN)
+					find_program(LLVM_COV_WRAPPER "llvm-cov-wrapper" PATHS
+						${CMAKE_MODULE_PATH})
+					if (LLVM_COV_WRAPPER)
+						set(GCOV_BIN "${LLVM_COV_WRAPPER}" CACHE FILEPATH "")
+
+						# set additional parameters
+						set(GCOV_${CMAKE_${LANG}_COMPILER_ID}_ENV
+							"LLVM_COV_BIN=${LLVM_COV_BIN}" CACHE STRING
+							"Environment variables for llvm-cov-wrapper.")
+						mark_as_advanced(GCOV_${CMAKE_${LANG}_COMPILER_ID}_ENV)
+					endif ()
+				endif ()
+			endif ()
+
+			if (NOT GCOV_BIN)
+				# Fall back to gcov binary if llvm-cov was not found or is
+				# incompatible. This is the default on OSX, but may crash on
+				# recent Linux versions.
+				find_program(GCOV_BIN gcov HINTS ${COMPILER_PATH})
+			endif ()
+		endif ()
+
+
+		if (GCOV_BIN)
+			set(GCOV_${CMAKE_${LANG}_COMPILER_ID}_BIN "${GCOV_BIN}" CACHE STRING
+				"${LANG} gcov binary.")
+
+			if (NOT CMAKE_REQUIRED_QUIET)
+				message("-- Found gcov evaluation for "
+				"${CMAKE_${LANG}_COMPILER_ID}: ${GCOV_BIN}")
+			endif()
+
+			unset(GCOV_BIN CACHE)
+		endif ()
+	endif ()
+endforeach ()
+
+
+
+
+# Add a new global target for all gcov targets. This target could be used to
+# generate the gcov files for the whole project instead of calling <TARGET>-gcov
+# for each target.
+if (NOT TARGET gcov)
+	add_custom_target(gcov)
+endif (NOT TARGET gcov)
+
+
+
+# This function will add gcov evaluation for target <TNAME>. Only sources of
+# this target will be evaluated and no dependencies will be added. It will call
+# Gcov on any source file of <TNAME> once and store the gcov file in the same
+# directory.
+function (add_gcov_target TNAME)
+	set(TDIR ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${TNAME}.dir)
+
+	# We don't have to check, if the target has support for coverage, thus this
+	# will be checked by add_coverage_target in Findcoverage.cmake. Instead we
+	# have to determine which gcov binary to use.
+	get_target_property(TSOURCES ${TNAME} SOURCES)
+	set(SOURCES "")
+	set(TCOMPILER "")
+	foreach (FILE ${TSOURCES})
+		codecov_path_of_source(${FILE} FILE)
+		if (NOT "${FILE}" STREQUAL "")
+			codecov_lang_of_source(${FILE} LANG)
+			if (NOT "${LANG}" STREQUAL "")
+				list(APPEND SOURCES "${FILE}")
+				set(TCOMPILER ${CMAKE_${LANG}_COMPILER_ID})
+			endif ()
+		endif ()
+	endforeach ()
+
+	# If no gcov binary was found, coverage data can't be evaluated.
+	if (NOT GCOV_${TCOMPILER}_BIN)
+		message(WARNING "No coverage evaluation binary found for ${TCOMPILER}.")
+		return()
+	endif ()
+
+	set(GCOV_BIN "${GCOV_${TCOMPILER}_BIN}")
+	set(GCOV_ENV "${GCOV_${TCOMPILER}_ENV}")
+
+
+	set(BUFFER "")
+	foreach(FILE ${SOURCES})
+		get_filename_component(FILE_PATH "${TDIR}/${FILE}" PATH)
+
+		# call gcov
+		add_custom_command(OUTPUT ${TDIR}/${FILE}.gcov
+			COMMAND ${GCOV_ENV} ${GCOV_BIN} ${TDIR}/${FILE}.gcno > /dev/null
+			DEPENDS ${TNAME} ${TDIR}/${FILE}.gcno
+			WORKING_DIRECTORY ${FILE_PATH}
+		)
+
+		list(APPEND BUFFER ${TDIR}/${FILE}.gcov)
+	endforeach()
+
+
+	# add target for gcov evaluation of <TNAME>
+	add_custom_target(${TNAME}-gcov DEPENDS ${BUFFER})
+
+	# add evaluation target to the global gcov target.
+	add_dependencies(gcov ${TNAME}-gcov)
+endfunction (add_gcov_target)

--- a/cmake/Modules/FindLcov.cmake
+++ b/cmake/Modules/FindLcov.cmake
@@ -1,0 +1,379 @@
+# This file is part of CMake-codecov.
+#
+# Copyright 2015-2017 RWTH Aachen University, Federal Republic of Germany
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the University of California, Berkeley nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Written by Alexander Haase, alexander.haase@rwth-aachen.de
+#
+
+
+# configuration
+set(LCOV_DATA_PATH "${CMAKE_BINARY_DIR}/lcov/data")
+set(LCOV_DATA_PATH_INIT "${LCOV_DATA_PATH}/init")
+set(LCOV_DATA_PATH_CAPTURE "${LCOV_DATA_PATH}/capture")
+set(LCOV_HTML_PATH "${CMAKE_BINARY_DIR}/lcov/html")
+
+
+
+
+# Search for Gcov which is used by Lcov.
+find_package(Gcov)
+
+
+
+
+# This function will add lcov evaluation for target <TNAME>. Only sources of
+# this target will be evaluated and no dependencies will be added. It will call
+# geninfo on any source file of <TNAME> once and store the info file in the same
+# directory.
+#
+# Note: This function is only a wrapper to define this function always, even if
+#   coverage is not supported by the compiler or disabled. This function must
+#   be defined here, because the module will be exited, if there is no coverage
+#   support by the compiler or it is disabled by the user.
+function (add_lcov_target TNAME)
+	if (LCOV_FOUND)
+		# capture initial coverage data
+		lcov_capture_initial_tgt(${TNAME})
+
+		# capture coverage data after execution
+		lcov_capture_tgt(${TNAME})
+	endif ()
+endfunction (add_lcov_target)
+
+
+
+
+# include required Modules
+include(FindPackageHandleStandardArgs)
+
+# Search for required lcov binaries.
+find_program(LCOV_BIN lcov)
+find_program(GENINFO_BIN geninfo)
+find_program(GENHTML_BIN genhtml)
+find_package_handle_standard_args(lcov
+	REQUIRED_VARS LCOV_BIN GENINFO_BIN GENHTML_BIN
+)
+
+# enable genhtml C++ demangeling, if c++filt is found.
+set(GENHTML_CPPFILT_FLAG "")
+find_program(CPPFILT_BIN c++filt)
+if (NOT CPPFILT_BIN STREQUAL "")
+	set(GENHTML_CPPFILT_FLAG "--demangle-cpp")
+endif (NOT CPPFILT_BIN STREQUAL "")
+
+# enable no-external flag for lcov, if available.
+if (GENINFO_BIN AND NOT DEFINED GENINFO_EXTERN_FLAG)
+	set(FLAG "")
+	execute_process(COMMAND ${GENINFO_BIN} --help OUTPUT_VARIABLE GENINFO_HELP)
+	string(REGEX MATCH "external" GENINFO_RES "${GENINFO_HELP}")
+	if (GENINFO_RES)
+		set(FLAG "--no-external")
+	endif ()
+
+	set(GENINFO_EXTERN_FLAG "${FLAG}"
+		CACHE STRING "Geninfo flag to exclude system sources.")
+endif ()
+
+# If Lcov was not found, exit module now.
+if (NOT LCOV_FOUND)
+	return()
+endif (NOT LCOV_FOUND)
+
+
+
+
+# Create directories to be used.
+file(MAKE_DIRECTORY ${LCOV_DATA_PATH_INIT})
+file(MAKE_DIRECTORY ${LCOV_DATA_PATH_CAPTURE})
+
+set(LCOV_REMOVE_PATTERNS "")
+
+# This function will merge lcov files to a single target file. Additional lcov
+# flags may be set with setting LCOV_EXTRA_FLAGS before calling this function.
+function (lcov_merge_files OUTFILE ...)
+	# Remove ${OUTFILE} from ${ARGV} and generate lcov parameters with files.
+	list(REMOVE_AT ARGV 0)
+
+	# Generate merged file.
+	string(REPLACE "${CMAKE_BINARY_DIR}/" "" FILE_REL "${OUTFILE}")
+	add_custom_command(OUTPUT "${OUTFILE}.raw"
+		COMMAND cat ${ARGV} > ${OUTFILE}.raw
+		DEPENDS ${ARGV}
+		COMMENT "Generating ${FILE_REL}"
+	)
+
+	add_custom_command(OUTPUT "${OUTFILE}"
+		COMMAND ${LCOV_BIN} --quiet -a ${OUTFILE}.raw --output-file ${OUTFILE}
+			--base-directory ${PROJECT_SOURCE_DIR} ${LCOV_EXTRA_FLAGS}
+		COMMAND ${LCOV_BIN} --quiet -r ${OUTFILE} ${LCOV_REMOVE_PATTERNS}
+			--output-file ${OUTFILE} ${LCOV_EXTRA_FLAGS}
+		DEPENDS ${OUTFILE}.raw
+		COMMENT "Post-processing ${FILE_REL}"
+	)
+endfunction ()
+
+
+
+
+# Add a new global target to generate initial coverage reports for all targets.
+# This target will be used to generate the global initial info file, which is
+# used to gather even empty report data.
+if (NOT TARGET lcov-capture-init)
+	add_custom_target(lcov-capture-init)
+	set(LCOV_CAPTURE_INIT_FILES "" CACHE INTERNAL "")
+endif (NOT TARGET lcov-capture-init)
+
+
+# This function will add initial capture of coverage data for target <TNAME>,
+# which is needed to get also data for objects, which were not loaded at
+# execution time. It will call geninfo for every source file of <TNAME> once and
+# store the info file in the same directory.
+function (lcov_capture_initial_tgt TNAME)
+	# We don't have to check, if the target has support for coverage, thus this
+	# will be checked by add_coverage_target in Findcoverage.cmake. Instead we
+	# have to determine which gcov binary to use.
+	get_target_property(TSOURCES ${TNAME} SOURCES)
+	set(SOURCES "")
+	set(TCOMPILER "")
+	foreach (FILE ${TSOURCES})
+		codecov_path_of_source(${FILE} FILE)
+		if (NOT "${FILE}" STREQUAL "")
+			codecov_lang_of_source(${FILE} LANG)
+			if (NOT "${LANG}" STREQUAL "")
+				list(APPEND SOURCES "${FILE}")
+				set(TCOMPILER ${CMAKE_${LANG}_COMPILER_ID})
+			endif ()
+		endif ()
+	endforeach ()
+
+	# If no gcov binary was found, coverage data can't be evaluated.
+	if (NOT GCOV_${TCOMPILER}_BIN)
+		message(WARNING "No coverage evaluation binary found for ${TCOMPILER}.")
+		return()
+	endif ()
+
+	set(GCOV_BIN "${GCOV_${TCOMPILER}_BIN}")
+	set(GCOV_ENV "${GCOV_${TCOMPILER}_ENV}")
+
+
+	set(TDIR ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${TNAME}.dir)
+	set(GENINFO_FILES "")
+	foreach(FILE ${SOURCES})
+		# generate empty coverage files
+		set(OUTFILE "${TDIR}/${FILE}.info.init")
+		list(APPEND GENINFO_FILES ${OUTFILE})
+
+		add_custom_command(OUTPUT ${OUTFILE} COMMAND ${GCOV_ENV} ${GENINFO_BIN}
+				--quiet --base-directory ${PROJECT_SOURCE_DIR} --initial
+				--gcov-tool ${GCOV_BIN} --output-filename ${OUTFILE}
+				${GENINFO_EXTERN_FLAG} ${TDIR}/${FILE}.gcno
+			DEPENDS ${TNAME}
+			COMMENT "Capturing initial coverage data for ${FILE}"
+		)
+	endforeach()
+
+	# Concatenate all files generated by geninfo to a single file per target.
+	set(OUTFILE "${LCOV_DATA_PATH_INIT}/${TNAME}.info")
+	set(LCOV_EXTRA_FLAGS "--initial")
+	lcov_merge_files("${OUTFILE}" ${GENINFO_FILES})
+	add_custom_target(${TNAME}-capture-init ALL DEPENDS ${OUTFILE})
+
+	# add geninfo file generation to global lcov-geninfo target
+	add_dependencies(lcov-capture-init ${TNAME}-capture-init)
+	set(LCOV_CAPTURE_INIT_FILES "${LCOV_CAPTURE_INIT_FILES}"
+		"${OUTFILE}" CACHE INTERNAL ""
+	)
+endfunction (lcov_capture_initial_tgt)
+
+
+# This function will generate the global info file for all targets. It has to be
+# called after all other CMake functions in the root CMakeLists.txt file, to get
+# a full list of all targets that generate coverage data.
+function (lcov_capture_initial)
+	# Skip this function (and do not create the following targets), if there are
+	# no input files.
+	if ("${LCOV_CAPTURE_INIT_FILES}" STREQUAL "")
+		return()
+	endif ()
+
+	# Add a new target to merge the files of all targets.
+	set(OUTFILE "${LCOV_DATA_PATH_INIT}/all_targets.info")
+	lcov_merge_files("${OUTFILE}" ${LCOV_CAPTURE_INIT_FILES})
+	add_custom_target(lcov-geninfo-init ALL	DEPENDS ${OUTFILE}
+		lcov-capture-init
+	)
+endfunction (lcov_capture_initial)
+
+
+
+
+# Add a new global target to generate coverage reports for all targets. This
+# target will be used to generate the global info file.
+if (NOT TARGET lcov-capture)
+	add_custom_target(lcov-capture)
+	set(LCOV_CAPTURE_FILES "" CACHE INTERNAL "")
+endif (NOT TARGET lcov-capture)
+
+
+# This function will add capture of coverage data for target <TNAME>, which is
+# needed to get also data for objects, which were not loaded at execution time.
+# It will call geninfo for every source file of <TNAME> once and store the info
+# file in the same directory.
+function (lcov_capture_tgt TNAME)
+	# We don't have to check, if the target has support for coverage, thus this
+	# will be checked by add_coverage_target in Findcoverage.cmake. Instead we
+	# have to determine which gcov binary to use.
+	get_target_property(TSOURCES ${TNAME} SOURCES)
+	set(SOURCES "")
+	set(TCOMPILER "")
+	foreach (FILE ${TSOURCES})
+		codecov_path_of_source(${FILE} FILE)
+		if (NOT "${FILE}" STREQUAL "")
+			codecov_lang_of_source(${FILE} LANG)
+			if (NOT "${LANG}" STREQUAL "")
+				list(APPEND SOURCES "${FILE}")
+				set(TCOMPILER ${CMAKE_${LANG}_COMPILER_ID})
+			endif ()
+		endif ()
+	endforeach ()
+
+	# If no gcov binary was found, coverage data can't be evaluated.
+	if (NOT GCOV_${TCOMPILER}_BIN)
+		message(WARNING "No coverage evaluation binary found for ${TCOMPILER}.")
+		return()
+	endif ()
+
+	set(GCOV_BIN "${GCOV_${TCOMPILER}_BIN}")
+	set(GCOV_ENV "${GCOV_${TCOMPILER}_ENV}")
+
+
+	set(TDIR ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${TNAME}.dir)
+	set(GENINFO_FILES "")
+	foreach(FILE ${SOURCES})
+		# Generate coverage files. If no .gcda file was generated during
+		# execution, the empty coverage file will be used instead.
+		set(OUTFILE "${TDIR}/${FILE}.info")
+		list(APPEND GENINFO_FILES ${OUTFILE})
+
+		add_custom_command(OUTPUT ${OUTFILE}
+			COMMAND test -f "${TDIR}/${FILE}.gcda"
+				&& ${GCOV_ENV} ${GENINFO_BIN} --quiet --base-directory
+					${PROJECT_SOURCE_DIR} --gcov-tool ${GCOV_BIN}
+					--output-filename ${OUTFILE} ${GENINFO_EXTERN_FLAG}
+					${TDIR}/${FILE}.gcda
+				|| cp ${OUTFILE}.init ${OUTFILE}
+			DEPENDS ${TNAME} ${TNAME}-capture-init
+			COMMENT "Capturing coverage data for ${FILE}"
+		)
+	endforeach()
+
+	# Concatenate all files generated by geninfo to a single file per target.
+	set(OUTFILE "${LCOV_DATA_PATH_CAPTURE}/${TNAME}.info")
+	lcov_merge_files("${OUTFILE}" ${GENINFO_FILES})
+	add_custom_target(${TNAME}-geninfo DEPENDS ${OUTFILE})
+
+	# add geninfo file generation to global lcov-capture target
+	add_dependencies(lcov-capture ${TNAME}-geninfo)
+	set(LCOV_CAPTURE_FILES "${LCOV_CAPTURE_FILES}" "${OUTFILE}" CACHE INTERNAL
+		""
+	)
+
+	# Add target for generating html output for this target only.
+	file(MAKE_DIRECTORY ${LCOV_HTML_PATH}/${TNAME})
+	add_custom_target(${TNAME}-genhtml
+		COMMAND ${GENHTML_BIN} --quiet --sort --prefix ${PROJECT_SOURCE_DIR}
+			--baseline-file ${LCOV_DATA_PATH_INIT}/${TNAME}.info
+			--output-directory ${LCOV_HTML_PATH}/${TNAME}
+			--title "${CMAKE_PROJECT_NAME} - target ${TNAME}"
+			${GENHTML_CPPFILT_FLAG} ${OUTFILE}
+		DEPENDS ${TNAME}-geninfo ${TNAME}-capture-init
+	)
+endfunction (lcov_capture_tgt)
+
+
+# This function will generate the global info file for all targets. It has to be
+# called after all other CMake functions in the root CMakeLists.txt file, to get
+# a full list of all targets that generate coverage data.
+function (lcov_capture)
+	# Skip this function (and do not create the following targets), if there are
+	# no input files.
+	if ("${LCOV_CAPTURE_FILES}" STREQUAL "")
+		return()
+	endif ()
+
+	# Add a new target to merge the files of all targets.
+	set(OUTFILE "${LCOV_DATA_PATH_CAPTURE}/all_targets.info")
+	lcov_merge_files("${OUTFILE}" ${LCOV_CAPTURE_FILES})
+	add_custom_target(lcov-geninfo DEPENDS ${OUTFILE} lcov-capture)
+
+	# Add a new global target for all lcov targets. This target could be used to
+	# generate the lcov html output for the whole project instead of calling
+	# <TARGET>-geninfo and <TARGET>-genhtml for each target. It will also be
+	# used to generate a html site for all project data together instead of one
+	# for each target.
+	if (NOT TARGET lcov)
+		file(MAKE_DIRECTORY ${LCOV_HTML_PATH}/all_targets)
+		add_custom_target(lcov
+			COMMAND ${GENHTML_BIN} --quiet --sort
+				--baseline-file ${LCOV_DATA_PATH_INIT}/all_targets.info
+				--output-directory ${LCOV_HTML_PATH}/all_targets
+				--title "${CMAKE_PROJECT_NAME}" --prefix "${PROJECT_SOURCE_DIR}"
+				${GENHTML_CPPFILT_FLAG} ${OUTFILE}
+			DEPENDS lcov-geninfo-init lcov-geninfo
+		)
+	endif ()
+endfunction (lcov_capture)
+
+
+
+
+# Add a new global target to generate the lcov html report for the whole project
+# instead of calling <TARGET>-genhtml for each target (to create an own report
+# for each target). Instead of the lcov target it does not require geninfo for
+# all targets, so you have to call <TARGET>-geninfo to generate the info files
+# the targets you'd like to have in your report or lcov-geninfo for generating
+# info files for all targets before calling lcov-genhtml.
+file(MAKE_DIRECTORY ${LCOV_HTML_PATH}/selected_targets)
+if (NOT TARGET lcov-genhtml)
+	add_custom_target(lcov-genhtml
+		COMMAND ${GENHTML_BIN}
+			--quiet
+			--output-directory ${LCOV_HTML_PATH}/selected_targets
+			--title \"${CMAKE_PROJECT_NAME} - targets  `find
+				${LCOV_DATA_PATH_CAPTURE} -name \"*.info\" ! -name
+				\"all_targets.info\" -exec basename {} .info \\\;`\"
+			--prefix ${PROJECT_SOURCE_DIR}
+			--sort
+			${GENHTML_CPPFILT_FLAG}
+			`find ${LCOV_DATA_PATH_CAPTURE} -name \"*.info\" ! -name
+				\"all_targets.info\"`
+	)
+endif (NOT TARGET lcov-genhtml)

--- a/cmake/Modules/Findcodecov.cmake
+++ b/cmake/Modules/Findcodecov.cmake
@@ -1,0 +1,283 @@
+# This file is part of CMake-codecov.
+#
+# Copyright 2015-2017 RWTH Aachen University, Federal Republic of Germany
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the University of California, Berkeley nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Written by Alexander Haase, alexander.haase@rwth-aachen.de
+#
+
+
+# Add an option to choose, if coverage should be enabled or not. If enabled
+# marked targets will be build with coverage support and appropriate targets
+# will be added. If disabled coverage will be ignored for *ALL* targets.
+option(ENABLE_COVERAGE "Enable coverage build." OFF)
+
+set(COVERAGE_FLAG_CANDIDATES
+	# gcc and clang
+	"-O0 -g -fprofile-arcs -ftest-coverage"
+
+	# gcc and clang fallback
+	"-O0 -g --coverage"
+)
+
+
+# Add coverage support for target ${TNAME} and register target for coverage
+# evaluation. If coverage is disabled or not supported, this function will
+# simply do nothing.
+#
+# Note: This function is only a wrapper to define this function always, even if
+#   coverage is not supported by the compiler or disabled. This function must
+#   be defined here, because the module will be exited, if there is no coverage
+#   support by the compiler or it is disabled by the user.
+function (add_coverage TNAME)
+	# only add coverage for target, if coverage is support and enabled.
+	if (ENABLE_COVERAGE)
+		foreach (TNAME ${ARGV})
+			add_coverage_target(${TNAME})
+		endforeach ()
+	endif ()
+endfunction (add_coverage)
+
+
+# Add global target to gather coverage information after all targets have been
+# added. Other evaluation functions could be added here, after checks for the
+# specific module have been passed.
+#
+# Note: This function is only a wrapper to define this function always, even if
+#   coverage is not supported by the compiler or disabled. This function must
+#   be defined here, because the module will be exited, if there is no coverage
+#   support by the compiler or it is disabled by the user.
+function (coverage_evaluate)
+	# add lcov evaluation
+	if (LCOV_FOUND)
+		lcov_capture_initial()
+		lcov_capture()
+	endif (LCOV_FOUND)
+endfunction ()
+
+
+# Exit this module, if coverage is disabled. add_coverage is defined before this
+# return, so this module can be exited now safely without breaking any build-
+# scripts.
+if (NOT ENABLE_COVERAGE)
+	return()
+endif ()
+
+
+
+
+# Find the required flags foreach language.
+set(CMAKE_REQUIRED_QUIET_SAVE ${CMAKE_REQUIRED_QUIET})
+set(CMAKE_REQUIRED_QUIET ${codecov_FIND_QUIETLY})
+
+get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+foreach (LANG ${ENABLED_LANGUAGES})
+	# Coverage flags are not dependent on language, but the used compiler. So
+	# instead of searching flags foreach language, search flags foreach compiler
+	# used.
+	set(COMPILER ${CMAKE_${LANG}_COMPILER_ID})
+	if (NOT COVERAGE_${COMPILER}_FLAGS)
+		foreach (FLAG ${COVERAGE_FLAG_CANDIDATES})
+			if(NOT CMAKE_REQUIRED_QUIET)
+				message(STATUS "Try ${COMPILER} code coverage flag = [${FLAG}]")
+			endif()
+
+			set(CMAKE_REQUIRED_FLAGS "${FLAG}")
+			unset(COVERAGE_FLAG_DETECTED CACHE)
+
+			if (${LANG} STREQUAL "C")
+				include(CheckCCompilerFlag)
+				check_c_compiler_flag("${FLAG}" COVERAGE_FLAG_DETECTED)
+
+			elseif (${LANG} STREQUAL "CXX")
+				include(CheckCXXCompilerFlag)
+				check_cxx_compiler_flag("${FLAG}" COVERAGE_FLAG_DETECTED)
+
+			elseif (${LANG} STREQUAL "Fortran")
+				# CheckFortranCompilerFlag was introduced in CMake 3.x. To be
+				# compatible with older Cmake versions, we will check if this
+				# module is present before we use it. Otherwise we will define
+				# Fortran coverage support as not available.
+				include(CheckFortranCompilerFlag OPTIONAL
+					RESULT_VARIABLE INCLUDED)
+				if (INCLUDED)
+					check_fortran_compiler_flag("${FLAG}"
+						COVERAGE_FLAG_DETECTED)
+				elseif (NOT CMAKE_REQUIRED_QUIET)
+					message("-- Performing Test COVERAGE_FLAG_DETECTED")
+					message("-- Performing Test COVERAGE_FLAG_DETECTED - Failed"
+						" (Check not supported)")
+				endif ()
+			endif()
+
+			if (COVERAGE_FLAG_DETECTED)
+				set(COVERAGE_${COMPILER}_FLAGS "${FLAG}"
+					CACHE STRING "${COMPILER} flags for code coverage.")
+				mark_as_advanced(COVERAGE_${COMPILER}_FLAGS)
+				break()
+			else ()
+				message(WARNING "Code coverage is not available for ${COMPILER}"
+				        " compiler. Targets using this compiler will be "
+				        "compiled without it.")
+			endif ()
+		endforeach ()
+	endif ()
+endforeach ()
+
+set(CMAKE_REQUIRED_QUIET ${CMAKE_REQUIRED_QUIET_SAVE})
+
+
+
+
+# Helper function to get the language of a source file.
+function (codecov_lang_of_source FILE RETURN_VAR)
+	get_filename_component(FILE_EXT "${FILE}" EXT)
+	string(TOLOWER "${FILE_EXT}" FILE_EXT)
+	string(SUBSTRING "${FILE_EXT}" 1 -1 FILE_EXT)
+
+	get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+	foreach (LANG ${ENABLED_LANGUAGES})
+		list(FIND CMAKE_${LANG}_SOURCE_FILE_EXTENSIONS "${FILE_EXT}" TEMP)
+		if (NOT ${TEMP} EQUAL -1)
+			set(${RETURN_VAR} "${LANG}" PARENT_SCOPE)
+			return()
+		endif ()
+	endforeach()
+
+	set(${RETURN_VAR} "" PARENT_SCOPE)
+endfunction ()
+
+
+# Helper function to get the relative path of the source file destination path.
+# This path is needed by FindGcov and FindLcov cmake files to locate the
+# captured data.
+function (codecov_path_of_source FILE RETURN_VAR)
+	string(REGEX MATCH "TARGET_OBJECTS:([^ >]+)" _source ${FILE})
+
+	# If expression was found, SOURCEFILE is a generator-expression for an
+	# object library. Currently we found no way to call this function automatic
+	# for the referenced target, so it must be called in the directoryso of the
+	# object library definition.
+	if (NOT "${_source}" STREQUAL "")
+		set(${RETURN_VAR} "" PARENT_SCOPE)
+		return()
+	endif ()
+
+
+	string(REPLACE "${CMAKE_CURRENT_BINARY_DIR}/" "" FILE "${FILE}")
+	if(IS_ABSOLUTE ${FILE})
+		file(RELATIVE_PATH FILE ${CMAKE_CURRENT_SOURCE_DIR} ${FILE})
+	endif()
+
+	# get the right path for file
+	string(REPLACE ".." "__" PATH "${FILE}")
+
+	set(${RETURN_VAR} "${PATH}" PARENT_SCOPE)
+endfunction()
+
+
+
+
+# Add coverage support for target ${TNAME} and register target for coverage
+# evaluation.
+function(add_coverage_target TNAME)
+	# Check if all sources for target use the same compiler. If a target uses
+	# e.g. C and Fortran mixed and uses different compilers (e.g. clang and
+	# gfortran) this can trigger huge problems, because different compilers may
+	# use different implementations for code coverage.
+	get_target_property(TSOURCES ${TNAME} SOURCES)
+	set(TARGET_COMPILER "")
+	set(ADDITIONAL_FILES "")
+	foreach (FILE ${TSOURCES})
+		# If expression was found, FILE is a generator-expression for an object
+		# library. Object libraries will be ignored.
+		string(REGEX MATCH "TARGET_OBJECTS:([^ >]+)" _file ${FILE})
+		if ("${_file}" STREQUAL "")
+			codecov_lang_of_source(${FILE} LANG)
+			if (LANG)
+				list(APPEND TARGET_COMPILER ${CMAKE_${LANG}_COMPILER_ID})
+
+				list(APPEND ADDITIONAL_FILES "${FILE}.gcno")
+				list(APPEND ADDITIONAL_FILES "${FILE}.gcda")
+			endif ()
+		endif ()
+	endforeach ()
+
+	list(REMOVE_DUPLICATES TARGET_COMPILER)
+	list(LENGTH TARGET_COMPILER NUM_COMPILERS)
+
+	if (NUM_COMPILERS GREATER 1)
+		message(WARNING "Can't use code coverage for target ${TNAME}, because "
+		        "it will be compiled by incompatible compilers. Target will be "
+		        "compiled without code coverage.")
+		return()
+
+	elseif (NUM_COMPILERS EQUAL 0)
+		message(WARNING "Can't use code coverage for target ${TNAME}, because "
+		        "it uses an unknown compiler. Target will be compiled without "
+		        "code coverage.")
+		return()
+
+	elseif (NOT DEFINED "COVERAGE_${TARGET_COMPILER}_FLAGS")
+		# A warning has been printed before, so just return if flags for this
+		# compiler aren't available.
+		return()
+	endif()
+
+
+	# enable coverage for target
+	set_property(TARGET ${TNAME} APPEND_STRING
+		PROPERTY COMPILE_FLAGS " ${COVERAGE_${TARGET_COMPILER}_FLAGS}")
+	set_property(TARGET ${TNAME} APPEND_STRING
+		PROPERTY LINK_FLAGS " ${COVERAGE_${TARGET_COMPILER}_FLAGS}")
+
+
+	# Add gcov files generated by compiler to clean target.
+	set(CLEAN_FILES "")
+	foreach (FILE ${ADDITIONAL_FILES})
+		codecov_path_of_source(${FILE} FILE)
+		list(APPEND CLEAN_FILES "CMakeFiles/${TNAME}.dir/${FILE}")
+	endforeach()
+
+	set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES
+		"${CLEAN_FILES}")
+
+
+	add_gcov_target(${TNAME})
+	add_lcov_target(${TNAME})
+endfunction(add_coverage_target)
+
+
+
+
+# Include modules for parsing the collected data and output it in a readable
+# format (like gcov and lcov).
+find_package(Gcov)
+find_package(Lcov)

--- a/cmake/Modules/llvm-cov-wrapper
+++ b/cmake/Modules/llvm-cov-wrapper
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+# This file is part of CMake-codecov.
+#
+# Copyright 2015-2017 RWTH Aachen University, Federal Republic of Germany
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the University of California, Berkeley nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Written by Alexander Haase, alexander.haase@rwth-aachen.de
+#
+
+if [ -z "$LLVM_COV_BIN" ]
+then
+	echo "LLVM_COV_BIN not set!" >& 2
+	exit 1
+fi
+
+
+# Get LLVM version to find out.
+LLVM_VERSION=$($LLVM_COV_BIN -version | grep -i "LLVM version" \
+	| sed "s/^\([A-Za-z ]*\)\([0-9]\).\([0-9]\).*$/\2.\3/g")
+
+if [ "$1" = "-v" ]
+then
+	echo "llvm-cov-wrapper $LLVM_VERSION"
+	exit 0
+fi
+
+
+if [ -n "$LLVM_VERSION" ]
+then
+	MAJOR=$(echo $LLVM_VERSION | cut -d'.' -f1)
+	MINOR=$(echo $LLVM_VERSION | cut -d'.' -f2)
+
+	if [ $MAJOR -eq 3 ] && [ $MINOR -le 4 ]
+	then
+		if [ -f "$1" ]
+		then
+			filename=$(basename "$1")
+			extension="${filename##*.}"
+
+			case "$extension" in
+				"gcno") exec $LLVM_COV_BIN --gcno="$1" ;;
+				"gcda") exec $LLVM_COV_BIN --gcda="$1" ;;
+			esac
+		fi
+	fi
+
+	if [ $MAJOR -eq 3 ] && [ $MINOR -le 5 ]
+	then
+		exec $LLVM_COV_BIN $@
+	fi
+fi
+
+exec $LLVM_COV_BIN gcov $@

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,8 @@
 [requires]
-cunit/2.1-3@bincrafters/stable
+cunit/2.1-3
 
 [generators]
 cmake
+
+[options]
+cunit:shared=True

--- a/examples/helloworld/CMakeLists.txt
+++ b/examples/helloworld/CMakeLists.txt
@@ -25,5 +25,14 @@ add_executable(ddscxxHelloworldSubscriber subscriber.cpp)
 target_link_libraries(ddscxxHelloworldPublisher CycloneDDS-CXX::ddscxx helloworlddata)
 target_link_libraries(ddscxxHelloworldSubscriber CycloneDDS-CXX::ddscxx helloworlddata)
 
+# Disable the static analyzer in GCC to avoid crashing the GNU C++ compiler
+# on Azure Pipelines
+if(DEFINED ENV{SYSTEM_TEAMFOUNDATIONSERVERURI})
+  if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND ANALYZER STREQUAL "on")
+    target_compile_options(ddscxxHelloworldPublisher PRIVATE -fno-analyzer)
+    target_compile_options(ddscxxHelloworldSubscriber PRIVATE -fno-analyzer)
+  endif()
+endif()
+
 set_property(TARGET ddscxxHelloworldPublisher PROPERTY CXX_STANDARD 11)
 set_property(TARGET ddscxxHelloworldSubscriber PROPERTY CXX_STANDARD 11)

--- a/src/ddscxx/CMakeLists.txt
+++ b/src/ddscxx/CMakeLists.txt
@@ -78,6 +78,8 @@ set_target_properties(ddscxx PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${P
 # those targets outside the regular Cyclone build-tree (i.e. the installed tree)
 add_library(${CMAKE_PROJECT_NAME}::ddscxx ALIAS ddscxx)
 
+add_coverage(ddscxx)
+
 target_include_directories(
   ddscxx
   PUBLIC

--- a/src/ddscxx/include/dds/core/policy/TQosPolicyCount.hpp
+++ b/src/ddscxx/include/dds/core/policy/TQosPolicyCount.hpp
@@ -28,6 +28,11 @@ namespace core
 namespace policy
 {
 
+#if defined(__GNUC__) && (__GNUC__ >= 10)
+_Pragma("GCC diagnostic push")
+_Pragma("GCC diagnostic ignored \"-Wanalyzer-null-dereference\"")
+#endif
+
 /**
  * The QosPolicyCount object shows, for a QosPolicy, the total number of
  * times that the concerned DataWriter discovered a DataReader for the
@@ -81,5 +86,9 @@ public:
 }
 }
 }
+
+#if defined(__GNUC__) && (__GNUC__ >= 10)
+_Pragma("GCC diagnostic pop")
+#endif
 
 #endif // !defined(OMG_TDDS_CORE_POLICY_QOS_POLICY_COUNT_HPP_)

--- a/src/ddscxx/include/dds/core/policy/detail/TQosPolicyCountImpl.hpp
+++ b/src/ddscxx/include/dds/core/policy/detail/TQosPolicyCountImpl.hpp
@@ -33,8 +33,17 @@ namespace policy
 template <typename D>
 TQosPolicyCount<D>::TQosPolicyCount(QosPolicyId policy_id, int32_t count) : dds::core::Value<D>(policy_id, count) { }
 
+#if defined(__GNUC__) && (__GNUC__ >= 10)
+_Pragma("GCC diagnostic push")
+_Pragma("GCC diagnostic ignored \"-Wanalyzer-null-dereference\"")
+#endif
+
 template <typename D>
 TQosPolicyCount<D>::TQosPolicyCount(const TQosPolicyCount& other) : dds::core::Value<D>(other.policy_id(), other.count()) { }
+
+#if defined(__GNUC__) && (__GNUC__ >= 10)
+_Pragma("GCC diagnostic pop")
+#endif
 
 template <typename D> QosPolicyId TQosPolicyCount<D>::policy_id() const
 {

--- a/src/ddscxx/include/dds/pub/detail/DataWriterImpl.hpp
+++ b/src/ddscxx/include/dds/pub/detail/DataWriterImpl.hpp
@@ -377,9 +377,11 @@ dds::pub::detail::DataWriter<T>::DataWriter(
     const dds::core::status::StatusMask& mask)
     : ::org::eclipse::cyclonedds::pub::AnyDataWriterDelegate(qos, topic), pub_(pub), topic_(topic)
 {
+    DDSCXX_WARNING_MSVC_OFF(6326)
     if (dds::topic::is_topic_type<T>::value == 0) {
         ISOCPP_THROW_EXCEPTION(ISOCPP_PRECONDITION_NOT_MET_ERROR, "DataWriter cannot be created, topic information not found");
     }
+    DDSCXX_WARNING_MSVC_ON(6326)
 
     org::eclipse::cyclonedds::pub::qos::DataWriterQosDelegate dwQos = qos.delegate();
 

--- a/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
@@ -481,9 +481,11 @@ dds::sub::detail::DataReader<T>::common_constructor(
             const dds::core::status::StatusMask& mask)
 {
     DDSCXX_WARNING_MSVC_OFF(4127)
+    DDSCXX_WARNING_MSVC_OFF(6326)
     if (dds::topic::is_topic_type<T>::value == 0) {
         ISOCPP_THROW_EXCEPTION(ISOCPP_PRECONDITION_NOT_MET_ERROR, "DataReader cannot be created, topic information not found");
     }
+    DDSCXX_WARNING_MSVC_ON(6326)
     DDSCXX_WARNING_MSVC_ON(4127)
 
     org::eclipse::cyclonedds::sub::qos::DataReaderQosDelegate drQos = qos_.delegate();

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/basic_cdr_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/basic_cdr_ser.hpp
@@ -167,12 +167,11 @@ void max(basic_cdr_stream& str, const T& max_sz) {
 * (bound of 0 equals no bound present).
 * Writes length to str as a uint32_t type.
 */
-static void write_length(basic_cdr_stream& str, size_t length, size_t bound)
+static inline void write_length(basic_cdr_stream& str, size_t length, size_t bound)
 {
   //throw an exception if we attempt to write a length field in excess of the supplied bound
-  if (bound &&
-    length > bound)
-    throw 1;  //replace throw
+  if (bound && length > bound)
+    throw 1; // replace throw
 
   write(str, uint32_t(length));
 }
@@ -184,7 +183,7 @@ static void write_length(basic_cdr_stream& str, size_t length, size_t bound)
 * This is not bound checked, to prevent reading of spurious data, which the program has
 * no control over to result in program failure.
 */
-static void read_length(basic_cdr_stream& str, uint32_t& length)
+static inline void read_length(basic_cdr_stream& str, uint32_t& length)
 {
   read(str, length);
 }
@@ -197,12 +196,11 @@ static void read_length(basic_cdr_stream& str, uint32_t& length)
 * (bound of 0 equals no bound present).
 * Moves the stream cursor by a uint32_t representation of the length.
 */
-static void move_length(basic_cdr_stream& str, size_t length, size_t bound)
+static inline void move_length(basic_cdr_stream& str, size_t length, size_t bound)
 {
   //throw an exception if we attempt to move the cursor for a length field in excess of the supplied bound
-  if (bound &&
-    length > bound)
-    throw 2;  //replace throw
+  if (bound && length > bound)
+    throw 2; // replace throw
 
   move(str, uint32_t(length));
 }
@@ -387,7 +385,7 @@ void write(basic_cdr_stream& str, const idl_array<T, N>& towrite)
 * Primitive array move function.
 */
 template<typename T, size_t N, typename = std::enable_if_t<std::is_arithmetic<T>::value> >
-void move(basic_cdr_stream& str, const idl_array<T, N>& toincr)
+void move(basic_cdr_stream& str, const idl_array<T, N>&)
 {
   str.align(sizeof(T), false);
 
@@ -583,7 +581,7 @@ void move(basic_cdr_stream& str, const idl_sequence<T, N>& toincr) {
 * Primitive sequence max function.
 */
 template<typename T, size_t N, typename = std::enable_if_t<std::is_arithmetic<T>::value> >
-void max(basic_cdr_stream& str, const idl_sequence<T, N>& max_sz) {
+void max(basic_cdr_stream& str, const idl_sequence<T, N>&) {
   if (str.position() == SIZE_MAX)
     return;
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/basic_cdr_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/basic_cdr_ser.hpp
@@ -48,13 +48,11 @@ public:
 template<typename T, std::enable_if_t<std::is_arithmetic<T>::value && !std::is_enum<T>::value, bool> = true >
 void read(basic_cdr_stream &str, T& toread)
 {
+  char *cursor = str.get_cursor();
   str.align(sizeof(T), false);
 
-  transfer_and_swap(
-    *(reinterpret_cast<const T*>(str.get_cursor())),
-    toread,
-    str.swap_endianness());
-
+  assert(cursor);
+  transfer_and_swap(*(reinterpret_cast<const T*>(cursor)), toread, str.swap_endianness());
   str.incr_position(sizeof(T));
 }
 
@@ -69,13 +67,11 @@ void read(basic_cdr_stream &str, T& toread)
 template<typename T, std::enable_if_t<std::is_arithmetic<T>::value && !std::is_enum<T>::value, bool> = true >
 void write(basic_cdr_stream& str, const T& towrite)
 {
+  char *cursor = str.get_cursor();
   str.align(sizeof(T), true);
 
-  transfer_and_swap(
-    towrite,
-    *(reinterpret_cast<T*>(str.get_cursor())),
-    str.swap_endianness());
-
+  assert(cursor);
+  transfer_and_swap(towrite, *(reinterpret_cast<T*>(cursor)), str.swap_endianness());
   str.incr_position(sizeof(T));
 }
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/cdr_stream.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/cdr_stream.hpp
@@ -55,8 +55,7 @@ void transfer_and_swap(const T& from, T& to, bool sw) {
 
   to = from;
 
-  if (sw &&
-    sizeof(T) > 1)
+  if (sw && sizeof(T) > 1)
     byte_swap(to);
 }
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/cdr_stream.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/cdr_stream.hpp
@@ -26,6 +26,7 @@ template<typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value> >
 void byte_swap(T& toswap) {
     union { T a; uint16_t u2; uint32_t u4; uint64_t u8; } u;
     u.a = toswap;
+    DDSCXX_WARNING_MSVC_OFF(6326)
     switch (sizeof(T)) {
     case 1:
         break;
@@ -44,6 +45,7 @@ void byte_swap(T& toswap) {
     default:
         throw std::invalid_argument(std::string("attempted byteswap on variable of invalid size: ") + std::to_string(sizeof(T)));
     }
+    DDSCXX_WARNING_MSVC_ON(6326)
     toswap = u.a;
 }
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/MiscUtils.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/MiscUtils.cpp
@@ -65,9 +65,13 @@ org::eclipse::cyclonedds::core::convertStringSeq(
     for(uint32_t i = 0; i < from.size(); i++)
     {
         size_t len = from[i].length();
+        DDSCXX_WARNING_MSVC_OFF(6386)
         to[i] = new char[len + 1];
+        DDSCXX_WARNING_MSVC_ON(6386)
         to[i][len] = '\0';
+        DDSCXX_WARNING_MSVC_OFF(6385)
         memcpy(to[i], from[i].c_str(), len);
+        DDSCXX_WARNING_MSVC_ON(6385)
     }
 }
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/cdr_stream.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/cdr_stream.cpp
@@ -9,27 +9,29 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-
-#include <org/eclipse/cyclonedds/topic/cdr_stream.hpp>
 #include <cstring>
 #include <algorithm>
+#include <assert.h>
+
+#include <org/eclipse/cyclonedds/topic/cdr_stream.hpp>
 
 void cdr_stream::set_buffer(void* toset) {
   m_buffer = static_cast<char*>(toset);
   reset_position();
 }
 
-size_t cdr_stream::align(size_t newalignment, bool add_zeroes) {
+size_t cdr_stream::align(size_t newalignment, bool add_zeroes)
+{
   if (m_current_alignment == newalignment)
     return 0;
 
   m_current_alignment = std::min(newalignment, m_max_alignment);
 
+  char *cursor = get_cursor();
+  assert(cursor);
   size_t tomove = (m_current_alignment - m_position % m_current_alignment) % m_current_alignment;
-  if (tomove &&
-    add_zeroes &&
-    m_buffer)
-    memset(get_cursor(), 0, tomove);
+  if (tomove && add_zeroes && m_buffer)
+    memset(cursor, 0, tomove);
 
   m_position += tomove;
 

--- a/src/idlcxx/CMakeLists.txt
+++ b/src/idlcxx/CMakeLists.txt
@@ -22,6 +22,8 @@ target_link_libraries(idlcxx PUBLIC CycloneDDS::idl)
 
 add_library(${PROJECT_NAME}::idlcxx ALIAS idlcxx)
 
+add_coverage(idlcxx)
+
 install(
   TARGETS idlcxx
   EXPORT "${CMAKE_PROJECT_NAME}"

--- a/src/idlcxx/CMakeLists.txt
+++ b/src/idlcxx/CMakeLists.txt
@@ -31,4 +31,9 @@ install(
   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT idlcxx
   ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT idlcxx)
 
+install(
+  FILES Generate.cmake
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/idlcxx"
+  COMPONENT idlcxx)
+
 include(Generate.cmake)

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -635,6 +635,7 @@ idl_retcode_t generate(const idl_pstate_t *pstate)
   assert(pstate->paths);
   assert(pstate->paths->name);
   path = pstate->sources->path->name;
+  assert(path);
 
   /* use relative directory if user provided a relative path, use current
      word directory otherwise */

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -46,7 +46,9 @@ static int makefmtp(
   do {
     if (tok) {
       if (str[src] == '}' && (num = istok(str+tok, src-tok, toks))) {
-        const char *flag = flags[num-1];
+        const char *flag;
+        assert(toks && flags);
+        flag = flags[num-1];
         len += (size_t)snprintf(buf, sizeof(buf), FMT, num, flag);
         tok = 0;
       } else if (str[src] == '}' || str[src] == '\0') {
@@ -69,7 +71,9 @@ static int makefmtp(
   do {
     if (tok) {
       if (str[src] == '}' && (num = istok(str+tok, src-tok, toks))) {
-        const char *flag = flags[num-1];
+        const char *flag;
+        assert(toks && flags);
+        flag = flags[num-1];
         dest += (size_t)snprintf(&fmt[dest], (len-dest)+1, FMT, num, flag);
         tok = 0;
       } else if (str[src] == '}' || str[src] == '\0') {
@@ -510,7 +514,6 @@ static idl_retcode_t print_guard_endif(FILE *fh, const char *guard)
 
 static idl_retcode_t print_includes(FILE *fh, const idl_source_t *source)
 {
-  idl_retcode_t ret;
   char *sep = NULL, *path;
   const idl_source_t *include;
 
@@ -525,7 +528,7 @@ static idl_retcode_t print_includes(FILE *fh, const idl_source_t *source)
   for (include = source->includes; include; include = include->next) {
     int cnt;
     char *ext, *relpath = NULL;
-    if ((ret = idl_relative_path(path, include->path->name, &relpath)))
+    if (idl_relative_path(path, include->path->name, &relpath))
       goto err_relpath;
     ext = relpath;
     for (char *ptr = ext; *ptr; ptr++) {

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -509,6 +509,7 @@ generate_streamers(const idl_pstate_t* pstate, struct generator *gen)
   idl_retcode_t ret;
   struct streams streams;
   idl_visitor_t visitor;
+  const char *sources[] = { NULL, NULL };
 
   memset(&streams, 0, sizeof(streams));
   memset(&visitor, 0, sizeof(visitor));
@@ -523,7 +524,8 @@ generate_streamers(const idl_pstate_t* pstate, struct generator *gen)
   visitor.accept[IDL_ACCEPT_SWITCH_TYPE_SPEC] = &process_switch_type_spec;
   visitor.accept[IDL_ACCEPT_INHERIT_SPEC] = &process_inherit_spec;
   if (pstate->sources)
-    visitor.sources = (const char *[]){ pstate->sources->path->name, NULL };
+    sources[0] = pstate->sources->path->name;
+  visitor.sources = sources;
 
   if ((ret = idl_visit(pstate, pstate->root, &visitor, &streams)) == IDL_RETCODE_OK)
     ret = flush(gen, &streams);

--- a/src/idlcxx/src/traits.c
+++ b/src/idlcxx/src/traits.c
@@ -113,6 +113,7 @@ generate_traits(const idl_pstate_t *pstate, struct generator *generator)
   idl_retcode_t ret;
   idl_visitor_t visitor;
   const char *fmt;
+  const char *sources[] = { NULL, NULL };
 
   fmt = "#include \"org/eclipse/cyclonedds/topic/TopicTraits.hpp\"\n"
         "#include \"org/eclipse/cyclonedds/topic/DataRepresentation.hpp\"\n\n"
@@ -127,7 +128,8 @@ generate_traits(const idl_pstate_t *pstate, struct generator *generator)
   visitor.visit = IDL_STRUCT;
   visitor.accept[IDL_ACCEPT_STRUCT] = &emit_traits;
   if (pstate->sources)
-    visitor.sources = (const char *[]){ pstate->sources->path->name, NULL };
+    sources[0] = pstate->sources->path->name;
+  visitor.sources = sources;
   if ((ret = idl_visit(pstate, pstate->root, &visitor, generator)))
     return ret;
 

--- a/src/idlcxx/src/types.c
+++ b/src/idlcxx/src/types.c
@@ -716,6 +716,7 @@ idl_retcode_t
 generate_types(const idl_pstate_t *pstate, struct generator *generator)
 {
   idl_visitor_t visitor;
+  const char *sources[] = { NULL, NULL };
 
   memset(&visitor, 0, sizeof(visitor));
   visitor.visit = IDL_CONST | IDL_TYPEDEF | IDL_STRUCT | IDL_MODULE | IDL_ENUM | IDL_UNION;
@@ -726,7 +727,8 @@ generate_types(const idl_pstate_t *pstate, struct generator *generator)
   visitor.accept[IDL_ACCEPT_ENUM] = &emit_enum;
   visitor.accept[IDL_ACCEPT_MODULE] = &emit_module;
   if (pstate->sources)
-    visitor.sources = (const char *[]){ pstate->sources->path->name, NULL };
+    sources[0] = pstate->sources->path->name;
+  visitor.sources = sources;
 
   return idl_visit(pstate, pstate->root, &visitor, generator);
 }


### PR DESCRIPTION
This PR adds build instructions for Azure Pipelines (including static analyzer checking (and fixes) for GCC, Clang-Tidy and the infamous random warning generator).