### PR TITLE
Fixes for issues with typedef of base types in type support generator

### DIFF
--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -991,7 +991,8 @@ process_union(
     //
     // FIXME: for the vast majority of the unions, this doesn't come into play this
     // simply wastes time.
-    putf(&streams->read, "  instance._d(d);\n");
+    if (putf(&streams->read, "  instance._d(d);\n"))
+      return IDL_RETCODE_NO_MEMORY;
 
     if (putf(&streams->max, pfmt)
      || print_constructed_type_close(user_data, node))

--- a/src/idlcxx/src/types.c
+++ b/src/idlcxx/src/types.c
@@ -48,6 +48,7 @@ emit_member(
   name = get_cpp11_name(node);
   if (IDL_PRINTA(&type, get_cpp11_type, type_spec, gen) < 0)
     return IDL_RETCODE_NO_MEMORY;
+  type_spec = idl_unalias(type_spec, 0);
   if (idl_is_array(type_spec))
     value = "{ }";
   else if (!idl_is_enum(type_spec) && !idl_is_base_type(type_spec))
@@ -94,7 +95,7 @@ emit_parameter(
   else
     type_spec = idl_type_spec(node);
 
-  simple = idl_mask(type_spec) & (IDL_BASE_TYPE|IDL_ENUM);
+  simple = idl_mask(idl_unalias(type_spec, 0)) & (IDL_BASE_TYPE|IDL_ENUM);
   sep = is_first(node) ? "" : ",\n";
   fmt = simple ? "%s    %s %s"
                : "%s    const %s& %s";
@@ -157,6 +158,7 @@ emit_member_methods(
   if (IDL_PRINTA(&type, get_cpp11_type, type_spec, gen) < 0)
     return IDL_RETCODE_NO_MEMORY;
 
+  type_spec = idl_unalias(type_spec, 0);
   if (idl_mask(type_spec) & (IDL_BASE_TYPE | IDL_ENUM))
     fmt = "  %1$s %2$s() const { return this->%2$s_; }\n"
           "  %1$s& %2$s() { return this->%2$s_; }\n"
@@ -644,7 +646,7 @@ emit_case_methods(
   if (IDL_PRINTA(&value, get_cpp11_value, branch->labels->const_expr, gen) < 0)
     return IDL_RETCODE_NO_MEMORY;
 
-  simple = (idl_mask(branch->type_spec) & IDL_BASE_TYPE) != 0;
+  simple = (idl_mask(idl_unalias(branch->type_spec, 0)) & (IDL_BASE_TYPE|IDL_ENUM)) != 0;
 
   /* const-getter */
   fmt = simple ? "  %1$s %2$s() const\n  {\n"


### PR DESCRIPTION
This fixes the setters (and initializers) for members that use type specifiers that are typedefs of base types or enumerators and fixes issues where the number of cases for setters suddenly changes. Still have to write tests, so put in draft mode.