### PR TITLE
Add required headers to generated code

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicTraits.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicTraits.hpp
@@ -20,7 +20,7 @@
 
 #include <vector>
 
-#include <org/eclipse/cyclonedds/topic/DataRepresentation.hpp>
+#include "org/eclipse/cyclonedds/topic/DataRepresentation.hpp"
 
 struct ddsi_sertype;
 

--- a/src/idlcxx/src/generator.h
+++ b/src/idlcxx/src/generator.h
@@ -29,6 +29,7 @@ struct generator {
   char *union_format;
   char *union_getter_format;
   const char *union_include;
+  bool uses_integers;
   bool uses_array;
   bool uses_sequence;
   bool uses_bounded_sequence;

--- a/src/idlcxx/src/traits.c
+++ b/src/idlcxx/src/traits.c
@@ -182,8 +182,10 @@ generate_traits(const idl_pstate_t *pstate, struct generator *generator)
   idl_visitor_t visitor;
   const char *sources[] = { NULL, NULL };
 
-  if (idl_fprintf(generator->header.handle, "#include \"org/eclipse/cyclonedds/topic/TopicTraits.hpp\"\n"
-        "#include \"org/eclipse/cyclonedds/topic/DataRepresentation.hpp\"\n\n"
+  if (idl_fprintf(generator->header.handle,
+        "#include \"dds/topic/TopicTraits.hpp\"\n"
+        "#include \"org/eclipse/cyclonedds/topic/TopicTraits.hpp\"\n"
+        "#include \"org/eclipse/cyclonedds/topic/datatopic.hpp\"\n\n"
         "namespace org {\n"
         "namespace eclipse {\n"
         "namespace cyclonedds {\n"

--- a/src/idlcxx/src/types.c
+++ b/src/idlcxx/src/types.c
@@ -355,15 +355,19 @@ emit_enum(
 static idl_retcode_t
 expand_typedef(
   struct generator* gen,
-  const idl_declarator_t* declarator,
-  const idl_typedef_t* _typedef)
+  const idl_declarator_t* declarator)
 {
-  const char* name = get_cpp11_name(declarator);
-  char* type = NULL;
+  char *type = NULL;
+  const char *name = get_cpp11_name(declarator);
+  const idl_type_spec_t *type_spec;
 
-  if (IDL_PRINTA(&type, get_cpp11_type, idl_is_array(declarator) ? declarator : _typedef->type_spec, gen) < 0)
+  if (idl_is_array(declarator))
+    type_spec = declarator;
+  else
+    type_spec = idl_type_spec(declarator);
+
+  if (IDL_PRINTA(&type, get_cpp11_type, type_spec, gen) < 0)
     return IDL_RETCODE_NO_MEMORY;
-
   if (idl_fprintf(gen->header.handle, "typedef %s %s;\n\n", type, name) < 0)
     return IDL_RETCODE_NO_MEMORY;
 
@@ -388,7 +392,7 @@ emit_typedef(
 
   idl_retcode_t ret = IDL_RETCODE_OK;
   IDL_FOREACH(declarator, _typedef->declarators) {
-    if ((ret = expand_typedef(gen, declarator, _typedef)) != IDL_RETCODE_OK)
+    if ((ret = expand_typedef(gen, declarator)) != IDL_RETCODE_OK)
       break;
   }
 


### PR DESCRIPTION
* Include cstdint header if integer types or octets are used
* Include array header for anonymous arrays
* Include string header if string constants are used
* Include datatopic.hpp from TopicTraits.hpp

Fixes #108. @sumanth-nirmal, can you verify this fixes it for you?

Requires [PR 863 in cyclonedds](https://github.com/eclipse-cyclonedds/cyclonedds/pull/863) to be merged for the string constant issue.