### PR TITLE
Drop CUnit and update to GoogleTest 1.10.0

### DIFF
--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -66,12 +66,12 @@ steps:
     name: setup_windows
   - task: Cache@2
     inputs:
-      key: pip | 1 | $(Agent.OS)
+      key: pip | 2 | $(Agent.OS)
       path: $(pip_cache)
     name: cache_pip
   - task: Cache@2
     inputs:
-      key: conan | 1 | $(Agent.OS) | $(arch) | $(build_type)
+      key: conan | 2 | $(Agent.OS) | $(arch) | $(build_type)
       path: $(conan_cache)
     name: cache_conan
   - bash: |

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,10 +1,8 @@
 [requires]
-cunit/2.1-3
-gtest/1.8.1
+gtest/1.10.0
 
 [generators]
 cmake
 
 [options]
-cunit:shared=True
 gtest:shared=True


### PR DESCRIPTION
For some reason one specific build fails after I merged #88. I have a feeling it's an outdated cache or something because I couldn't reproduce it on an Ubuntu 20.04 machine locally, but we should drop CUnit and update GoogleTest anyway. The problem does not occur on my Azure Pipeline builds so this should fix the problem.