### PR TITLE
Save Coverity build log for debugging

### DIFF
--- a/.azure/coverity-scan.yml
+++ b/.azure/coverity-scan.yml
@@ -101,3 +101,7 @@ steps:
     name: submit_to_coverity_scan
     env:
       token: $(COVERITY_SCAN_TOKEN)
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: cov-int/build-log.txt
+      artifactName: 'coverity-build-log.txt'


### PR DESCRIPTION
This PR retains the Coverity build log for debugging. The C++ build does not suffer from the same problems as *cyclonedds*, but I couldn't figure out what exactly is wrong with it in a test repository. Perhaps it's the fact that it's mostly header files that do not result in object files but at this point I'm not really sure.