### PR TITLE
Serialization fixes

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp
@@ -75,9 +75,9 @@ void read(basic_cdr_stream &str, T& toread)
   if (str.abort_status())
     return;
 
-  char *cursor = str.get_cursor();
   str.align(sizeof(T), false);
 
+  char *cursor = str.get_cursor();
   assert(cursor);
   transfer_and_swap(*(reinterpret_cast<const T*>(cursor)), toread, str.swap_endianness());
   str.incr_position(sizeof(T));
@@ -102,9 +102,9 @@ void write(basic_cdr_stream& str, const T& towrite)
   if (str.abort_status())
     return;
 
-  char *cursor = str.get_cursor();
   str.align(sizeof(T), true);
 
+  char *cursor = str.get_cursor();
   assert(cursor);
   transfer_and_swap(towrite, *(reinterpret_cast<T*>(cursor)), str.swap_endianness());
   str.incr_position(sizeof(T));

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp
@@ -254,7 +254,7 @@ public:
      * @retval false If the stream endianness DOES match the local endianness.
      * @retval true If the stream endianness DOES NOT match the local endianness.
      */
-    bool swap_endianness() const { return m_stream_endianness == m_local_endianness; }
+    bool swap_endianness() const { return m_stream_endianness != m_local_endianness; }
 
     /**
      * @brief

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -119,7 +119,10 @@ public:
     T *t = m_t.load(std::memory_order_acquire);
     if (t == nullptr) {
       t = new T();
-      org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str;
+      org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str(
+          *(static_cast<unsigned char*>(data())+1) == 0x1 ?
+              org::eclipse::cyclonedds::core::cdr::endianness::little_endian :
+              org::eclipse::cyclonedds::core::cdr::endianness::big_endian);
       str.set_buffer(calc_offset(data(),4));
       switch (kind)
       {
@@ -391,7 +394,10 @@ bool serdata_to_sample(
   (void)buflim;
   auto ptr = static_cast<const ddscxx_serdata<T>*>(dcmn);
 
-  org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str;
+  org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str(
+          *(static_cast<unsigned char*>(ptr->data())+1) == 0x1 ?
+              org::eclipse::cyclonedds::core::cdr::endianness::little_endian :
+              org::eclipse::cyclonedds::core::cdr::endianness::big_endian);
   str.set_buffer(calc_offset(ptr->data(), 4));
   auto& msg = *static_cast<T*>(sample);
   read(str, msg);
@@ -454,7 +460,10 @@ bool serdata_untyped_to_sample(
   auto d = static_cast<const ddscxx_serdata<T>*>(dcmn);
 
   T* ptr = static_cast<T*>(sample);
-  org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str;
+  org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str(
+          *(static_cast<unsigned char*>(d->data())+1) == 0x1 ?
+              org::eclipse::cyclonedds::core::cdr::endianness::little_endian :
+              org::eclipse::cyclonedds::core::cdr::endianness::big_endian);
   str.set_buffer(calc_offset(d->data(), 4));
   key_read(str, *ptr);
 

--- a/src/ddscxx/tests/Bounded.cpp
+++ b/src/ddscxx/tests/Bounded.cpp
@@ -13,7 +13,7 @@
 #include <string>
 
 #include "dds/dds.hpp"
-#include "Bounded.hpp"
+#include "Serialization.hpp"
 
 /**
  * Fixture for the tests

--- a/src/ddscxx/tests/CMakeLists.txt
+++ b/src/ddscxx/tests/CMakeLists.txt
@@ -11,7 +11,7 @@
 #
 find_package(GTest REQUIRED)
 
-idlcxx_generate(TARGET ddscxx_test_types FILES data/Space.idl data/HelloWorldData.idl data/Bounded.idl)
+idlcxx_generate(TARGET ddscxx_test_types FILES data/Space.idl data/HelloWorldData.idl data/Serialization.idl)
 
 configure_file(
   config_simple.xml.in config_simple.xml @ONLY)
@@ -29,6 +29,7 @@ set(sources
   FindTopic.cpp
   Topic.cpp
   Publisher.cpp
+  Serdata.cpp
   Subscriber.cpp
   DataWriter.cpp
   DataReader.cpp

--- a/src/ddscxx/tests/Serdata.cpp
+++ b/src/ddscxx/tests/Serdata.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <gtest/gtest.h>
+
+#include "dds/dds.hpp"
+#include "Serialization.hpp"
+#include <org/eclipse/cyclonedds/topic/datatopic.hpp>
+
+using namespace org::eclipse::cyclonedds::core::cdr;
+
+/**
+ * Fixture for the tests
+ */
+class Serdata : public ::testing::Test
+{
+public:
+
+    ddsi_sertype *m_st = nullptr;
+
+    Serdata()
+    {
+    }
+
+    void SetUp()
+    {
+        m_st = org::eclipse::cyclonedds::topic::TopicTraits<Endianness::Msg>::getSerType();
+        sd = new ddscxx_serdata<Endianness::Msg>(m_st,SDK_DATA);
+        ASSERT_NE(sd,nullptr);
+
+        sd->resize(12);
+        ptr = static_cast<unsigned char*>(sd->data());
+
+        ptr[4] = 0x10;
+        ptr[5] = 0x19;
+        ptr[6] = 0x24;
+        ptr[7] = 0x00;
+        ptr[8] = 0x01;
+        ptr[9] = 0x02;
+        ptr[10] = 0x03;
+        ptr[11] = 0x04;
+    }
+
+    void TearDown()
+    {
+        delete sd;
+        sd = nullptr;
+        ddsrt_atomic_st32(&m_st->flags_refc, 0);
+        ddsi_sertype_fini(m_st);
+        delete m_st;
+    }
+
+    Endianness::Msg& getMsg(endianness end)
+    {
+        ptr[1] = (end == endianness::little_endian ? 0x01 : 0x00);
+
+        return *(sd->getT());
+    }
+
+private:
+
+    ddscxx_serdata<Endianness::Msg> *sd = nullptr;
+    unsigned char *ptr = nullptr;
+};
+
+/*
+ * Checking that the cdr stream correctly aligns between single- and multibyte primitives
+ */
+TEST_F(Serdata, alignment)
+{
+    Endianness::Msg msg({16,25,36},65535);
+
+    basic_cdr_stream str(endianness::little_endian);
+    std::vector<unsigned char> vec(8,0x0);
+    str.set_buffer(vec.data());
+
+    write(str,msg);
+
+    ASSERT_EQ(vec, std::vector<unsigned char>({16,25,36,0,255,255,0,0}));
+}
+
+/*
+ * Checking that ddscxx_serdata uses the correct endianness flags for deserialization
+ * of a big endian stream
+ */
+TEST_F(Serdata, deserialization_big_endianness)
+{
+    auto msg = getMsg(endianness::big_endian);
+
+    if (native_endianness() == endianness::big_endian)
+      ASSERT_EQ(msg.l(), 0x04030201);
+    else
+      ASSERT_EQ(msg.l(), 0x01020304);
+}
+
+/*
+ * Checking that ddscxx_serdata uses the correct endianness flags for deserialization
+ * of a little endian stream
+ */
+TEST_F(Serdata, deserialization_little_endianness)
+{
+    auto msg = getMsg(endianness::little_endian);
+
+    if (native_endianness() == endianness::little_endian)
+      ASSERT_EQ(msg.l(), 0x04030201);
+    else
+      ASSERT_EQ(msg.l(), 0x01020304);
+}
+
+/*
+ * Checking that ddscxx_serdata uses the correct endianness flags for serialization
+ */
+TEST_F(Serdata, serialization_big_endianness)
+{
+    Endianness::Msg msg({0x4,0x5,0x6},
+                     4278255360); //(0xFF00FF00 LE)
+
+    auto d = static_cast<const ddscxx_serdata<Endianness::Msg>*>(serdata_from_sample<Endianness::Msg>(
+        m_st,
+        SDK_DATA,
+        static_cast<const void*>(&msg)));
+
+    ASSERT_NE(d, nullptr);
+
+    if (native_endianness() == endianness::big_endian)
+      ASSERT_EQ(0,memcmp(d->data(),std::vector<unsigned char>({0x0,0x0,0x0,0x0,0x4,0x5,0x6,0x0,0xFF,0x00,0xFF,0x00}).data(), 12));
+    else
+      ASSERT_EQ(0,memcmp(d->data(),std::vector<unsigned char>({0x0,0x1,0x0,0x0,0x4,0x5,0x6,0x0,0x00,0xFF,0x00,0xFF}).data(), 12));
+
+    delete d;
+}

--- a/src/ddscxx/tests/data/Serialization.idl
+++ b/src/ddscxx/tests/data/Serialization.idl
@@ -9,3 +9,14 @@ module Bounded
   };
 
 };
+
+module Endianness
+{
+
+  struct Msg
+  {
+    char chars[3];
+    unsigned long l;
+  };
+
+};


### PR DESCRIPTION
This fixes a number of issues in the CDR serialization, namely issues #115, #117 and #119:
- Alignment
- Byte Swapping on read side
and adds unittests to check for their correctness.
