### PR TITLE
Use unique topic name per test

### DIFF
--- a/src/ddscxx/tests/CMakeLists.txt
+++ b/src/ddscxx/tests/CMakeLists.txt
@@ -40,7 +40,7 @@ set(sources
   Qos.cpp
   Condition.cpp)
 
-add_executable(ddscxx_tests ${sources})
+add_executable(ddscxx_tests ${sources} Util.cpp)
 
 # Disable the static analyzer in GCC to avoid crashing the GNU C++ compiler
 # on Azure Pipelines

--- a/src/ddscxx/tests/EntityStatus.cpp
+++ b/src/ddscxx/tests/EntityStatus.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include "Util.hpp"
 #include "HelloWorldData.hpp"
 
 /**
@@ -27,6 +28,8 @@ public:
     }
 
     void SetUp() {
+        char name[32];
+
         this->par = dds::domain::DomainParticipant(org::eclipse::cyclonedds::domain::default_id());
         ASSERT_NE(this->par, dds::core::null);
 
@@ -36,7 +39,8 @@ public:
         this->sub = dds::sub::Subscriber(this->par);
         ASSERT_NE(this->sub, dds::core::null);
 
-        this->topic = dds::topic::Topic<HelloWorldData::Msg>(this->par, "EntiyStatus_test");
+        create_unique_topic_name("EntityStatus", name, sizeof(name));
+        this->topic = dds::topic::Topic<HelloWorldData::Msg>(this->par, name);
         ASSERT_NE(this->topic, dds::core::null);
     }
 

--- a/src/ddscxx/tests/Listener.cpp
+++ b/src/ddscxx/tests/Listener.cpp
@@ -18,6 +18,7 @@
 #include "dds/ddsrt/sync.h"
 #include "dds/ddsrt/threads.h"
 
+#include "Util.hpp"
 #include "HelloWorldData.hpp"
 
 static uint32_t cb_called = 0;
@@ -308,8 +309,7 @@ public:
     }
 
     void SetUp() {
-        char buf[32];
-        ddsrt_pid_t pid = ddsrt_getpid();
+        char name[32];
 
         ddsrt_mutex_init(&g_mutex);
         ddsrt_cond_init(&g_cond);
@@ -319,8 +319,8 @@ public:
         ASSERT_NE(participant, dds::core::null);
 
         // Create topic
-        snprintf(buf, sizeof(buf), "listener_topic_%" PRIdPID, pid);
-        topic = dds::topic::Topic<HelloWorldData::Msg>(participant, buf);
+        create_unique_topic_name("Listener", name, sizeof(name));
+        topic = dds::topic::Topic<HelloWorldData::Msg>(participant, name);
         ASSERT_NE(topic, dds::core::null);
 
         // Create publisher

--- a/src/ddscxx/tests/Util.cpp
+++ b/src/ddscxx/tests/Util.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include "dds/dds.h"
+#include "dds/ddsrt/atomics.h"
+#include "dds/ddsrt/process.h"
+#include "dds/ddsrt/threads.h"
+#include "Util.hpp"
+
+char *create_unique_topic_name (const char *prefix, char *name, size_t size)
+{
+  static ddsrt_atomic_uint32_t count = DDSRT_ATOMIC_UINT64_INIT (0);
+  const ddsrt_pid_t pid = ddsrt_getpid();
+  const ddsrt_tid_t tid = ddsrt_gettid();
+  const uint32_t nr = ddsrt_atomic_inc32_nv (&count);
+  (void) snprintf (name, size, "%s%" PRIu32 "_pid%" PRIdPID "_tid%" PRIdTID "", prefix, nr, pid, tid);
+  return name;
+}

--- a/src/ddscxx/tests/Util.hpp
+++ b/src/ddscxx/tests/Util.hpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef _TEST_UTIL_H
+#define _TEST_UTIL_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* Get unique g_topic name on each invocation. */
+char *create_unique_topic_name (const char *prefix, char *name, size_t size);
+
+#endif /* _TEST_UTIL_H */

--- a/src/ddscxx/tests/WaitSet.cpp
+++ b/src/ddscxx/tests/WaitSet.cpp
@@ -16,6 +16,7 @@
 #include "dds/ddsrt/threads.h"
 #include "dds/ddsrt/sync.h"
 
+#include "Util.hpp"
 #include "Space.hpp"
 
 #define TA_ATTACH_REMOVE_CONDITION "attach_remove_condition"
@@ -322,8 +323,7 @@ public:
 
     void SetUp()
     {
-        char buf[32];
-        ddsrt_pid_t pid = ddsrt_getpid();
+        char name[32];
 
         this->participant = dds::domain::DomainParticipant(org::eclipse::cyclonedds::domain::default_id());
         ASSERT_NE(this->participant, dds::core::null);
@@ -334,8 +334,8 @@ public:
         this->subscriber = dds::sub::Subscriber(this->participant);
         ASSERT_NE(this->subscriber, dds::core::null);
 
-        snprintf(buf, sizeof(buf), "waitset_test_topic_%" PRIdPID, pid);
-        this->topic = dds::topic::Topic<Space::Type1>(this->participant, buf);
+        create_unique_topic_name("WaitSet", name, sizeof(name));
+        this->topic = dds::topic::Topic<Space::Type1>(this->participant, name);
         ASSERT_NE(this->topic, dds::core::null);
 
         this->reader = dds::sub::DataReader<Space::Type1>(this->subscriber, this->topic);


### PR DESCRIPTION
A shameless rip from the tests for ddsc in cyclonedds to ensure tests that require it use a unique topic name to avoid intermittent failures. Using the command `ctest -T test -R EntityStatus -j 4 --repeat until-fail:1000` didn't show any failure when testing locally whereas it failed 2 out of 3 times before. It's meant to be an addition to the work @reicheratwork did on #105 to ensure builds for PRs are reliable.