### PR TITLE
Fix idlcxx two backend bugs

### DIFF
--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -968,7 +968,7 @@ process_union(
     "  streamer.alignment(alignment_max);\n";
   static const char *ffmt =
     "template<typename T>\n"
-    "void max(T& streamer, const %2$s& instance) {\n"
+    "void max(T& streamer, const %1$s& instance) {\n"
     "  (void)instance;\n"
     "  streamer.position(SIZE_MAX);\n"
     "}\n\n";

--- a/src/idlcxx/src/types.c
+++ b/src/idlcxx/src/types.c
@@ -826,7 +826,7 @@ emit_union(
   /* implicit default setter */
   if (idl_mask(_union->default_case) == IDL_IMPLICIT_DEFAULT_CASE_LABEL) {
     if (_union->unused_labels > 1)
-      fmt = "  void _default(%1$s d = %2$ss)\n"
+      fmt = "  void _default(%1$s d = %2$s)\n"
             "  {\n"
             "    if (!_is_compatible_discriminator(d, %2$s))\n"
             "      return;\n";


### PR DESCRIPTION
These two commits fix a generation issue in the type definitions and one in the generated serializer. Both deal with unions, both result in a uncompilable code.