### PR TITLE
improvements to templated streaming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -196,7 +196,7 @@ before_script:
   - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
 
 build_cyclonedds: &build_cyclonedds
-  - eval "export CYCLONEDDS_BRANCH=idlcxx"
+  - eval "export CYCLONEDDS_BRANCH=master"
   - eval "export CYCLONEDDS_REPOSITORY=https://github.com/eclipse-cyclonedds/cyclonedds.git"
   - git clone --single-branch --branch ${CYCLONEDDS_BRANCH} ${CYCLONEDDS_REPOSITORY} cyclonedds
   - mkdir cyclonedds/build

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/basic_cdr_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/basic_cdr_ser.hpp
@@ -14,7 +14,7 @@
 
 #include "cdr_stream.hpp"
 #include <org/eclipse/cyclonedds/core/type_helpers.hpp>
-#include <stdexcept>
+#include <dds/core/Exception.hpp>
 #include <array>
 #include <vector>
 #include <string>
@@ -154,75 +154,6 @@ void max(basic_cdr_stream& str, const T& max_sz) {
   max(str, uint32_t(max_sz));
 }
 
-/**
-* Stream length field manipulation functions.
-* Functions for reading/writing length fields for objects like sequences/strings.
-*/
-
-/**
-* Bound checked length field write function.
-*
-* Will check whether a bound is present for this length field, and will throw
-* an exception if a length is attempted to be written which exceeds this
-* (bound of 0 equals no bound present).
-* Writes length to str as a uint32_t type.
-*/
-static inline void write_length(basic_cdr_stream& str, size_t length, size_t bound)
-{
-  //throw an exception if we attempt to write a length field in excess of the supplied bound
-  if (bound && length > bound)
-    throw 1; // replace throw
-
-  write(str, uint32_t(length));
-}
-
-/**
-* Length field read function.
-*
-* Reads length from the stream.
-* This is not bound checked, to prevent reading of spurious data, which the program has
-* no control over to result in program failure.
-*/
-static inline void read_length(basic_cdr_stream& str, uint32_t& length)
-{
-  read(str, length);
-}
-
-/**
-* Bounds checked length field move function.
-*
-* Will check whether a bound is present for this length field, and will throw
-* an exception if a length is attempted to be written which exceeds this
-* (bound of 0 equals no bound present).
-* Moves the stream cursor by a uint32_t representation of the length.
-*/
-static inline void move_length(basic_cdr_stream& str, size_t length, size_t bound)
-{
-  //throw an exception if we attempt to move the cursor for a length field in excess of the supplied bound
-  if (bound && length > bound)
-    throw 2; // replace throw
-
-  move(str, uint32_t(length));
-}
-
-/**
-* Bounded vector length read and resize combo function.
-*
-* Reads the length field from str into seq_length, but only increases the size of 
-* toread by at most N if this is not 0.
-*/
-template<typename T, size_t N>
-void read_vec_resize(basic_cdr_stream& str, idl_sequence<T, N>& toread, uint32_t& seq_length)
-{
-  //the length of the entries contained in the stream is read, but...
-  read_length(str, seq_length);
-
-  //the container is only enlarged upto its maximum size
-  auto read_length = std::min<size_t>(seq_length, N ? N : SIZE_MAX);
-
-  toread.resize(read_length);
-}
-
 /*
 * String type stream manipulation functions
 *
@@ -237,17 +168,20 @@ void read_vec_resize(basic_cdr_stream& str, idl_sequence<T, N>& toread, uint32_t
 * Reads the length from str, but then initializes toread with at most N characters from it.
 * It does move the cursor by length read, since that is the number of characters in the stream.
 */
-template<size_t N>
-void read(basic_cdr_stream& str, idl_string<N>& toread)
+template<typename T>
+void read_string(basic_cdr_stream& str, T& toread, size_t N)
 {
   uint32_t string_length = 0;
 
-  read_length(str, string_length);
+  read(str, string_length);
 
   auto cursor = str.get_cursor();
   toread.assign(cursor, cursor + std::min<size_t>(string_length - 1, N ? N : SIZE_MAX));  //remove 1 for terminating NULL
 
   str.incr_position(string_length);
+
+  //aligned to chars
+  str.alignment(1);
 }
 
 /**
@@ -256,18 +190,23 @@ void read(basic_cdr_stream& str, idl_string<N>& toread)
 * Attempts to write the length of towrite to str, where the bound is checked.
 * Then writes the contents of towrite to str.
 */
-template<size_t N>
-void write(basic_cdr_stream& str, const idl_string<N>& towrite)
+template<typename T>
+void write_string(basic_cdr_stream& str, const T& towrite, size_t N)
 {
   size_t string_length = towrite.length() + 1;  //add 1 extra for terminating NULL
 
-  write_length(str, string_length, N);
+  //throw an exception if we attempt to write a length field in excess of the supplied bound
+  if (N && string_length > N)
+    throw dds::core::InvalidDataError("Attempt to write string with length " + std::to_string(string_length) + " exceeding maximum length of " + std::to_string(N) + ".");
 
-  //no check on string length necessary after this since it is already checked in write_length
+  write(str, uint32_t(string_length));
 
   memcpy(str.get_cursor(), towrite.c_str(), string_length);
 
   str.incr_position(string_length);
+
+  //aligned to chars
+  str.alignment(1);
 }
 
 /**
@@ -276,16 +215,21 @@ void write(basic_cdr_stream& str, const idl_string<N>& towrite)
 * Attempts to move the cursor for the length field, where the bound is checked.
 * Then moves the cursor for the length of the string.
 */
-template<size_t N>
-void move(basic_cdr_stream& str, const idl_string<N>& toincr)
+template<typename T>
+void move_string(basic_cdr_stream& str, const T& toincr, size_t N)
 {
   size_t string_length = toincr.length() + 1;  //add 1 extra for terminating NULL
 
-  move_length(str, string_length, N);
+  //throw an exception if we attempt to move the cursor for a length field in excess of the supplied bound
+  if (N && string_length > N)
+    throw dds::core::InvalidDataError("Attempt to move cursor for string with length " + std::to_string(string_length) + " exceeding maximum length of " + std::to_string(N) + ".");
 
-  //no check on string length necessary after this since it is already checked in incr_length
+  move(str, uint32_t(string_length));
 
   str.incr_position(string_length);
+
+  //aligned to chars
+  str.alignment(1);
 }
 
 /**
@@ -295,8 +239,8 @@ void move(basic_cdr_stream& str, const idl_string<N>& toincr)
 * is done if the cursor is already at its maximum position, and that the cursor
 * is set to its maximum position if the bound is equal to 0 (unbounded).
 */
-template<size_t N>
-void max(basic_cdr_stream& str, const idl_string<N>& max_sz)
+template<typename T>
+void max_string(basic_cdr_stream& str, const T& max_sz, size_t N)
 {
   (void)max_sz;
 
@@ -315,363 +259,9 @@ void max(basic_cdr_stream& str, const idl_string<N>& max_sz)
 
     //bounded string, length maximum N+1 characters
     str.incr_position(N + 1);
-  }
-}
 
-/**
-* Array type stream manipulation functions.
-*/
-
-/**
-* Arrays of primitive types.
-*
-* These are "endpoints" for write functions, since compound
-* (sequence/array/constructed type) functions will consist of these
-* calls.
-*/
-
-/**
-* Primitive array read function.
-*
-* Copies the entire array to toread with a single memcpy, since there
-* are no structures to be unpacked.
-*/
-template<typename T, size_t N, typename = std::enable_if_t<std::is_arithmetic<T>::value> >
-void read(basic_cdr_stream& str, idl_array<T, N>& toread)
-{
-  str.align(sizeof(T), false);
-
-  memcpy(toread.data(), str.get_cursor(), N*sizeof(T));
-
-  if (sizeof(T) > 1 &&
-    str.swap_endianness())
-  {
-    for (auto& e : toread)
-      byte_swap(e);
-  }
-
-  str.incr_position(N * sizeof(T));
-}
-
-/**
-* Primitive array write function.
-*
-* Copies the entire array to toread with a single memcpy, since there
-* are no structures to be unpacked.
-*/
-template<typename T, size_t N, typename = std::enable_if_t<std::is_arithmetic<T>::value> >
-void write(basic_cdr_stream& str, const idl_array<T, N>& towrite)
-{
-  str.align(sizeof(T), false);
-
-  memcpy(str.get_cursor(), towrite.data(), N * sizeof(T));
-
-  if (sizeof(T) > 1 &&
-    str.swap_endianness())
-  {
-    for (size_t i = 0; i < N; i++)
-    {
-      byte_swap(*static_cast<T*>(str.get_cursor()));
-      str.incr_position(sizeof(T));
-    }
-  }
-  else
-  {
-    str.incr_position(N * sizeof(T));
-  }
-}
-
-/**
-* Primitive array move function.
-*/
-template<typename T, size_t N, typename = std::enable_if_t<std::is_arithmetic<T>::value> >
-void move(basic_cdr_stream& str, const idl_array<T, N>&)
-{
-  str.align(sizeof(T), false);
-
-  str.incr_position(N * sizeof(T));
-}
-
-/**
-* Primitive array max move function.
-*/
-template<typename T, size_t N, typename = std::enable_if_t<std::is_arithmetic<T>::value> >
-void max(basic_cdr_stream& str, const idl_array<T, N>& max_sz)
-{
-  (void)max_sz;
-
-  if (str.position() == SIZE_MAX)
-    return;
-
-  str.align(sizeof(T), false);
-
-  str.incr_position(N * sizeof(T));
-}
-
-/**
-* Arrays of complex types.
-*
-* All these functions do is call more "derived" type functions.
-*/
-
-/**
-* Complex type array read function.
-*/
-template<typename T, size_t N>
-void read(basic_cdr_stream& str, idl_array<T, N>& toread)
-{
-  for (auto& e : toread)
-    read(str, e);
-}
-
-/**
-* Complex type array write function.
-*/
-template<typename T, size_t N>
-void write(basic_cdr_stream& str, const idl_array<T, N>& towrite)
-{
-  for (const auto& e : towrite)
-    write(str, e);
-}
-
-/**
-* Complex type array move function.
-*/
-template<typename T, size_t N>
-void move(basic_cdr_stream& str, const idl_array<T, N>& toincr)
-{
-  for (const auto& e : toincr)
-    move(str, e);
-}
-
-/**
-* Complex type array max function.
-*/
-template<typename T, size_t N>
-void max(basic_cdr_stream& str, const idl_array<T, N>& max_sz)
-{
-  if (str.position() == SIZE_MAX)
-    return;
-
-  for (const auto & e:max_sz)
-    max(str, e);
-}
-
-/**
-* Sequence type stream manipulation functions.
-*
-* These attempt to manipulate the sequence length field,
-* and then do the appropriate actions for the sequence
-* fields.
-*/
-
-/**
-* Sequences of primitive types.
-*
-* These are "endpoints" for write functions, since compound
-* (sequence/array/constructed type) functions will consist of these
-* calls.
-*/
-
-/**
-* Read function for sequences of bools, since the std::vector<bool> is also specialized, and direct copy will not give a happy result.
-*/
-template<size_t N>
-void read(basic_cdr_stream& str, idl_sequence<bool, N>& toread) {
-  uint32_t seq_length = 0;  //this is the sequence length retrieved from the stream, not the number of entities to be written to the sequence object
-  read_vec_resize(str, toread, seq_length);
-
-  for (auto& b : toread)
-  {
-    if (*(str.get_cursor()))
-      b = true;
-    else
-      b = false;
-    str.incr_position(1);
-  }
-
-  if (N &&
-    seq_length > N)
-    str.incr_position(seq_length-N);
-}
-
-/**
-* Primitive sequence read function.
-*/
-template<typename T, size_t N, typename = std::enable_if_t<std::is_arithmetic<T>::value> >
-void read(basic_cdr_stream& str, idl_sequence<T, N>& toread) {
-  uint32_t seq_length = 0;  //this is the sequence length retrieved from the stream, not the number of entities to be written to the sequence object
-  read_vec_resize(str, toread, seq_length);
-
-  str.align(sizeof(T), false);
-
-  memcpy(toread.data(), str.get_cursor(), toread.size() * sizeof(T));
-
-  if (sizeof(T) > 1 &&
-    str.swap_endianness())
-  {
-    for (auto & e:toread)
-      byte_swap(e);
-  }
-
-  str.incr_position(seq_length * sizeof(T));
-}
-
-/**
-* Write function for sequences of bools, since the std::vector<bool> is also specialized, and direct copy will not give a happy result.
-*/
-template<size_t N>
-void write(basic_cdr_stream& str, const idl_sequence<bool, N>& towrite) {
-  write_length(str, towrite.size(), N);
-
-  //no check on length necessary after this point, it is done in the write_length function
-
-  str.alignment(1);
-
-  for (const auto& b : towrite)
-  {
-    *(str.get_cursor()) = b ? 0x1 : 0x0;
-    str.incr_position(1);
-  }
-}
-
-/**
-* Primitive sequence write function.
-*/
-template<typename T, size_t N, typename = std::enable_if_t<std::is_arithmetic<T>::value> >
-void write(basic_cdr_stream& str, const idl_sequence<T, N>& towrite) {
-  write_length(str, towrite.size(), N);
-
-  //no check on length necessary after this point, it is done in the write_length function
-
-  str.align(sizeof(T), true);
-
-  memcpy(str.get_cursor(), towrite.data(), towrite.size() * sizeof(T));
-
-  if (sizeof(T) > 1 &&
-    str.swap_endianness())
-  {
-    for (size_t i = 0; i < towrite.size(); i++)
-    {
-      byte_swap(*static_cast<T*>(str.get_cursor()));
-      str.incr_position(sizeof(T));
-    }
-  }
-  else
-  {
-    str.incr_position(towrite.size() * sizeof(T));
-  }
-}
-
-/**
-* Primitive sequence move function.
-*/
-template<typename T, size_t N, typename = std::enable_if_t<std::is_arithmetic<T>::value> >
-void move(basic_cdr_stream& str, const idl_sequence<T, N>& toincr) {
-  move_length(str, toincr.size(), N);
-
-  //no check on length necessary after this point, it is done in the incr_length function
-
-  str.align(sizeof(T), false);
-
-  str.incr_position(toincr.size() * sizeof(T));
-}
-
-/**
-* Primitive sequence max function.
-*/
-template<typename T, size_t N, typename = std::enable_if_t<std::is_arithmetic<T>::value> >
-void max(basic_cdr_stream& str, const idl_sequence<T, N>&) {
-  if (str.position() == SIZE_MAX)
-    return;
-
-  if (N == 0)
-  {
-    str.position(SIZE_MAX);
-  }
-  else
-  {
-    max(str, uint32_t(0));
-
-    str.align(sizeof(T), false);
-
-    str.incr_position(N * sizeof(T));
-  }
-}
-
-/*
-* Sequences of complex types stream manipulation functions.
-*
-* These functions just call the more basic implementation functions.
-*/
-
-/**
-* Complex type sequence read function.
-*/
-template<typename T, size_t N>
-void read(basic_cdr_stream& str, idl_sequence<T, N>& toread) {
-  uint32_t seq_length = 0;  //this is the sequence length of entities in the stream, not the number of entities to be read to the sequence
-  read_vec_resize(str, toread, seq_length);
-
-  for (auto& e : toread)
-    read(str, e);
-
-  //dummy reads
-  for (size_t i = N; i < static_cast<size_t>(seq_length); i++)
-  {
-    T dummy;
-    read(str, dummy);
-  }
-}
-
-/**
-* Complex type sequence write function.
-*/
-template<typename T, size_t N>
-void write(basic_cdr_stream& str, const idl_sequence<T, N>& towrite) {
-  write_length(str, towrite.size(), N);
-
-  //no check on length necessary after this point, it is done in the write_length function
-
-  for (const auto& e : towrite)
-    write(str, e);
-}
-
-/**
-* Complex type sequence read function.
-*/
-template<typename T, size_t N>
-void move(basic_cdr_stream& str, const idl_sequence<T, N>& toincr) {
-  move_length(str, toincr.size(), N);
-
-  //no check on length necessary after this point, it is done in the incr_length function
-
-  for (const auto& e : toincr)
-    move(str, e);
-}
-
-/**
-* Complex type sequence read function.
-*/
-template<typename T, size_t N>
-void max(basic_cdr_stream& str, const idl_sequence<T, N>& max_sz)
-{
-  (void)max_sz;
-
-  if (str.position() == SIZE_MAX)
-    return;
-
-  if (N == 0)
-  {
-    str.position(SIZE_MAX);
-  }
-  else
-  {
-    max(str, uint32_t(0));
-
-    T dummy;
-    for (size_t i = 0; i < N; i++)
-      max(str, dummy);
+    //aligned to chars
+    str.alignment(1);
   }
 }
 

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -635,7 +635,7 @@ generate_includes(const idl_pstate_t *pstate, struct generator *generator)
         ext = ptr;
     }
     if (ext > relpath && idl_strcasecmp(ext, ".idl") == 0) {
-      const char *fmt = "#include \"%.*s.h\"\n";
+      const char *fmt = "#include \"%.*s.hpp\"\n";
       int len = (int)(ext - relpath);
       cnt = idl_fprintf(generator->header.handle, fmt, len, relpath);
     } else {

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -717,16 +717,16 @@ err_print:
   return ret;
 }
 
-const char *seq_tmpl = "idl_sequence<{TYPE}, 0>";
-const char *seq_inc = "<org/eclipse/cyclonedds/topic/cdr_dummys.hpp>";
-const char *arr_tmpl = "idl_array<{TYPE}, {DIMENSION}>";
-const char *arr_inc = "<org/eclipse/cyclonedds/topic/cdr_dummys.hpp>";
-const char *bnd_seq_tmpl = "idl_sequence<{TYPE}, {BOUND}>";
-const char *bnd_seq_inc = "<org/eclipse/cyclonedds/topic/cdr_dummys.hpp>";
-const char *str_tmpl = "idl_string<0>";
-const char *str_inc = "<org/eclipse/cyclonedds/topic/cdr_dummys.hpp>";
-const char *bnd_str_tmpl = "idl_string<{BOUND}>";
-const char *bnd_str_inc = "<org/eclipse/cyclonedds/topic/cdr_dummys.hpp>";
+const char *seq_tmpl = "std::vector<{TYPE}>";
+const char *seq_inc = "<vector>";
+const char *arr_tmpl = "std::array<{TYPE}, {DIMENSION}>";
+const char *arr_inc = "<array>";
+const char *bnd_seq_tmpl = "std::vector<{TYPE}>";
+const char *bnd_seq_inc = "<vector>";
+const char *str_tmpl = "std::string";
+const char *str_inc = "<string>";
+const char *bnd_str_tmpl = "std::string";
+const char *bnd_str_inc = "<string>";
 const char *uni_tmpl = "std::variant";
 const char *uni_get_tmpl = "std::get";
 const char *uni_inc = "<variant>";

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -451,20 +451,20 @@ process_case(
                        "      read(str, obj);\n"
                        "      instance.%2$s(obj);\n"
                        "    }\n"
-                       "      break;";
+                       "      break;\n";
   else
     readfmt = simple ? "    {\n"
                        "      %1$s obj = %3$s;\n"
                        "      read(str, obj);\n"
                        "      instance.%2$s(obj, d);\n"
                        "    }\n"
-                       "      break;"
+                       "      break;\n"
                      : "    {\n"
                        "      %1$s obj;\n"
                        "      read(str, obj);\n"
                        "      instance.%2$s(obj, d);\n"
                        "    }\n"
-                       "      break;";
+                       "      break;\n";
 
   if (revisit) {
     const char *fmt = "  }\n";

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -254,8 +254,8 @@ process_inherit_spec(
   struct streams *streams = user_data;
   const idl_type_spec_t *type_spec = ((const idl_inherit_spec_t *)node)->base;
   char *type = NULL;
-  const char *fmt = "  %2$s(dynamic_cast<%s&>(instance));\n";
-  const char *constfmt = "  %2$s(dynamic_cast<const %1$s&>(instance));\n";
+  const char *fmt = "  %2$s(str,dynamic_cast<%s&>(instance));\n";
+  const char *constfmt = "  %2$s(str,dynamic_cast<const %1$s&>(instance));\n";
 
   (void)pstate;
   (void)revisit;


### PR DESCRIPTION
Improvements for the following:
- array declarators not being parsed correctly
- template streamers are more compatible with user-supplied container classes
- processing of typedefs
- safety of reading bounded sequences
- more descriptive exceptions thrown
- improved generated comparison operators for structs
- added generation of comparison operators for unions