### PR TITLE
Fix clang12 warnings on destructor naming

### DIFF
--- a/src/ddscxx/include/dds/core/detail/ReferenceImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/ReferenceImpl.hpp
@@ -55,7 +55,7 @@ dds::core::Reference<DELEGATE>::Reference(const DELEGATE_REF_T& p) : impl_(p)
 }
 
 template <typename DELEGATE>
-dds::core::Reference<DELEGATE>::~Reference()
+dds::core::Reference<DELEGATE>::~Reference<DELEGATE>()
 {
 }
 

--- a/src/ddscxx/include/dds/core/detail/TEntityImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/TEntityImpl.hpp
@@ -26,7 +26,7 @@
 // Implementation
 
 template <typename DELEGATE>
-dds::core::TEntity<DELEGATE>::~TEntity()
+dds::core::TEntity<DELEGATE>::~TEntity<DELEGATE>()
 {
 }
 

--- a/src/ddscxx/include/dds/pub/detail/DataWriterImpl.hpp
+++ b/src/ddscxx/include/dds/pub/detail/DataWriterImpl.hpp
@@ -62,7 +62,7 @@ DataWriter<T, DELEGATE>::DataWriter(const dds::pub::Publisher& pub,
 }
 
 template <typename T, template <typename Q> class DELEGATE>
-DataWriter<T, DELEGATE>::~DataWriter()
+DataWriter<T, DELEGATE>::~DataWriter<T, DELEGATE>()
 {
 }
 
@@ -405,7 +405,7 @@ dds::pub::detail::DataWriter<T>::DataWriter(
 }
 
 template <typename T>
-dds::pub::detail::DataWriter<T>::~DataWriter()
+dds::pub::detail::DataWriter<T>::~DataWriter<T>()
 {
     if (!this->closed) {
         try {

--- a/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
@@ -291,7 +291,7 @@ DataReader<T, DELEGATE>::DataReader(
 #endif /* OMG_DDS_MULTI_TOPIC_SUPPORT */
 
 template <typename T, template <typename Q> class DELEGATE>
-DataReader<T, DELEGATE>::~DataReader() { }
+DataReader<T, DELEGATE>::~DataReader<T, DELEGATE>() { }
 
 template <typename T, template <typename Q> class DELEGATE>
 dds::sub::status::DataState
@@ -514,7 +514,7 @@ dds::sub::detail::DataReader<T>::common_constructor(
 }
 
 template <typename T>
-dds::sub::detail::DataReader<T>::~DataReader()
+dds::sub::detail::DataReader<T>::~DataReader<T>()
 {
     if (!this->closed) {
         try {

--- a/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
@@ -205,7 +205,7 @@ dds::topic::detail::Topic<T>::Topic(const dds::domain::DomainParticipant& dp,
 
 
 template <typename T>
-dds::topic::detail::Topic<T>::~Topic()
+dds::topic::detail::Topic<T>::~Topic<T>()
 {
     if (!closed) {
         try {


### PR DESCRIPTION
This eliminates a warning that I get since switching to Clang 12:

```
../src/ddscxx/include/dds/core/detail/TEntityImpl.hpp:29:29: warning: ISO C++ requires the name after '::~' to be found in the same scope as the name before '::~' [-Wdtor-name]
dds::core::TEntity<DELEGATE>::~TEntity()
~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```

It don't really see how this warning and this change could have anything to do with each other because in my mind template parameters are not part of the name, but with everything still compiling and the warning gone, I suppose it must be ok.