### PR TITLE
Check for nullptr when accessing data with loaned samples

### DIFF
--- a/src/ddscxx/include/dds/sub/detail/SampleRef.hpp
+++ b/src/ddscxx/include/dds/sub/detail/SampleRef.hpp
@@ -61,7 +61,9 @@ public:
 
     virtual ~SampleRef()
     {
-        ddsi_serdata_unref(reinterpret_cast<ddsi_serdata*>(data_));
+      if (data_ != nullptr) {
+        ddsi_serdata_unref(reinterpret_cast<ddsi_serdata *>(data_));
+      }
     }
 
     SampleRef& operator=(const SampleRef& other)
@@ -76,7 +78,11 @@ public:
 public:
     const T& data() const
     {
-        return *data_->getT();
+      if (data_ == nullptr)
+      {
+        throw dds::core::Error("Data is Null");
+      }
+      return *data_->getT();
     }
 
     const dds::sub::SampleInfo& info() const


### PR DESCRIPTION
Fixes #118 