### PR TITLE
Fix idlcxx_generate, make assert in alignment conditional and finish up unions

### DIFF
--- a/examples/helloworld/CMakeLists.txt
+++ b/examples/helloworld/CMakeLists.txt
@@ -34,5 +34,5 @@ if(DEFINED ENV{SYSTEM_TEAMFOUNDATIONSERVERURI})
   endif()
 endif()
 
-set_property(TARGET ddscxxHelloworldPublisher PROPERTY CXX_STANDARD 11)
-set_property(TARGET ddscxxHelloworldSubscriber PROPERTY CXX_STANDARD 11)
+set_property(TARGET ddscxxHelloworldPublisher PROPERTY CXX_STANDARD 17)
+set_property(TARGET ddscxxHelloworldSubscriber PROPERTY CXX_STANDARD 17)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,9 +10,6 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 
-IF (WIN32)
-  add_compile_options(/wd4251 /wd4250)
-ENDIF()
 
 add_subdirectory(ddscxx)
 add_subdirectory(idlcxx)

--- a/src/ddscxx/CMakeLists.txt
+++ b/src/ddscxx/CMakeLists.txt
@@ -87,7 +87,7 @@ target_include_directories(
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ddscxx>)
 
-set_property(TARGET ddscxx PROPERTY CXX_STANDARD 11)
+set_property(TARGET ddscxx PROPERTY CXX_STANDARD 17)
 target_link_libraries(ddscxx PUBLIC CycloneDDS::ddsc)
 
 generate_export_header(

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/cdr_stream.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/cdr_stream.cpp
@@ -27,11 +27,12 @@ size_t cdr_stream::align(size_t newalignment, bool add_zeroes)
 
   m_current_alignment = std::min(newalignment, m_max_alignment);
 
-  char *cursor = get_cursor();
-  assert(cursor);
   size_t tomove = (m_current_alignment - m_position % m_current_alignment) % m_current_alignment;
-  if (tomove && add_zeroes && m_buffer)
+  if (tomove && add_zeroes && m_buffer) {
+    char *cursor = get_cursor();
+    assert(cursor);
     memset(cursor, 0, tomove);
+  }
 
   m_position += tomove;
 

--- a/src/idlcxx/Generate.cmake
+++ b/src/idlcxx/Generate.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020 ADLINK Technology Limited and others
+# Copyright(c) 2021 ADLINK Technology Limited and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -10,31 +10,59 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 function(IDLCXX_GENERATE)
-  cmake_parse_arguments(IDLCXX "" "TARGET" "FILES" "" ${ARGN})
+  set(one_value_keywords TARGET)
+  set(multi_value_keywords FILES FEATURES)
+  cmake_parse_arguments(
+    IDLCXX "" "${one_value_keywords}" "${multi_value_keywords}" "" ${ARGN})
+
+  if(NOT IDLCXX_TARGET AND NOT IDLCXX_FILES)
+    # assume deprecated invocation: TARGET FILE [FILE..]
+    list(GET IDLCXX_UNPARSED_ARGUMENTS 0 IDLCXX_TARGET)
+    list(REMOVE_AT IDLCXX_UNPARSED_ARGUMENTS 0)
+    set(IDLCXX_FILES ${IDLCXX_UNPARSED_ARGUMENTS})
+    if (IDLCXX_TARGET AND IDLCXX_FILES)
+      message(WARNING " Deprecated use of idlcxx_generate. \n"
+                      " Consider switching to keyword based invocation.")
+    endif()
+    # Java based compiler used to be case sensitive
+    list(APPEND IDLCXX_FEATURES "case-sensitive")
+  endif()
 
   if(NOT IDLCXX_TARGET)
-    message(FATAL_ERROR "idlcxx_generate was called without TARGET")
+    message(FATAL_ERROR "idlcxx_generate called without TARGET")
+  elseif(NOT IDLCXX_FILES)
+    message(FATAL_ERROR "idlcxx_generate called without FILES")
   endif()
-  if(NOT IDLCXX_FILES)
-    message(FATAL_ERROR "idlcxx_generate was called without FILES")
+
+  # remove duplicate features
+  if(IDLCXX_FEATURES)
+    list(REMOVE_DUPLICATES IDLCXX_FEATURES)
   endif()
+  foreach(_feature ${IDLCXX_FEATURES})
+    list(APPEND IDLCXX_ARGS "-f" ${_feature})
+  endforeach()
 
   set(_dir ${CMAKE_CURRENT_BINARY_DIR})
   set(_target ${IDLCXX_TARGET})
   foreach(_file ${IDLCXX_FILES})
     get_filename_component(_path ${_file} ABSOLUTE)
+    list(APPEND _files "${_path}")
+  endforeach()
+
+  foreach(_file ${_files})
     get_filename_component(_name ${_file} NAME_WE)
     set(_header "${_dir}/${_name}.hpp")
     list(APPEND _headers "${_header}")
     add_custom_command(
-      OUTPUT "${_header}"
-      COMMAND $<TARGET_FILE:CycloneDDS::idlc>
-      ARGS -l $<TARGET_FILE:CycloneDDS-CXX::idlcxx> ${_path})
+      OUTPUT   "${_header}"
+      COMMAND  CycloneDDS::idlc
+      ARGS     -l $<TARGET_FILE:CycloneDDS-CXX::idlcxx> ${IDLCXX_ARGS} ${_file}
+      DEPENDS  ${_files} CycloneDDS::idlc CycloneDDS-CXX::idlcxx)
   endforeach()
 
-  add_custom_target("${_target}_generate" DEPENDS ${_sources} ${_headers})
+  add_custom_target("${_target}_generate" DEPENDS ${_headers})
   add_library(${_target} INTERFACE)
-  target_sources(${_target} INTERFACE ${_sources} ${_headers})
+  target_sources(${_target} INTERFACE ${_headers})
   target_include_directories(${_target} INTERFACE "${_dir}")
+  add_dependencies(${_target} "${_target}_generate")
 endfunction()
-

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -740,18 +740,6 @@ static const char *bnd_seq_flags[] = { "s", PRIu32, NULL };
 static const char *bnd_str_toks[] = { "BOUND", NULL };
 static const char *bnd_str_flags[] = { PRIu32, NULL };
 
-static FILE *open_file(const char *pathname, const char *mode)
-{
-#if _WIN32
-  FILE *handle = NULL;
-  if (fopen_s(&handle, pathname, mode) != 0)
-    return NULL;
-  return handle;
-#else
-  return fopen(pathname, mode);
-#endif
-}
-
 #if _WIN32
 __declspec(dllexport)
 #endif
@@ -797,7 +785,7 @@ idl_retcode_t generate(const idl_pstate_t *pstate)
   sep = dir[0] == '\0' ? "" : "/";
   if (idl_asprintf(&gen.header.path, "%s%s%s.hpp", dir, sep, basename) < 0)
     goto err_hdr;
-  if (!(gen.header.handle = open_file(gen.header.path, "wb")))
+  if (!(gen.header.handle = idl_fopen(gen.header.path, "wb")))
     goto err_hdr_fh;
 
   /* generate format strings from templates */

--- a/src/idlcxx/src/generator.h
+++ b/src/idlcxx/src/generator.h
@@ -29,6 +29,15 @@ struct generator {
   char *union_format;
   char *union_getter_format;
   const char *union_include;
+  bool uses_array;
+  bool uses_sequence;
+  bool uses_bounded_sequence;
+  bool uses_string;
+  bool uses_bounded_string;
+  bool uses_union;
+#if 0
+  bool uses_optional;
+#endif
   struct {
     FILE *handle;
     char *path;

--- a/src/idlcxx/src/traits.c
+++ b/src/idlcxx/src/traits.c
@@ -127,8 +127,8 @@ generate_traits(const idl_pstate_t *pstate, struct generator *generator)
   memset(&visitor, 0, sizeof(visitor));
   visitor.visit = IDL_STRUCT;
   visitor.accept[IDL_ACCEPT_STRUCT] = &emit_traits;
-  if (pstate->sources)
-    sources[0] = pstate->sources->path->name;
+  assert(pstate->sources);
+  sources[0] = pstate->sources->path->name;
   visitor.sources = sources;
   if ((ret = idl_visit(pstate, pstate->root, &visitor, generator)))
     return ret;


### PR DESCRIPTION
* `idlcxx_generate` didn't add a dependency on the right target causing parallel Windows builds, like our CI builds, to fail.
* Aparently the cursor is always NULL in alignment of the CDR stream initially, or at least, it depends on the `add_zeroes` parameter. This PR corrects that.
* Union support depended on something not yet available in the IDL tree structure, namely the number of unused labels. [PR 784](https://github.com/eclipse-cyclonedds/cyclonedds/pull/784) in the *cyclonedds* repository fixes that. (until that one is merged, this PR will fail to build).