### PR TITLE
Fix issue where filtered read/take may result in a crash when returning loan

### DIFF
--- a/src/ddscxx/include/dds/sub/detail/SamplesHolder.hpp
+++ b/src/ddscxx/include/dds/sub/detail/SamplesHolder.hpp
@@ -59,19 +59,15 @@ public:
         return (*this->samples_.delegate())[this->index_].delegate().info();
     }
 
-    void **cpp_sample_pointers()
+    void **cpp_sample_pointers(size_t length)
     {
 
-        uint32_t cpp_sample_size = this->samples_.delegate()->length();
-        void **c_sample_pointers = new void * [cpp_sample_size];
-        return c_sample_pointers;
+        return new void * [length];
     }
 
-    dds_sample_info_t *cpp_info_pointers()
+    dds_sample_info_t *cpp_info_pointers(size_t length)
     {
-        uint32_t cpp_sample_size = this->samples_.delegate()->length();
-        dds_sample_info_t *c_info_pointers = new dds_sample_info_t[cpp_sample_size];
-        return c_info_pointers;
+        return new dds_sample_info_t[length];
     }
 
     void set_sample_contents(void** c_sample_pointers, dds_sample_info_t *info)
@@ -127,17 +123,14 @@ public:
         return (*this->samples_.delegate())[this->index_].delegate().info();
     }
 
-    void **cpp_sample_pointers()
+    void **cpp_sample_pointers(size_t length)
     {
-        uint32_t cpp_sample_size = this->samples_.delegate()->length();
-        return new void * [cpp_sample_size];
+        return new void * [length];
     }
 
-    dds_sample_info_t *cpp_info_pointers()
+    dds_sample_info_t *cpp_info_pointers(size_t length)
     {
-        uint32_t cpp_sample_size = this->samples_.delegate()->length();
-        dds_sample_info_t *c_info_pointers = new dds_sample_info_t[cpp_sample_size];
-        return c_info_pointers;
+        return new dds_sample_info_t[length];
     }
 
     void set_sample_contents(void** c_sample_pointers, dds_sample_info_t *info)
@@ -179,17 +172,17 @@ template <typename T, typename SamplesFWIterator>
 class SamplesFWInteratorHolder : public SamplesHolder
 {
 public:
-    SamplesFWInteratorHolder(SamplesFWIterator& it) : iterator(it), length(0)
+    SamplesFWInteratorHolder(SamplesFWIterator& it) : iterator(it), size(0)
     {
     }
 
     void set_length(uint32_t len) {
-        this->length = len;
+        this->size = len;
 
     }
 
     uint32_t get_length() const {
-        return this->length;
+        return this->size;
     }
 
     SamplesHolder& operator++(int)
@@ -208,7 +201,7 @@ public:
         return (*iterator).delegate().info();
     }
 
-    void **cpp_sample_pointers()
+    void **cpp_sample_pointers(size_t length)
     {
         void **c_sample_pointers = new void * [length];
         SamplesFWIterator tmp_iterator = iterator;
@@ -218,17 +211,16 @@ public:
         return c_sample_pointers;
     }
 
-    dds_sample_info_t *cpp_info_pointers()
+    dds_sample_info_t *cpp_info_pointers(size_t length)
     {
-      dds_sample_info_t *c_info_pointers = new dds_sample_info_t[length];
-      return c_info_pointers;
+      return new dds_sample_info_t[length];
     }
 
     void set_sample_contents(void**, dds_sample_info_t *info)
     {
         /* Samples have already been deserialized in their containers during the read/take call. */
         SamplesFWIterator tmp_iterator = iterator;
-        for (uint32_t i = 0; i < length; ++i, ++tmp_iterator) {
+        for (uint32_t i = 0; i < size; ++i, ++tmp_iterator) {
             org::eclipse::cyclonedds::sub::AnyDataReaderDelegate::copy_sample_infos(info[i], tmp_iterator->delegate().info());
         }
     }
@@ -241,7 +233,7 @@ public:
 
 private:
     SamplesFWIterator& iterator;
-    uint32_t length;
+    uint32_t size;
 
 };
 
@@ -249,17 +241,17 @@ template <typename T, typename SamplesBIIterator>
 class SamplesBIIteratorHolder : public SamplesHolder
 {
 public:
-    SamplesBIIteratorHolder(SamplesBIIterator& it) : iterator(it), length(0)
+    SamplesBIIteratorHolder(SamplesBIIterator& it) : iterator(it), size(0)
     {
     }
 
     void set_length(uint32_t len) {
-        this->length = len;
+        this->size = len;
         samples.resize(len);
     }
 
     uint32_t get_length() const {
-        return this->length;
+        return this->size;
     }
 
     SamplesHolder& operator++(int)
@@ -278,8 +270,9 @@ public:
         return this->samples[0].delegate().info();
     }
 
-    void **cpp_sample_pointers()
+    void **cpp_sample_pointers(size_t length)
     {
+        set_length(static_cast<uint32_t>(length));
         void **c_sample_pointers = new void*[length];
         for (uint32_t i = 0; i < length; ++i) {
           c_sample_pointers[i] = samples[i].delegate().data_ptr();
@@ -287,7 +280,7 @@ public:
         return c_sample_pointers;
     }
 
-    dds_sample_info_t *cpp_info_pointers()
+    dds_sample_info_t *cpp_info_pointers(size_t length)
     {
         dds_sample_info_t *c_info_pointers = new dds_sample_info_t[length];
         return c_info_pointers;
@@ -296,7 +289,7 @@ public:
     void set_sample_contents(void**, dds_sample_info_t *info)
     {
         /* Samples have already been deserialized in their containers during the read/take call. */
-        for (uint32_t i = 0; i < length; ++i) {
+        for (uint32_t i = 0; i < size; ++i) {
             org::eclipse::cyclonedds::sub::AnyDataReaderDelegate::copy_sample_infos(info[i], samples[i].delegate().info());
             this->iterator = std::move(samples[i]);
             this->iterator++;
@@ -312,7 +305,7 @@ public:
 private:
     SamplesBIIterator& iterator;
     std::vector< dds::sub::Sample<T, dds::sub::detail::Sample> > samples;
-    uint32_t length;
+    uint32_t size;
 
 };
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.hpp
@@ -73,8 +73,8 @@ public:
     virtual SamplesHolder& operator++(int) = 0;
     virtual void *data() = 0;
     virtual detail::SampleInfo& info() = 0;
-    virtual void **cpp_sample_pointers() = 0;
-    virtual dds_sample_info_t *cpp_info_pointers() = 0;
+    virtual void **cpp_sample_pointers(size_t length) = 0;
+    virtual dds_sample_info_t *cpp_info_pointers(size_t length) = 0;
     virtual void set_sample_contents(void** c_sample_pointers, dds_sample_info_t *info) = 0;
     virtual void fini_samples_buffers(void**& c_sample_pointers, dds_sample_info_t*& c_sample_infos) = 0;
 };

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
@@ -174,19 +174,14 @@ bool AnyDataReaderDelegate::init_samples_buffers(
     {
         c_sample_pointers_size = static_cast<size_t>(requested_max_samples);
         samples_to_read_cnt    = requested_max_samples;
+        samples.set_length(requested_max_samples);
     }
 
     /* Prepare the buffers. */
     if (c_sample_pointers_size)
     {
-      /*
-       * Unfortunately, the kludge doesn't work properly with read/take with
-       * loan. So, prepare sample memory up-front. This will cause performance
-       * decrease due to an extra copy action. Oh, well.
-       */
-        samples.set_length(static_cast<uint32_t>(c_sample_pointers_size));
-        c_sample_pointers = samples.cpp_sample_pointers();
-        c_sample_infos = samples.cpp_info_pointers();
+        c_sample_pointers = samples.cpp_sample_pointers(c_sample_pointers_size);
+        c_sample_infos = samples.cpp_info_pointers(c_sample_pointers_size);
     }
 
     return (c_sample_pointers_size > 0);

--- a/src/ddscxx/tests/DataReader.cpp
+++ b/src/ddscxx/tests/DataReader.cpp
@@ -453,7 +453,7 @@ TEST_F(DataReader, read_SamplesBIIterator)
 }
 
 
-TEST_F(DataReader, DISABLED_read_default_filter_read)
+TEST_F(DataReader, read_default_filter_read)
 {
     dds::sub::status::DataState state =
                     dds::sub::status::DataState(dds::sub::status::SampleState::read(),
@@ -481,7 +481,7 @@ TEST_F(DataReader, DISABLED_read_default_filter_read)
 }
 
 
-TEST_F(DataReader, DISABLED_read_default_filter_not_read)
+TEST_F(DataReader, read_default_filter_not_read)
 {
     dds::sub::LoanedSamples<Space::Type1> samples;
     std::vector<Space::Type1> test_samples;
@@ -506,7 +506,7 @@ TEST_F(DataReader, DISABLED_read_default_filter_not_read)
 }
 
 
-TEST_F(DataReader, DISABLED_read_default_filter_new_view)
+TEST_F(DataReader, read_default_filter_new_view)
 {
     dds::sub::LoanedSamples<Space::Type1> samples;
     std::vector<Space::Type1> test_samples;
@@ -531,7 +531,7 @@ TEST_F(DataReader, DISABLED_read_default_filter_new_view)
 }
 
 
-TEST_F(DataReader, DISABLED_read_default_filter_not_new_view)
+TEST_F(DataReader, read_default_filter_not_new_view)
 {
     dds::sub::status::DataState state =
                     dds::sub::status::DataState(dds::sub::status::SampleState::read(),
@@ -559,7 +559,7 @@ TEST_F(DataReader, DISABLED_read_default_filter_not_new_view)
 }
 
 
-TEST_F(DataReader, DISABLED_read_default_filter_alive)
+TEST_F(DataReader, read_default_filter_alive)
 {
     dds::sub::LoanedSamples<Space::Type1> samples;
     std::vector<Space::Type1> test_samples;
@@ -577,7 +577,7 @@ TEST_F(DataReader, DISABLED_read_default_filter_alive)
 }
 
 
-TEST_F(DataReader, DISABLED_read_default_filter_not_alive_disposed)
+TEST_F(DataReader, read_default_filter_not_alive_disposed)
 {
     dds::sub::status::DataState state(dds::sub::status::SampleState::not_read(),
                                       dds::sub::status::ViewState::new_view(),
@@ -607,7 +607,7 @@ TEST_F(DataReader, DISABLED_read_default_filter_not_alive_disposed)
 }
 
 
-TEST_F(DataReader, DISABLED_read_default_filter_not_alive_no_writers)
+TEST_F(DataReader, read_default_filter_not_alive_no_writers)
 {
     dds::sub::status::DataState state(dds::sub::status::SampleState::not_read(),
                                       dds::sub::status::ViewState::new_view(),
@@ -726,7 +726,7 @@ TEST_F(DataReader, DISABLED_take_default_filter_read)
 }
 
 
-TEST_F(DataReader, DISABLED_take_default_filter_not_read)
+TEST_F(DataReader, take_default_filter_not_read)
 {
     dds::sub::LoanedSamples<Space::Type1> samples;
     std::vector<Space::Type1> test_samples;
@@ -751,7 +751,7 @@ TEST_F(DataReader, DISABLED_take_default_filter_not_read)
 }
 
 
-TEST_F(DataReader, DISABLED_take_default_filter_new_view)
+TEST_F(DataReader, take_default_filter_new_view)
 {
     dds::sub::LoanedSamples<Space::Type1> samples;
     std::vector<Space::Type1> test_samples;
@@ -776,7 +776,7 @@ TEST_F(DataReader, DISABLED_take_default_filter_new_view)
 }
 
 
-TEST_F(DataReader, DISABLED_take_default_filter_not_new_view)
+TEST_F(DataReader, take_default_filter_not_new_view)
 {
     dds::sub::status::DataState state =
                     dds::sub::status::DataState(dds::sub::status::SampleState::read(),
@@ -804,7 +804,7 @@ TEST_F(DataReader, DISABLED_take_default_filter_not_new_view)
 }
 
 
-TEST_F(DataReader, DISABLED_take_default_filter_alive)
+TEST_F(DataReader, take_default_filter_alive)
 {
     dds::sub::LoanedSamples<Space::Type1> samples;
     std::vector<Space::Type1> test_samples;
@@ -822,7 +822,7 @@ TEST_F(DataReader, DISABLED_take_default_filter_alive)
 }
 
 
-TEST_F(DataReader, DISABLED_take_default_filter_not_alive_disposed)
+TEST_F(DataReader, take_default_filter_not_alive_disposed)
 {
     dds::sub::status::DataState state(dds::sub::status::SampleState::not_read(),
                                       dds::sub::status::ViewState::new_view(),
@@ -852,7 +852,7 @@ TEST_F(DataReader, DISABLED_take_default_filter_not_alive_disposed)
 }
 
 
-TEST_F(DataReader, DISABLED_take_default_filter_not_alive_no_writers)
+TEST_F(DataReader, take_default_filter_not_alive_no_writers)
 {
     dds::sub::status::DataState state(dds::sub::status::SampleState::not_read(),
                                       dds::sub::status::ViewState::new_view(),


### PR DESCRIPTION
Fix issue where filtered read/take may result in uninitialized SampleRefs for loans that are dimensioned to hold all available samples, not just the filtered ones. In cases where the loan is bigger than the number of matching samples, the destructor of the loan would crash on the uninitialized SampleRef objects.