### PR TITLE
Generated isSelfContained trait and streaming fixes

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicTraits.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicTraits.hpp
@@ -75,6 +75,11 @@ public:
     {
         return 0;
     }
+
+    static bool isSelfContained()
+    {
+      return true;
+    }
 };
 
 }

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -511,7 +511,7 @@ print_header(FILE *fh, const char *in, const char *out)
 
 static idl_retcode_t print_guard_if(FILE* fh, const char *guard)
 {
-  static const char fmt[] =
+  static const char *fmt =
     "#ifndef %1$s\n"
     "#define %1$s\n\n";
   if (idl_fprintf(fh, fmt, guard) < 0)

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -278,16 +278,15 @@ static void copy(
   memmove(dest+off, src, cnt);
 }
 
-int get_cpp11_fully_scoped_name(
-  char *str, size_t size, const void *node, void *user_data)
+static int get_cpp11_fully_scoped_name_seps(
+  char *str, size_t size, const void *node, const char *sep)
 {
-  const char *name, *sep = "::";
+  const char *name;
   size_t cnt, off, len = 0;
   static const idl_mask_t mask =
     IDL_MODULE | IDL_STRUCT | IDL_UNION | IDL_ENUM |
     IDL_ENUMERATOR | IDL_DECLARATOR;
 
-  (void)user_data;
   assert(str && size);
 
   for (const idl_node_t *n = node; n; n = n->parent) {
@@ -316,6 +315,20 @@ int get_cpp11_fully_scoped_name(
   str[ (len < size ? len : size - 1) ] = '\0';
 
   return (int)len;
+}
+
+int get_cpp11_fully_scoped_name(
+  char *str, size_t size, const void *node, void *user_data)
+{
+  (void)user_data;
+  return get_cpp11_fully_scoped_name_seps(str, size, node, "::");
+}
+
+int get_cpp11_name_typedef(
+  char *str, size_t size, const void *node, void *user_data)
+{
+  (void)user_data;
+  return get_cpp11_fully_scoped_name_seps(str, size, node, "_");
 }
 
 int get_cpp11_type(

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -318,18 +318,6 @@ int get_cpp11_fully_scoped_name(
   return (int)len;
 }
 
-int get_cpp11_namespace(
-  char *str, size_t size, const void *node, void *user_data)
-{
-  assert(node);
-  const idl_node_t* n = node;
-
-  assert((idl_mask(n) & (IDL_STRUCT | IDL_UNION | IDL_ENUM |
-    IDL_ENUMERATOR | IDL_DECLARATOR)));
-
-  return get_cpp11_fully_scoped_name(str, size,n->parent, user_data);
-}
-
 int get_cpp11_type(
   char *str, size_t size, const void *node, void *user_data)
 {

--- a/src/idlcxx/src/generator.h
+++ b/src/idlcxx/src/generator.h
@@ -52,7 +52,7 @@ int get_cpp11_type(
 int get_cpp11_fully_scoped_name(
   char *str, size_t size, const void *node, void *user_data);
 
-int get_cpp11_namespace(
+int get_cpp11_name_typedef(
   char *str, size_t size, const void *node, void *user_data);
 
 int get_cpp11_default_value(

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -84,7 +84,8 @@ static int get_sequence_member_accessor(char* str, size_t size, const void* node
 {
   (void)node;
   sequence_holder_t* sh = (sequence_holder_t*)user_data;
-  return idl_snprintf(str, size, "%s[i_%u]", sh->sequence_accessor, sh->depth);
+  const char *fmt = "%1$s[i_%2$u]";
+  return idl_snprintf(str, size, fmt, sh->sequence_accessor, (uint32_t)sh->depth);
 }
 
 enum instance_mask {
@@ -738,13 +739,14 @@ process_key(
     //using malloc because windows causes a warning for using stack allocation (IDL_PRINTA) in a loop
     if (i < key->field_name->length - 1) {
       const char* name = get_cpp11_name(decl);
-      int res = idl_snprintf(tmp, 0, "%1$s.%2$s()", loc.parent, name);
+      const char *fmt = "%1$s.%2$s()";
+      int res = idl_snprintf(tmp, 0, fmt, loc.parent, name);
       if (res < 0) {
         ret = IDL_RETCODE_NO_MEMORY;
         goto fail;
       }
       tmp = malloc((size_t)res+1);
-      res = idl_snprintf(tmp, (size_t)res+1, "%1$s.%2$s()", loc.parent, name);
+      res = idl_snprintf(tmp, (size_t)res+1, fmt, loc.parent, name);
       if (res < 0) {
         ret = IDL_RETCODE_NO_MEMORY;
         goto fail;

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -241,7 +241,9 @@ write_typedef_streaming_functions(
   instance_location_t loc)
 {
   const char* fmt = "  %2$s_%3$s(streamer, %1$s);\n";
-  const char* name = get_cpp11_name(type_spec);
+  char* name = NULL;
+  if (IDL_PRINTA(&name, get_cpp11_name_typedef, type_spec, streams->generator) < 0)
+    return IDL_RETCODE_NO_MEMORY;
 
   if ((loc.type & NORMAL_INSTANCE) &&
       (putf(&streams->write, fmt, accessor, "write", name)
@@ -1038,7 +1040,9 @@ process_typedef_decl(
     "  (void)instance;\n"
     "  streamer.position(SIZE_MAX);\n"
     "}\n\n";
-  const char* name = get_cpp11_name(declarator);
+  char* name = NULL;
+  if (IDL_PRINTA(&name, get_cpp11_name_typedef, declarator, streams->generator) < 0)
+    return IDL_RETCODE_NO_MEMORY;
 
   char* fullname = NULL;
   if (IDL_PRINTA(&fullname, get_cpp11_fully_scoped_name, declarator, streams->generator) < 0)

--- a/src/idlcxx/src/traits.c
+++ b/src/idlcxx/src/traits.c
@@ -180,17 +180,15 @@ generate_traits(const idl_pstate_t *pstate, struct generator *generator)
 {
   idl_retcode_t ret;
   idl_visitor_t visitor;
-  const char *fmt;
   const char *sources[] = { NULL, NULL };
 
-  fmt = "#include \"org/eclipse/cyclonedds/topic/TopicTraits.hpp\"\n"
+  if (idl_fprintf(generator->header.handle, "#include \"org/eclipse/cyclonedds/topic/TopicTraits.hpp\"\n"
         "#include \"org/eclipse/cyclonedds/topic/DataRepresentation.hpp\"\n\n"
         "namespace org {\n"
         "namespace eclipse {\n"
         "namespace cyclonedds {\n"
         "namespace topic {\n"
-        "/* all traits not explicitly set are defaulted to the values in TopicTraits.hpp */\n\n";
-  if (idl_fprintf(generator->header.handle, fmt) < 0)
+        "/* all traits not explicitly set are defaulted to the values in TopicTraits.hpp */\n\n") < 0)
     return IDL_RETCODE_NO_MEMORY;
 
   memset(&visitor, 0, sizeof(visitor));
@@ -202,18 +200,16 @@ generate_traits(const idl_pstate_t *pstate, struct generator *generator)
   if ((ret = idl_visit(pstate, pstate->root, &visitor, generator)))
     return ret;
 
-  fmt = "}\n}\n}\n}\n\n"
+  if (idl_fprintf(generator->header.handle, "}\n}\n}\n}\n\n"
         "namespace dds {\n"
-        "namespace topic {\n\n";
-  if (idl_fprintf(generator->header.handle, fmt) < 0)
+        "namespace topic {\n\n") < 0)
     return IDL_RETCODE_NO_MEMORY;
 
   visitor.accept[IDL_ACCEPT_STRUCT] = &emit_topic_type_name;
   if ((ret = idl_visit(pstate, pstate->root, &visitor, generator)))
     return ret;
 
-  fmt = "}\n}\n\n";
-  if (idl_fprintf(generator->header.handle, fmt) < 0)
+  if (idl_fprintf(generator->header.handle, "}\n}\n\n") < 0)
     return IDL_RETCODE_NO_MEMORY;
 
   visitor.accept[IDL_ACCEPT_STRUCT] = &emit_register_topic_type;

--- a/src/idlcxx/src/types.c
+++ b/src/idlcxx/src/types.c
@@ -551,7 +551,8 @@ emit_case_comparison(
     return IDL_VISIT_REVISIT;
 
   const char* branch_name = get_cpp11_name(branch->declarator);
-  if (idl_fprintf(gen->header.handle, "        return %1$s() == _other.%1$s();\n", branch_name) < 0)
+  static const char* fmt = "        return %1$s() == _other.%1$s();\n";
+  if (idl_fprintf(gen->header.handle, fmt, branch_name) < 0)
     return IDL_RETCODE_NO_MEMORY;
 
   return IDL_RETCODE_OK;
@@ -733,8 +734,7 @@ emit_union(
   visitor.accept[IDL_ACCEPT_CASE] = emit_variant;
   if ((ret = idl_visit(pstate, _union->cases, &visitor, user_data)))
     return ret;
-  fmt = "> m__u;\n\n";
-  if (idl_fprintf(gen->header.handle, fmt) < 0)
+  if (idl_fprintf(gen->header.handle, "> m__u;\n\n") < 0)
     return ret;
 
   /**/


### PR DESCRIPTION
- move streaming functions to namespace org::eclipse::cyclonedds::core::cdr
- generated streaming functions for maximum size are now return immediately if they are of unbounded size
- streaming functions for typedefs avoid name clashes by adding the typedef namespace to the function name
- add the topic trait isSelfContained indicating whether the topic does not contain any pointers
- group the generated traits by namespace