### PR TITLE
Add builtin topics support

### DIFF
--- a/src/ddscxx/CMakeLists.txt
+++ b/src/ddscxx/CMakeLists.txt
@@ -20,6 +20,7 @@ set(sources
     src/dds/core/status/State.cpp
     src/dds/domain/discovery.cpp
     src/dds/domain/find.cpp
+    src/dds/topic/BuiltinTopic.cpp
     src/dds/pub/pubdiscovery.cpp
     src/dds/sub/subdiscovery.cpp
     src/dds/sub/subfind.cpp
@@ -59,6 +60,7 @@ set(sources
     src/org/eclipse/cyclonedds/sub/qos/SubscriberQosDelegate.cpp
     src/org/eclipse/cyclonedds/topic/find.cpp
     src/org/eclipse/cyclonedds/topic/hash.cpp
+    src/org/eclipse/cyclonedds/topic/BuiltinDataTopic.cpp
     src/org/eclipse/cyclonedds/topic/AnyTopicDelegate.cpp
     src/org/eclipse/cyclonedds/topic/FilterDelegate.cpp
     src/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.cpp

--- a/src/ddscxx/include/dds/sub/detail/SamplesHolder.hpp
+++ b/src/ddscxx/include/dds/sub/detail/SamplesHolder.hpp
@@ -223,10 +223,10 @@ private:
 };
 
 template <typename T, typename SamplesFWIterator>
-class SamplesFWInteratorHolder : public SamplesHolder
+class SamplesFWIteratorHolder : public SamplesHolder
 {
 public:
-    SamplesFWInteratorHolder(SamplesFWIterator& it) : iterator(it), size(0)
+    SamplesFWIteratorHolder(SamplesFWIterator& it) : iterator(it), size(0)
     {
     }
 

--- a/src/ddscxx/include/dds/sub/detail/SamplesHolder.hpp
+++ b/src/ddscxx/include/dds/sub/detail/SamplesHolder.hpp
@@ -18,7 +18,7 @@
 
 #include <dds/sub/LoanedSamples.hpp>
 #include "org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.hpp"
-#include "org/eclipse/cyclonedds/topic/datatopic.hpp"
+#include "org/eclipse/cyclonedds/topic/BuiltinDataTopic.hpp"
 
 namespace dds
 {
@@ -79,6 +79,12 @@ public:
             tmp_iterator->delegate().data_ptr() = static_cast<ddscxx_serdata<T>*>(c_sample_pointers[i]);
             org::eclipse::cyclonedds::sub::AnyDataReaderDelegate::copy_sample_infos(info[i], tmp_iterator->delegate().info());
         }
+    }
+
+    template<typename T_ = T, IsBuiltinTopicType<T_> = true>
+    void set_builtin_sample_contents(void** cxx_sample_pointers, dds_sample_info_t *info)
+    {
+        set_sample_contents(cxx_sample_pointers, info);
     }
 
     void fini_samples_buffers(void**& c_sample_pointers, dds_sample_info_t*& c_sample_infos)
@@ -270,6 +276,20 @@ public:
       return new dds_sample_info_t[length];
     }
 
+    template<typename T_ = T, IsBuiltinTopicType<T_> = true>
+    void set_builtin_sample_contents(void** cxx_sample_pointers, dds_sample_info_t *info)
+    {
+        /* Samples have already been deserialized in their containers during the read/take call. */
+        SamplesFWIterator tmp_iterator = iterator;
+        for (uint32_t i = 0; i < size; ++i, ++tmp_iterator) {
+            auto ptr = static_cast<ddscxx_serdata<T>*>(cxx_sample_pointers[i]);
+            tmp_iterator->delegate().data() = *ptr->getT();
+            org::eclipse::cyclonedds::sub::AnyDataReaderDelegate::copy_sample_infos(info[i], tmp_iterator->delegate().info());
+            delete(ptr);
+            cxx_sample_pointers[i] = nullptr;
+        }
+    }
+
     void set_sample_contents(void**, dds_sample_info_t *info)
     {
         /* Samples have already been deserialized in their containers during the read/take call. */
@@ -338,6 +358,20 @@ public:
     {
         dds_sample_info_t *c_info_pointers = new dds_sample_info_t[length];
         return c_info_pointers;
+    }
+
+    template<typename T_ = T, IsBuiltinTopicType<T_> = true>
+    void set_builtin_sample_contents(void** cxx_sample_pointers, dds_sample_info_t *info)
+    {
+        /* Samples have already been deserialized in their containers during the read/take call. */
+        for (uint32_t i = 0; i < size; ++i, ++iterator) {
+            auto ptr = static_cast<ddscxx_serdata<T>*>(cxx_sample_pointers[i]);
+            samples[i].data(*ptr->getT());
+            org::eclipse::cyclonedds::sub::AnyDataReaderDelegate::copy_sample_infos(info[i], samples[i].delegate().info());
+            iterator = samples[i];
+            delete(ptr);
+            cxx_sample_pointers[i] = nullptr;
+        }
     }
 
     void set_sample_contents(void**, dds_sample_info_t *info)

--- a/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
@@ -670,7 +670,7 @@ template<typename SamplesFWIterator>
 uint32_t
 dds::sub::detail::DataReader<T>::read(SamplesFWIterator samples, uint32_t max_samples)
 {
-    dds::sub::detail::SamplesFWInteratorHolder<T, SamplesFWIterator> holder(samples);
+    dds::sub::detail::SamplesFWIteratorHolder<T, SamplesFWIterator> holder(samples);
 
     this->AnyDataReaderDelegate::read(static_cast<dds_entity_t>(this->ddsc_entity), this->status_filter_, holder, max_samples);
 
@@ -682,7 +682,7 @@ template<typename SamplesFWIterator>
 uint32_t
 dds::sub::detail::DataReader<T>::take(SamplesFWIterator samples, uint32_t max_samples)
 {
-    dds::sub::detail::SamplesFWInteratorHolder<T, SamplesFWIterator> holder(samples);
+    dds::sub::detail::SamplesFWIteratorHolder<T, SamplesFWIterator> holder(samples);
 
     this->AnyDataReaderDelegate::take(static_cast<dds_entity_t>(this->ddsc_entity), this->status_filter_, holder, max_samples);
 
@@ -1099,7 +1099,7 @@ uint32_t
 dds::sub::detail::DataReader<T>::read(SamplesFWIterator samples,
               uint32_t max_samples, const Selector& selector)
 {
-    dds::sub::detail::SamplesFWInteratorHolder<T, SamplesFWIterator> holder(samples);
+    dds::sub::detail::SamplesFWIteratorHolder<T, SamplesFWIterator> holder(samples);
     max_samples = std::min(max_samples, selector.max_samples_);
 
     switch(selector.mode) {
@@ -1149,7 +1149,7 @@ uint32_t
 dds::sub::detail::DataReader<T>::take(SamplesFWIterator samples,
               uint32_t max_samples, const Selector& selector)
 {
-    dds::sub::detail::SamplesFWInteratorHolder<T, SamplesFWIterator> holder(samples);
+    dds::sub::detail::SamplesFWIteratorHolder<T, SamplesFWIterator> holder(samples);
     max_samples = std::min(max_samples, selector.max_samples_);
 
     switch(selector.mode) {

--- a/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
@@ -1525,24 +1525,25 @@ void convert_builtin_pubsub(
     ptr->delegate().qos(c_data->qos);
 }
 
+namespace detail {
 #define readtakefunction(TYPE, METHOD, TF, FNCTN)\
-template <> inline LoanedSamples<TYPE> \
-detail::DataReader<TYPE>::METHOD() {\
-    dds::sub::LoanedSamples<TYPE> samples;\
-    detail::LoanedSamplesHolder<TYPE> holder(samples);\
-    status::DataState state;\
-    readtake<TYPE, detail::LoanedSamplesHolder<TYPE> >(\
+template <> inline ::dds::sub::LoanedSamples<TYPE> \
+DataReader<TYPE>::METHOD() {\
+    ::dds::sub::LoanedSamples<TYPE> samples;\
+    LoanedSamplesHolder<TYPE> holder(samples);\
+    ::dds::sub::status::DataState state;\
+    readtake<TYPE, LoanedSamplesHolder<TYPE> >(\
         holder, this->ddsc_entity, TF, state, MAX_SAMPLES, &FNCTN<TYPE>);\
     return samples;\
 }\
 \
-template <> inline LoanedSamples<TYPE> \
-detail::DataReader<TYPE>::METHOD(const Selector& selector) {\
-    dds::sub::LoanedSamples<TYPE> samples;\
-    detail::LoanedSamplesHolder<TYPE> holder(samples);\
+template <> inline ::dds::sub::LoanedSamples<TYPE> \
+DataReader<TYPE>::METHOD(const Selector& selector) {\
+    ::dds::sub::LoanedSamples<TYPE> samples;\
+    LoanedSamplesHolder<TYPE> holder(samples);\
     switch(selector.mode) {\
     case SELECT_MODE_READ:\
-        readtake<TYPE, detail::LoanedSamplesHolder<TYPE> >(\
+        readtake<TYPE, LoanedSamplesHolder<TYPE> >(\
             holder, this->ddsc_entity, TF, selector.state_filter_, selector.max_samples_, &FNCTN<TYPE>);\
         break;\
     default:\
@@ -1553,19 +1554,19 @@ detail::DataReader<TYPE>::METHOD(const Selector& selector) {\
 
 #define iteratorfunction(TYPE, METHOD, TF, FNCTN)\
 template <> template <typename SamplesFWIterator> inline uint32_t \
-detail::DataReader<TYPE>::METHOD(SamplesFWIterator samples, uint32_t max_samples) {\
-    detail::SamplesFWIteratorHolder<TYPE, SamplesFWIterator> holder(samples);\
-    status::DataState state;\
-    readtake<TYPE, detail::SamplesFWIteratorHolder<TYPE, SamplesFWIterator> >(\
+DataReader<TYPE>::METHOD(SamplesFWIterator samples, uint32_t max_samples) {\
+    SamplesFWIteratorHolder<TYPE, SamplesFWIterator> holder(samples);\
+    ::dds::sub::status::DataState state;\
+    readtake<TYPE, SamplesFWIteratorHolder<TYPE, SamplesFWIterator> >(\
         holder, this->ddsc_entity, TF, state, max_samples, &FNCTN<TYPE>);\
     return holder.get_length();\
 }\
 template <> template <typename SamplesFWIterator> inline uint32_t \
-detail::DataReader<TYPE>::METHOD(SamplesFWIterator samples, uint32_t max_samples, const Selector& selector) {\
-    detail::SamplesFWIteratorHolder<TYPE, SamplesFWIterator> holder(samples);\
+DataReader<TYPE>::METHOD(SamplesFWIterator samples, uint32_t max_samples, const Selector& selector) {\
+    SamplesFWIteratorHolder<TYPE, SamplesFWIterator> holder(samples);\
     switch(selector.mode) {\
     case SELECT_MODE_READ:\
-        readtake<TYPE, detail::SamplesFWIteratorHolder<TYPE, SamplesFWIterator> >(\
+        readtake<TYPE, SamplesFWIteratorHolder<TYPE, SamplesFWIterator> >(\
             holder, this->ddsc_entity, TF, selector.state_filter_, std::min<uint32_t>(selector.max_samples_, max_samples), &FNCTN<TYPE>);\
         break;\
     default:\
@@ -1574,19 +1575,19 @@ detail::DataReader<TYPE>::METHOD(SamplesFWIterator samples, uint32_t max_samples
     return holder.get_length();\
 }\
 template <> template <typename SamplesBIIterator> inline uint32_t \
-detail::DataReader<TYPE>::METHOD(SamplesBIIterator samples) {\
-    detail::SamplesBIIteratorHolder<TYPE, SamplesBIIterator> holder(samples);\
-    status::DataState state;\
-    readtake<TYPE, detail::SamplesBIIteratorHolder<TYPE, SamplesBIIterator> >(\
+DataReader<TYPE>::METHOD(SamplesBIIterator samples) {\
+    SamplesBIIteratorHolder<TYPE, SamplesBIIterator> holder(samples);\
+    ::dds::sub::status::DataState state;\
+    readtake<TYPE, SamplesBIIteratorHolder<TYPE, SamplesBIIterator> >(\
         holder, this->ddsc_entity, TF, state, MAX_SAMPLES, &FNCTN<TYPE>);\
     return holder.get_length();\
 }\
 template <> template <typename SamplesBIIterator> inline uint32_t \
-detail::DataReader<TYPE>::METHOD(SamplesBIIterator samples, const Selector& selector) {\
-    detail::SamplesBIIteratorHolder<TYPE, SamplesBIIterator> holder(samples);\
+DataReader<TYPE>::METHOD(SamplesBIIterator samples, const Selector& selector) {\
+    SamplesBIIteratorHolder<TYPE, SamplesBIIterator> holder(samples);\
     switch(selector.mode) {\
     case SELECT_MODE_READ:\
-        readtake<TYPE, detail::SamplesBIIteratorHolder<TYPE, SamplesBIIterator> >(\
+        readtake<TYPE, SamplesBIIteratorHolder<TYPE, SamplesBIIterator> >(\
             holder, this->ddsc_entity, TF, selector.state_filter_, selector.max_samples_, &FNCTN<TYPE>);\
         break;\
     default:\
@@ -1619,6 +1620,7 @@ typefunctions(dds::topic::PublicationBuiltinTopicData, convert_builtin_pubsub)
 #undef iteratorfunctions
 #undef typefunctions
 
+}  /* namespace detail */
 }  /* namespace sub */
 }  /* namespace dds */
 

--- a/src/ddscxx/include/dds/topic/BuiltinTopic.hpp
+++ b/src/ddscxx/include/dds/topic/BuiltinTopic.hpp
@@ -20,6 +20,7 @@
  */
 
 #include <dds/topic/detail/BuiltinTopic.hpp>
+#include <dds/topic/TopicTraits.hpp>
 
 namespace dds
 {
@@ -34,8 +35,39 @@ typedef dds::topic::detail::PublicationBuiltinTopicData PublicationBuiltinTopicD
 
 typedef dds::topic::detail::SubscriptionBuiltinTopicData SubscriptionBuiltinTopicData;
 
-}
-}
+template <>
+Topic<ParticipantBuiltinTopicData, detail::Topic>::Topic(
+    const dds::domain::DomainParticipant& dp,
+    const std::string& topic_name);
 
+template <>
+Topic<TopicBuiltinTopicData, detail::Topic>::Topic(
+    const dds::domain::DomainParticipant& dp,
+    const std::string& topic_name);
+
+template <>
+Topic<PublicationBuiltinTopicData, detail::Topic>::Topic(
+    const dds::domain::DomainParticipant& dp,
+    const std::string& topic_name);
+
+template <>
+Topic<SubscriptionBuiltinTopicData, detail::Topic>::Topic(
+    const dds::domain::DomainParticipant& dp,
+    const std::string& topic_name);
+
+} /* topic */
+} /* dds */
+
+REGISTER_TOPIC_TYPE(ParticipantBuiltinTopicData)
+REGISTER_TOPIC_TYPE(TopicBuiltinTopicData)
+REGISTER_TOPIC_TYPE(PublicationBuiltinTopicData)
+REGISTER_TOPIC_TYPE(SubscriptionBuiltinTopicData)
+
+template<typename T>
+using IsBuiltinTopicType = std::enable_if_t<
+        std::is_same<T,dds::topic::ParticipantBuiltinTopicData>::value
+     || std::is_same<T,dds::topic::TopicBuiltinTopicData>::value
+     || std::is_same<T,dds::topic::SubscriptionBuiltinTopicData>::value
+     || std::is_same<T,dds::topic::PublicationBuiltinTopicData>::value, bool >;
 
 #endif /* OMG_DDS_TOPIC_BUILTIN_TOPIC_HPP_ */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinDataTopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinDataTopic.hpp
@@ -1,0 +1,209 @@
+/*
+ * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+
+/**
+ * @file
+ */
+
+#ifndef CYCLONEDDS_TOP_BUILTINDATATOPIC_HPP_
+#define CYCLONEDDS_TOP_BUILTINDATATOPIC_HPP_
+
+#include <org/eclipse/cyclonedds/topic/datatopic.hpp>
+#include <dds/topic/BuiltinTopic.hpp>
+#include <org/eclipse/cyclonedds/topic/BuiltinTopicTraits.hpp>
+#include <dds/core/macros.hpp>
+
+/**
+ * Generic builtin topic serdata function declarations.
+ */
+
+OMG_DDS_API_DETAIL
+bool builtin_serdata_eqkey(const ddsi_serdata* a, const ddsi_serdata* b);
+
+OMG_DDS_API_DETAIL
+uint32_t builtin_serdata_size(const ddsi_serdata* dcmn);
+
+OMG_DDS_API_DETAIL
+ddsi_serdata *builtin_serdata_from_ser(
+  const ddsi_sertype* type,
+  enum ddsi_serdata_kind kind,
+  const struct nn_rdata* fragchain,
+  size_t size);
+
+OMG_DDS_API_DETAIL
+ddsi_serdata *builtin_serdata_from_ser_iov(
+  const ddsi_sertype* type,
+  enum ddsi_serdata_kind kind,
+  ddsrt_msg_iovlen_t niov,
+  const ddsrt_iovec_t* iov,
+  size_t size);
+
+OMG_DDS_API_DETAIL
+ddsi_serdata *builtin_serdata_from_keyhash(
+  const ddsi_sertype* type,
+  const struct ddsi_keyhash* keyhash);
+
+OMG_DDS_API_DETAIL
+ddsi_serdata *builtin_serdata_from_sample(
+  const ddsi_sertype* typecmn,
+  enum ddsi_serdata_kind kind,
+  const void* sample);
+
+OMG_DDS_API_DETAIL
+void builtin_serdata_to_ser(const ddsi_serdata* dcmn, size_t off, size_t sz, void* buf);
+
+OMG_DDS_API_DETAIL ddsi_serdata *builtin_serdata_to_ser_ref(
+  const ddsi_serdata* dcmn, size_t off,
+  size_t sz, ddsrt_iovec_t* ref);
+
+OMG_DDS_API_DETAIL
+void builtin_serdata_to_ser_unref(ddsi_serdata* dcmn, const ddsrt_iovec_t* ref);
+
+OMG_DDS_API_DETAIL
+bool builtin_serdata_to_sample(
+  const ddsi_serdata* dcmn, void* sample, void** bufptr,
+  void* buflim);
+
+OMG_DDS_API_DETAIL
+ddsi_serdata *builtin_serdata_to_untyped(const ddsi_serdata* dcmn);
+
+OMG_DDS_API_DETAIL
+bool builtin_serdata_untyped_to_sample(
+  const ddsi_sertype* type,
+  const ddsi_serdata* dcmn, void* sample,
+  void** bufptr, void* buflim);
+
+OMG_DDS_API_DETAIL
+void builtin_serdata_get_keyhash(
+  const ddsi_serdata* d, struct ddsi_keyhash* buf,
+  bool force_md5);
+
+/**
+ * Builtin topic serdata function template specialization declarations.
+ */
+
+template <>
+OMG_DDS_API_DETAIL
+dds::topic::ParticipantBuiltinTopicData* ddscxx_serdata<dds::topic::ParticipantBuiltinTopicData>::getT();
+
+template <>
+OMG_DDS_API_DETAIL
+dds::topic::TopicBuiltinTopicData* ddscxx_serdata<dds::topic::TopicBuiltinTopicData>::getT();
+
+template <>
+OMG_DDS_API_DETAIL
+dds::topic::PublicationBuiltinTopicData* ddscxx_serdata<dds::topic::PublicationBuiltinTopicData>::getT();
+
+template <>
+OMG_DDS_API_DETAIL
+dds::topic::SubscriptionBuiltinTopicData* ddscxx_serdata<dds::topic::SubscriptionBuiltinTopicData>::getT();
+
+/**
+ * Due to a bug in MSVC template class static const member need to be initialized in-place.
+ */
+
+#ifdef _WIN32
+
+template <>
+const ddsi_serdata_ops ddscxx_serdata<dds::topic::ParticipantBuiltinTopicData>::ddscxx_serdata_ops = {
+  &builtin_serdata_eqkey,
+  &builtin_serdata_size,
+  &builtin_serdata_from_ser,
+  &builtin_serdata_from_ser_iov,
+  &builtin_serdata_from_keyhash,
+  &builtin_serdata_from_sample,
+  &builtin_serdata_to_ser,
+  &builtin_serdata_to_ser_ref,
+  &builtin_serdata_to_ser_unref,
+  &builtin_serdata_to_sample,
+  &builtin_serdata_to_untyped,
+  &builtin_serdata_untyped_to_sample,
+  &serdata_free<dds::topic::ParticipantBuiltinTopicData>,
+  &serdata_print<dds::topic::ParticipantBuiltinTopicData>,
+  &builtin_serdata_get_keyhash
+};
+
+template <>
+const ddsi_serdata_ops ddscxx_serdata<dds::topic::TopicBuiltinTopicData>::ddscxx_serdata_ops = {
+  &builtin_serdata_eqkey,
+  &builtin_serdata_size,
+  &builtin_serdata_from_ser,
+  &builtin_serdata_from_ser_iov,
+  &builtin_serdata_from_keyhash,
+  &builtin_serdata_from_sample,
+  &builtin_serdata_to_ser,
+  &builtin_serdata_to_ser_ref,
+  &builtin_serdata_to_ser_unref,
+  &builtin_serdata_to_sample,
+  &builtin_serdata_to_untyped,
+  &builtin_serdata_untyped_to_sample,
+  &serdata_free<dds::topic::TopicBuiltinTopicData>,
+  &serdata_print<dds::topic::TopicBuiltinTopicData>,
+  &builtin_serdata_get_keyhash
+};
+
+template <>
+const ddsi_serdata_ops ddscxx_serdata<dds::topic::SubscriptionBuiltinTopicData>::ddscxx_serdata_ops = {
+  &builtin_serdata_eqkey,
+  &builtin_serdata_size,
+  &builtin_serdata_from_ser,
+  &builtin_serdata_from_ser_iov,
+  &builtin_serdata_from_keyhash,
+  &builtin_serdata_from_sample,
+  &builtin_serdata_to_ser,
+  &builtin_serdata_to_ser_ref,
+  &builtin_serdata_to_ser_unref,
+  &builtin_serdata_to_sample,
+  &builtin_serdata_to_untyped,
+  &builtin_serdata_untyped_to_sample,
+  &serdata_free<dds::topic::SubscriptionBuiltinTopicData>,
+  &serdata_print<dds::topic::SubscriptionBuiltinTopicData>,
+  &builtin_serdata_get_keyhash
+};
+
+template <>
+const ddsi_serdata_ops ddscxx_serdata<dds::topic::PublicationBuiltinTopicData>::ddscxx_serdata_ops = {
+  &builtin_serdata_eqkey,
+  &builtin_serdata_size,
+  &builtin_serdata_from_ser,
+  &builtin_serdata_from_ser_iov,
+  &builtin_serdata_from_keyhash,
+  &builtin_serdata_from_sample,
+  &builtin_serdata_to_ser,
+  &builtin_serdata_to_ser_ref,
+  &builtin_serdata_to_ser_unref,
+  &builtin_serdata_to_sample,
+  &builtin_serdata_to_untyped,
+  &builtin_serdata_untyped_to_sample,
+  &serdata_free<dds::topic::PublicationBuiltinTopicData>,
+  &serdata_print<dds::topic::PublicationBuiltinTopicData>,
+  &builtin_serdata_get_keyhash
+};
+
+#else
+
+template <>
+const ddsi_serdata_ops ddscxx_serdata<dds::topic::ParticipantBuiltinTopicData>::ddscxx_serdata_ops;
+
+template <>
+const ddsi_serdata_ops ddscxx_serdata<dds::topic::TopicBuiltinTopicData>::ddscxx_serdata_ops;
+
+template <>
+const ddsi_serdata_ops ddscxx_serdata<dds::topic::SubscriptionBuiltinTopicData>::ddscxx_serdata_ops;
+
+template <>
+const ddsi_serdata_ops ddscxx_serdata<dds::topic::PublicationBuiltinTopicData>::ddscxx_serdata_ops;
+
+#endif  /* _WIN32 */
+
+#endif  /* CYCLONEDDS_TOP_BUILTINDATATOPIC_HPP_ */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinDataTopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinDataTopic.hpp
@@ -15,8 +15,8 @@
  * @file
  */
 
-#ifndef CYCLONEDDS_TOP_BUILTINDATATOPIC_HPP_
-#define CYCLONEDDS_TOP_BUILTINDATATOPIC_HPP_
+#ifndef CYCLONEDDS_TOPIC_BUILTINDATATOPIC_HPP_
+#define CYCLONEDDS_TOPIC_BUILTINDATATOPIC_HPP_
 
 #include <org/eclipse/cyclonedds/topic/datatopic.hpp>
 #include <dds/topic/BuiltinTopic.hpp>
@@ -28,182 +28,166 @@
  */
 
 OMG_DDS_API_DETAIL
-bool builtin_serdata_eqkey(const ddsi_serdata* a, const ddsi_serdata* b);
+bool builtin_serdata_eqkey(
+  const ddsi_serdata*,
+  const ddsi_serdata*);
 
 OMG_DDS_API_DETAIL
-uint32_t builtin_serdata_size(const ddsi_serdata* dcmn);
+uint32_t builtin_serdata_size(
+  const ddsi_serdata*);
 
 OMG_DDS_API_DETAIL
 ddsi_serdata *builtin_serdata_from_ser(
-  const ddsi_sertype* type,
-  enum ddsi_serdata_kind kind,
-  const struct nn_rdata* fragchain,
+  const ddsi_sertype*,
+  enum ddsi_serdata_kind,
+  const struct nn_rdata*,
   size_t size);
 
 OMG_DDS_API_DETAIL
 ddsi_serdata *builtin_serdata_from_ser_iov(
-  const ddsi_sertype* type,
-  enum ddsi_serdata_kind kind,
-  ddsrt_msg_iovlen_t niov,
-  const ddsrt_iovec_t* iov,
-  size_t size);
+  const ddsi_sertype*,
+  enum ddsi_serdata_kind,
+  ddsrt_msg_iovlen_t,
+  const ddsrt_iovec_t*,
+  size_t);
 
 OMG_DDS_API_DETAIL
 ddsi_serdata *builtin_serdata_from_keyhash(
-  const ddsi_sertype* type,
-  const struct ddsi_keyhash* keyhash);
+  const ddsi_sertype*,
+  const struct ddsi_keyhash*);
 
 OMG_DDS_API_DETAIL
 ddsi_serdata *builtin_serdata_from_sample(
-  const ddsi_sertype* typecmn,
-  enum ddsi_serdata_kind kind,
-  const void* sample);
+  const ddsi_sertype*,
+  enum ddsi_serdata_kind,
+  const void*);
 
 OMG_DDS_API_DETAIL
-void builtin_serdata_to_ser(const ddsi_serdata* dcmn, size_t off, size_t sz, void* buf);
+void builtin_serdata_to_ser(
+  const ddsi_serdata*,
+  size_t,
+  size_t,
+  void*);
 
 OMG_DDS_API_DETAIL ddsi_serdata *builtin_serdata_to_ser_ref(
-  const ddsi_serdata* dcmn, size_t off,
-  size_t sz, ddsrt_iovec_t* ref);
+  const ddsi_serdata*,
+  size_t,
+  size_t,
+  ddsrt_iovec_t*);
 
 OMG_DDS_API_DETAIL
-void builtin_serdata_to_ser_unref(ddsi_serdata* dcmn, const ddsrt_iovec_t* ref);
+void builtin_serdata_to_ser_unref(
+  ddsi_serdata*,
+  const ddsrt_iovec_t*);
 
 OMG_DDS_API_DETAIL
 bool builtin_serdata_to_sample(
-  const ddsi_serdata* dcmn, void* sample, void** bufptr,
-  void* buflim);
+  const ddsi_serdata*,
+  void*,
+  void**,
+  void*);
 
 OMG_DDS_API_DETAIL
-ddsi_serdata *builtin_serdata_to_untyped(const ddsi_serdata* dcmn);
+ddsi_serdata *builtin_serdata_to_untyped(
+  const ddsi_serdata*);
 
 OMG_DDS_API_DETAIL
 bool builtin_serdata_untyped_to_sample(
-  const ddsi_sertype* type,
-  const ddsi_serdata* dcmn, void* sample,
-  void** bufptr, void* buflim);
+  const ddsi_sertype*,
+  const ddsi_serdata*,
+  void*,
+  void**,
+  void*);
 
 OMG_DDS_API_DETAIL
 void builtin_serdata_get_keyhash(
-  const ddsi_serdata* d, struct ddsi_keyhash* buf,
-  bool force_md5);
+  const ddsi_serdata*,
+  struct ddsi_keyhash*,
+  bool);
+
+#ifdef DDSCXX_HAS_SHM
+OMG_DDS_API_DETAIL
+uint32_t builtin_serdata_iox_size(
+  const struct ddsi_serdata*);
+
+OMG_DDS_API_DETAIL
+ddsi_serdata * builtin_serdata_from_iox_buffer(
+  const struct ddsi_sertype *,
+  enum ddsi_serdata_kind,
+  void *,
+  void *);
+#endif
 
 /**
  * Builtin topic serdata function template specialization declarations.
  */
 
-template <>
-OMG_DDS_API_DETAIL
-dds::topic::ParticipantBuiltinTopicData* ddscxx_serdata<dds::topic::ParticipantBuiltinTopicData>::getT();
-
-template <>
-OMG_DDS_API_DETAIL
-dds::topic::TopicBuiltinTopicData* ddscxx_serdata<dds::topic::TopicBuiltinTopicData>::getT();
-
-template <>
-OMG_DDS_API_DETAIL
-dds::topic::PublicationBuiltinTopicData* ddscxx_serdata<dds::topic::PublicationBuiltinTopicData>::getT();
-
-template <>
-OMG_DDS_API_DETAIL
-dds::topic::SubscriptionBuiltinTopicData* ddscxx_serdata<dds::topic::SubscriptionBuiltinTopicData>::getT();
+#ifdef DDSCXX_HAS_SHM
+#define builtin_topic_ops(builtin_topic_type)\
+template <> const ddsi_serdata_ops ddscxx_serdata<dds::topic::builtin_topic_type>::ddscxx_serdata_ops = {\
+  &builtin_serdata_eqkey,\
+  &builtin_serdata_size,\
+  &builtin_serdata_from_ser,\
+  &builtin_serdata_from_ser_iov,\
+  &builtin_serdata_from_keyhash,\
+  &builtin_serdata_from_sample,\
+  &builtin_serdata_to_ser,\
+  &builtin_serdata_to_ser_ref,\
+  &builtin_serdata_to_ser_unref,\
+  &builtin_serdata_to_sample,\
+  &builtin_serdata_to_untyped,\
+  &builtin_serdata_untyped_to_sample,\
+  &serdata_free<dds::topic::builtin_topic_type>,\
+  &serdata_print<dds::topic::builtin_topic_type>,\
+  &builtin_serdata_get_keyhash,\
+  &builtin_serdata_iox_size,\
+  &builtin_serdata_from_iox_buffer\
+};
+#else
+#define builtin_topic_ops(builtin_topic_type)\
+template <> const ddsi_serdata_ops ddscxx_serdata<dds::topic::builtin_topic_type>::ddscxx_serdata_ops = {\
+  &builtin_serdata_eqkey,\
+  &builtin_serdata_size,\
+  &builtin_serdata_from_ser,\
+  &builtin_serdata_from_ser_iov,\
+  &builtin_serdata_from_keyhash,\
+  &builtin_serdata_from_sample,\
+  &builtin_serdata_to_ser,\
+  &builtin_serdata_to_ser_ref,\
+  &builtin_serdata_to_ser_unref,\
+  &builtin_serdata_to_sample,\
+  &builtin_serdata_to_untyped,\
+  &builtin_serdata_untyped_to_sample,\
+  &serdata_free<dds::topic::builtin_topic_type>,\
+  &serdata_print<dds::topic::builtin_topic_type>,\
+  &builtin_serdata_get_keyhash\
+};
+#endif
 
 /**
  * Due to a bug in MSVC template class static const member need to be initialized in-place.
  */
 
 #ifdef _WIN32
-
-template <>
-const ddsi_serdata_ops ddscxx_serdata<dds::topic::ParticipantBuiltinTopicData>::ddscxx_serdata_ops = {
-  &builtin_serdata_eqkey,
-  &builtin_serdata_size,
-  &builtin_serdata_from_ser,
-  &builtin_serdata_from_ser_iov,
-  &builtin_serdata_from_keyhash,
-  &builtin_serdata_from_sample,
-  &builtin_serdata_to_ser,
-  &builtin_serdata_to_ser_ref,
-  &builtin_serdata_to_ser_unref,
-  &builtin_serdata_to_sample,
-  &builtin_serdata_to_untyped,
-  &builtin_serdata_untyped_to_sample,
-  &serdata_free<dds::topic::ParticipantBuiltinTopicData>,
-  &serdata_print<dds::topic::ParticipantBuiltinTopicData>,
-  &builtin_serdata_get_keyhash
-};
-
-template <>
-const ddsi_serdata_ops ddscxx_serdata<dds::topic::TopicBuiltinTopicData>::ddscxx_serdata_ops = {
-  &builtin_serdata_eqkey,
-  &builtin_serdata_size,
-  &builtin_serdata_from_ser,
-  &builtin_serdata_from_ser_iov,
-  &builtin_serdata_from_keyhash,
-  &builtin_serdata_from_sample,
-  &builtin_serdata_to_ser,
-  &builtin_serdata_to_ser_ref,
-  &builtin_serdata_to_ser_unref,
-  &builtin_serdata_to_sample,
-  &builtin_serdata_to_untyped,
-  &builtin_serdata_untyped_to_sample,
-  &serdata_free<dds::topic::TopicBuiltinTopicData>,
-  &serdata_print<dds::topic::TopicBuiltinTopicData>,
-  &builtin_serdata_get_keyhash
-};
-
-template <>
-const ddsi_serdata_ops ddscxx_serdata<dds::topic::SubscriptionBuiltinTopicData>::ddscxx_serdata_ops = {
-  &builtin_serdata_eqkey,
-  &builtin_serdata_size,
-  &builtin_serdata_from_ser,
-  &builtin_serdata_from_ser_iov,
-  &builtin_serdata_from_keyhash,
-  &builtin_serdata_from_sample,
-  &builtin_serdata_to_ser,
-  &builtin_serdata_to_ser_ref,
-  &builtin_serdata_to_ser_unref,
-  &builtin_serdata_to_sample,
-  &builtin_serdata_to_untyped,
-  &builtin_serdata_untyped_to_sample,
-  &serdata_free<dds::topic::SubscriptionBuiltinTopicData>,
-  &serdata_print<dds::topic::SubscriptionBuiltinTopicData>,
-  &builtin_serdata_get_keyhash
-};
-
-template <>
-const ddsi_serdata_ops ddscxx_serdata<dds::topic::PublicationBuiltinTopicData>::ddscxx_serdata_ops = {
-  &builtin_serdata_eqkey,
-  &builtin_serdata_size,
-  &builtin_serdata_from_ser,
-  &builtin_serdata_from_ser_iov,
-  &builtin_serdata_from_keyhash,
-  &builtin_serdata_from_sample,
-  &builtin_serdata_to_ser,
-  &builtin_serdata_to_ser_ref,
-  &builtin_serdata_to_ser_unref,
-  &builtin_serdata_to_sample,
-  &builtin_serdata_to_untyped,
-  &builtin_serdata_untyped_to_sample,
-  &serdata_free<dds::topic::PublicationBuiltinTopicData>,
-  &serdata_print<dds::topic::PublicationBuiltinTopicData>,
-  &builtin_serdata_get_keyhash
-};
-
+#define builtin_topic_ops_decl(builtin_topic_type)\
+builtin_topic_ops(builtin_topic_type)
 #else
+#define builtin_topic_ops_decl(builtin_topic_type)\
+template <> const ddsi_serdata_ops ddscxx_serdata<dds::topic::builtin_topic_type>::ddscxx_serdata_ops;
+#endif
 
-template <>
-const ddsi_serdata_ops ddscxx_serdata<dds::topic::ParticipantBuiltinTopicData>::ddscxx_serdata_ops;
+#define builtin_topic_decl(builtin_topic_type)\
+template <> OMG_DDS_API_DETAIL \
+dds::topic::builtin_topic_type* ddscxx_serdata<dds::topic::builtin_topic_type>::getT();\
+template <> OMG_DDS_API_DETAIL \
+bool sertype_serialize_into<dds::topic::builtin_topic_type>(const ddsi_sertype*, const void*, void*, size_t);\
+template <> OMG_DDS_API_DETAIL \
+size_t sertype_get_serialized_size<dds::topic::builtin_topic_type>(const ddsi_sertype*, const void*);\
+builtin_topic_ops_decl(builtin_topic_type)
 
-template <>
-const ddsi_serdata_ops ddscxx_serdata<dds::topic::TopicBuiltinTopicData>::ddscxx_serdata_ops;
+builtin_topic_decl(ParticipantBuiltinTopicData)
+builtin_topic_decl(TopicBuiltinTopicData)
+builtin_topic_decl(PublicationBuiltinTopicData)
+builtin_topic_decl(SubscriptionBuiltinTopicData)
 
-template <>
-const ddsi_serdata_ops ddscxx_serdata<dds::topic::SubscriptionBuiltinTopicData>::ddscxx_serdata_ops;
-
-template <>
-const ddsi_serdata_ops ddscxx_serdata<dds::topic::PublicationBuiltinTopicData>::ddscxx_serdata_ops;
-
-#endif  /* _WIN32 */
-
-#endif  /* CYCLONEDDS_TOP_BUILTINDATATOPIC_HPP_ */
+#endif  /* CYCLONEDDS_TOPIC_BUILTINDATATOPIC_HPP_ */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicDelegate.hpp
@@ -56,9 +56,9 @@ public:
         return key_;
     }
 
-    void key(const int32_t* key)
+    void key(const uint8_t* key)
     {
-        key_.delegate().value(const_cast<int32_t*>(key));
+        key_.delegate().value(key);
     }
 
     const ::dds::core::policy::UserData& user_data() const
@@ -69,6 +69,11 @@ public:
     void user_data(const dds_qos_t* policy)
     {
         user_data_.delegate().set_iso_policy(policy);
+    }
+
+    void qos(const dds_qos_t* policy)
+    {
+        user_data(policy);
     }
 
     bool operator ==(const ParticipantBuiltinTopicDataDelegate& other) const
@@ -89,9 +94,9 @@ public:
         return key_;
     }
 
-    void key(const int32_t* key)
+    void key(const uint8_t* key)
     {
-        key_.delegate().value(const_cast<int32_t*>(key));
+        key_.delegate().value(key);
     }
 
     const std::string&                  name() const
@@ -250,6 +255,23 @@ public:
         topic_data_.delegate().set_iso_policy(policy);
     }
 
+    void qos(const dds_qos_t* policy)
+    {
+        durability(policy);
+#ifdef  OMG_DDS_PERSISTENCE_SUPPORT
+        durability_service(policy);
+#endif  // OMG_DDS_PERSISTENCE_SUPPORT
+        deadline(policy);
+        latency_budget(policy);
+        liveliness(policy);
+        transport_priority(policy);
+        lifespan(policy);
+        destination_order(policy);
+        history(policy);
+        resource_limits(policy);
+        topic_data(policy);
+    }
+
     bool operator ==(const TopicBuiltinTopicDataDelegate& other) const
     {
         return other.key_ == key_
@@ -309,9 +331,9 @@ public:
         return key_;
     }
 
-    void key(const int32_t* key)
+    void key(const uint8_t* key)
     {
-        key_.delegate().value(const_cast<int32_t*>(key));
+        key_.delegate().value(key);
     }
 
     const dds::topic::BuiltinTopicKey& participant_key() const
@@ -319,9 +341,9 @@ public:
         return participant_key_;
     }
 
-    void participant_key(const int32_t* key)
+    void participant_key(const uint8_t* key)
     {
-        participant_key_.delegate().value(const_cast<int32_t*>(key));
+        participant_key_.delegate().value(key);
     }
 
     const std::string&                  topic_name() const
@@ -359,6 +381,11 @@ public:
     const ::dds::core::policy::DurabilityService&  durability_service() const
     {
         return durability_service_;
+    }
+
+    void durability_service(const dds_qos_t* policy)
+    {
+        durability_service_.delegate().set_iso_policy(policy);
     }
 
 #endif  // OMG_DDS_PERSISTENCE_SUPPORT
@@ -499,6 +526,28 @@ public:
         group_data_.delegate().set_iso_policy(policy);
     }
 
+    void qos(const dds_qos_t* policy)
+    {
+        durability(policy);
+    #ifdef  OMG_DDS_PERSISTENCE_SUPPORT
+        durability_service(policy);
+    #endif  // OMG_DDS_PERSISTENCE_SUPPORT
+        deadline(policy);
+        latency_budget(policy);
+        liveliness(policy);
+        reliability(policy);
+        lifespan(policy);
+        user_data(policy);
+        ownership(policy);
+    #ifdef  OMG_DDS_OWNERSHIP_SUPPORT
+        ownership_strength(policy);
+    #endif  // OMG_DDS_OWNERSHIP_SUPPORT
+        destination_order(policy);
+        presentation(policy);
+        partition(policy);
+        topic_data(policy);
+        group_data(policy);
+    }
 
     bool operator ==(const PublicationBuiltinTopicDataDelegate& other) const
     {
@@ -567,9 +616,9 @@ public:
         return key_;
     }
 
-    void key(const int32_t* key)
+    void key(const uint8_t* key)
     {
-        key_.delegate().value(const_cast<int32_t*>(key));
+        key_.delegate().value(key);
     }
 
     const dds::topic::BuiltinTopicKey& participant_key() const
@@ -577,9 +626,9 @@ public:
         return participant_key_;
     }
 
-    void participant_key(const int32_t* key)
+    void participant_key(const uint8_t* key)
     {
-        participant_key_.delegate().value(const_cast<int32_t*>(key));
+        participant_key_.delegate().value(key);
     }
 
     const std::string&                  topic_name() const
@@ -732,6 +781,23 @@ public:
         group_data_.delegate().set_iso_policy(policy);
     }
 
+    void qos(const dds_qos_t* policy)
+    {
+        durability(policy);
+        deadline(policy);
+        latency_budget(policy);
+        liveliness(policy);
+        reliability(policy);
+        ownership(policy);
+        destination_order(policy);
+        user_data(policy);
+        time_based_filter(policy);
+        presentation(policy);
+        partition(policy);
+        topic_data(policy);
+        group_data(policy);
+    }
+
     bool operator ==(const SubscriptionBuiltinTopicDataDelegate& other) const
     {
         return other.key_ == key_
@@ -785,9 +851,9 @@ public:
         return key_;
     }
 
-    void key(const int32_t* key)
+    void key(const uint8_t* key)
     {
-        key_.delegate().value(const_cast<int32_t*>(key));
+        key_.delegate().value(key);
     }
 
     bool operator ==(const CMParticipantBuiltinTopicDataDelegate& other) const
@@ -811,9 +877,9 @@ public:
         return key_;
     }
 
-    void key(const int32_t* key)
+    void key(const uint8_t* key)
     {
-        key_.delegate().value(const_cast<int32_t*>(key));
+        key_.delegate().value(key);
     }
 
     const dds::topic::BuiltinTopicKey&        participant_key() const
@@ -821,9 +887,9 @@ public:
         return participant_key_;
     }
 
-    void participant_key(const int32_t* key)
+    void participant_key(const uint8_t* key)
     {
-        participant_key_.delegate().value(const_cast<int32_t*>(key));
+        participant_key_.delegate().value(key);
     }
 
     const std::string&                        name() const
@@ -885,9 +951,9 @@ public:
         return key_;
     }
 
-    void key(const int32_t* key)
+    void key(const uint8_t* key)
     {
-        key_.delegate().value(const_cast<int32_t*>(key));
+        key_.delegate().value(key);
     }
 
     const dds::topic::BuiltinTopicKey&        participant_key() const
@@ -895,9 +961,9 @@ public:
         return participant_key_;
     }
 
-    void participant_key(const int32_t* key)
+    void participant_key(const uint8_t* key)
     {
-        participant_key_.delegate().value(const_cast<int32_t*>(key));
+        participant_key_.delegate().value(key);
     }
 
     const std::string&                        name() const
@@ -961,7 +1027,7 @@ public:
 
     void key(const dds_qos_t* key)
     {
-        key_.delegate().value(const_cast<int32_t*>(reinterpret_cast<const int32_t*>(key)));
+        key_.delegate().value(reinterpret_cast<const uint8_t*>(key));
     }
 
     const dds::topic::BuiltinTopicKey&              publisher_key() const
@@ -971,7 +1037,7 @@ public:
 
     void publisher_key(const dds_qos_t* key)
     {
-        publisher_key_.delegate().value(const_cast<int32_t*>(reinterpret_cast<const int32_t*>(key)));
+        publisher_key_.delegate().value(reinterpret_cast<const uint8_t*>(key));
     }
 
     const std::string&                              name() const
@@ -1045,9 +1111,9 @@ public:
         return key_;
     }
 
-    void key(const int32_t* key)
+    void key(const uint8_t* key)
     {
-        key_.delegate().value(const_cast<int32_t*>(key));
+        key_.delegate().value(key);
     }
 
     const dds::topic::BuiltinTopicKey&              subscriber_key() const
@@ -1055,9 +1121,9 @@ public:
         return subscriber_key_;
     }
 
-    void subscriber_key(const int32_t* key)
+    void subscriber_key(const uint8_t* key)
     {
-        subscriber_key_.delegate().value(const_cast<int32_t*>(key));
+        subscriber_key_.delegate().value(key);
     }
 
     const std::string&                              name() const

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicKeyDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicKeyDelegate.hpp
@@ -18,6 +18,8 @@
 #ifndef CYCLONEDDS_TOPIC_BUILTIN_TOPIC_KEY_DELEGATE_HPP_
 #define CYCLONEDDS_TOPIC_BUILTIN_TOPIC_KEY_DELEGATE_HPP_
 
+#include <array>
+
 namespace org
 {
 namespace eclipse
@@ -30,37 +32,29 @@ namespace topic
 class BuiltinTopicKeyDelegate
 {
 public:
-    typedef uint32_t VALUE_T;
-public:
     BuiltinTopicKeyDelegate() { }
-    BuiltinTopicKeyDelegate(int32_t v[])
+    BuiltinTopicKeyDelegate(const uint8_t *v)
     {
-        key_[0] = v[0];
-        key_[1] = v[1];
-        key_[2] = v[2];
+        memcpy(key_.data(), v, key_.size());
     }
 public:
-    const int32_t* value() const
+    const uint8_t* value() const
     {
-        return key_;
+        return key_.data();
     }
 
-    void value(int32_t v[])
+    void value(const uint8_t *v)
     {
-        key_[0] = v[0];
-        key_[1] = v[1];
-        key_[2] = v[2];
+        memcpy(key_.data(), v, key_.size());
     }
 
     bool operator ==(const BuiltinTopicKeyDelegate& other) const
     {
-        return other.key_[0] == key_[0]
-                 && other.key_[1] == key_[1]
-                 && other.key_[2] == key_[2];
+        return other.key_ == key_;
     }
 
 private:
-    int32_t key_[3];
+    std::array<uint8_t, 16> key_;
 };
 
 }

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicTraits.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicTraits.hpp
@@ -16,6 +16,142 @@
 #include <org/eclipse/cyclonedds/topic/TopicTraits.hpp>
 #include <org/eclipse/cyclonedds/topic/BuiltinTopicCopy.hpp>
 
-/* TODO: add builtin topic traits. */
+namespace org
+{
+namespace eclipse
+{
+namespace cyclonedds
+{
+namespace topic
+{
+
+template <>
+class TopicTraits<dds::topic::ParticipantBuiltinTopicData>
+{
+public:
+  static bool isKeyless()
+  {
+    return true;
+  }
+
+  static const char *getTypeName()
+  {
+    return "dds::topic::ParticipantBuiltinTopicData";
+  }
+
+  static ddsi_sertype *getSerType()
+  {
+    auto *st = new ddscxx_sertype<dds::topic::ParticipantBuiltinTopicData>();
+    return static_cast<ddsi_sertype*>(st);
+  }
+
+  static size_t getSampleSize()
+  {
+    return sizeof(dds::topic::ParticipantBuiltinTopicData);
+  }
+
+  static bool isSelfContained()
+  {
+    return false;
+  }
+};
+
+template <>
+class TopicTraits<dds::topic::TopicBuiltinTopicData>
+{
+public:
+  static bool isKeyless()
+  {
+    return true;
+  }
+
+  static const char *getTypeName()
+  {
+    return "dds::topic::TopicBuiltinTopicData";
+  }
+
+  static ddsi_sertype *getSerType()
+  {
+    auto *st = new ddscxx_sertype<dds::topic::TopicBuiltinTopicData>();
+    return static_cast<ddsi_sertype*>(st);
+  }
+
+  static size_t getSampleSize()
+  {
+    return sizeof(dds::topic::TopicBuiltinTopicData);
+  }
+
+  static bool isSelfContained()
+  {
+    return false;
+  }
+};
+
+template <>
+class TopicTraits<dds::topic::PublicationBuiltinTopicData>
+{
+public:
+  static bool isKeyless()
+  {
+    return true;
+  }
+
+  static const char *getTypeName()
+  {
+    return "dds::topic::PublicationBuiltinTopicData";
+  }
+
+  static ddsi_sertype *getSerType()
+  {
+    auto *st = new ddscxx_sertype<dds::topic::PublicationBuiltinTopicData>();
+    return static_cast<ddsi_sertype*>(st);
+  }
+
+  static size_t getSampleSize()
+  {
+    return sizeof(dds::topic::PublicationBuiltinTopicData);
+  }
+
+  static bool isSelfContained()
+  {
+    return false;
+  }
+};
+
+template <>
+class TopicTraits<dds::topic::SubscriptionBuiltinTopicData>
+{
+public:
+  static bool isKeyless()
+  {
+    return true;
+  }
+
+  static const char *getTypeName()
+  {
+    return "dds::topic::SubscriptionBuiltinTopicData";
+  }
+
+  static ddsi_sertype *getSerType()
+  {
+    auto *st = new ddscxx_sertype<dds::topic::SubscriptionBuiltinTopicData>();
+    return static_cast<ddsi_sertype*>(st);
+  }
+
+  static size_t getSampleSize()
+  {
+    return sizeof(dds::topic::SubscriptionBuiltinTopicData);
+  }
+
+  static bool isSelfContained()
+  {
+    return false;
+  }
+};
+
+}  /* topic */
+}  /* cyclonedds */
+}  /* eclipse */
+}  /* org */
 
 #endif /* CYCLONEDDS_TOPIC_BUILTIN_TOPIC_TRAITS_HPP */

--- a/src/ddscxx/src/dds/sub/subfind.cpp
+++ b/src/ddscxx/src/dds/sub/subfind.cpp
@@ -26,15 +26,9 @@ namespace sub
 const Subscriber
 builtin_subscriber(const dds::domain::DomainParticipant& dp)
 {
-    (void)dp;
-    ISOCPP_THROW_EXCEPTION(ISOCPP_UNSUPPORTED_ERROR, "Function not currently supported");
-#if 0
     org::eclipse::cyclonedds::sub::SubscriberDelegate::ref_type ref =
             org::eclipse::cyclonedds::sub::BuiltinSubscriberDelegate::get_builtin_subscriber(dp);
     return Subscriber(ref);
-#else
-    return Subscriber(dds::core::null);
-#endif
 }
 
 }

--- a/src/ddscxx/src/dds/topic/BuiltinTopic.cpp
+++ b/src/ddscxx/src/dds/topic/BuiltinTopic.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright(c) 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+
+/**
+ * @file
+ */
+
+#include <dds/topic/BuiltinTopic.hpp>
+
+namespace dds
+{
+
+namespace topic
+{
+
+class default_builtin_topic_qos: public qos::TopicQos {
+    public:
+        default_builtin_topic_qos(): qos::TopicQos() {
+            const char *partition = "__BUILT-IN PARTITION__";
+            dds_qos_t *qos = dds_create_qos ();
+            dds_qset_durability (qos, DDS_DURABILITY_TRANSIENT_LOCAL);
+            dds_qset_presentation (qos, DDS_PRESENTATION_TOPIC, false, false);
+            dds_qset_reliability (qos, DDS_RELIABILITY_RELIABLE, DDS_MSECS(100));
+            dds_qset_partition (qos, 1, &partition);
+            delegate().ddsc_qos(qos);
+            dds_delete_qos(qos);
+        }
+};
+
+template <>
+Topic<ParticipantBuiltinTopicData, detail::Topic>::Topic(const dds::domain::DomainParticipant& dp,
+                          const std::string& topic_name) :
+::dds::core::Reference< detail::Topic<ParticipantBuiltinTopicData> >(new detail::Topic<ParticipantBuiltinTopicData>(
+              dp,
+              topic_name,
+              "org::eclipse::cyclonedds::builtin::DCPSParticipant",
+              default_builtin_topic_qos(),
+              DDS_BUILTIN_TOPIC_DCPSPARTICIPANT))
+{
+    this->delegate()->init(this->impl_);
+}
+
+template <>
+Topic<TopicBuiltinTopicData, detail::Topic>::Topic(const dds::domain::DomainParticipant& dp,
+                          const std::string& topic_name) :
+::dds::core::Reference< detail::Topic<TopicBuiltinTopicData> >(new detail::Topic<TopicBuiltinTopicData>(
+              dp,
+              topic_name,
+              "org::eclipse::cyclonedds::builtin::DCPSTopic",
+              default_builtin_topic_qos(),
+              DDS_BUILTIN_TOPIC_DCPSTOPIC))
+{
+    this->delegate()->init(this->impl_);
+}
+
+template <>
+Topic<SubscriptionBuiltinTopicData, detail::Topic>::Topic(const dds::domain::DomainParticipant& dp,
+                          const std::string& topic_name) :
+::dds::core::Reference< detail::Topic<SubscriptionBuiltinTopicData> >(new detail::Topic<SubscriptionBuiltinTopicData>(
+              dp,
+              topic_name,
+              "org::eclipse::cyclonedds::builtin::DCPSSubscription",
+              default_builtin_topic_qos(),
+              DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION))
+{
+    this->delegate()->init(this->impl_);
+}
+
+template <>
+Topic<PublicationBuiltinTopicData, detail::Topic>::Topic(const dds::domain::DomainParticipant& dp,
+                          const std::string& topic_name) :
+::dds::core::Reference< detail::Topic<PublicationBuiltinTopicData> >(new detail::Topic<PublicationBuiltinTopicData>(
+              dp,
+              topic_name,
+              "org::eclipse::cyclonedds::builtin::DCPSPublication",
+              default_builtin_topic_qos(),
+              DDS_BUILTIN_TOPIC_DCPSPUBLICATION))
+{
+    this->delegate()->init(this->impl_);
+}
+
+}
+
+}

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/EntityDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/EntityDelegate.cpp
@@ -62,6 +62,12 @@ org::eclipse::cyclonedds::core::EntityDelegate::~EntityDelegate()
 
 void org::eclipse::cyclonedds::core::EntityDelegate::enable()
 {
+  if (DDS_BUILTIN_TOPIC_DCPSPARTICIPANT == this->ddsc_entity
+   || DDS_BUILTIN_TOPIC_DCPSTOPIC == this->ddsc_entity
+   || DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION == this->ddsc_entity
+   || DDS_BUILTIN_TOPIC_DCPSPUBLICATION == this->ddsc_entity)
+    return;
+
   dds_return_t ret;
   enabled_ = true;
   ret = dds_set_listener (this->ddsc_entity, this->listener_callbacks);

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
@@ -465,6 +465,16 @@ org::eclipse::cyclonedds::domain::DomainParticipantDelegate::lookup_topic(
 
     this->check();
 
+    if (topic_name == "DCPSParticipant") {
+        return DDS_BUILTIN_TOPIC_DCPSPARTICIPANT;
+    } else if (topic_name == "DCPSTopic") {
+        return DDS_BUILTIN_TOPIC_DCPSTOPIC;
+    } else if (topic_name == "DCPSPublication") {
+        return DDS_BUILTIN_TOPIC_DCPSPUBLICATION;
+    } else if (topic_name == "DCPSSubscription") {
+        return DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION;
+    }
+
     dds_time_t starttime = dds_time();
     while (true)
     {

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/BuiltinSubscriberDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/BuiltinSubscriberDelegate.cpp
@@ -112,14 +112,7 @@ org::eclipse::cyclonedds::sub::create_builtin_reader(
 {
     dds::sub::qos::DataReaderQos rQos;
 
-    dds::topic::Topic<T> topic =
-            dds::topic::find< dds::topic::Topic<T> >(subscriber.participant(), topic_name);
-    if (topic.is_nil()) {
-        topic = dds::topic::discover< dds::topic::Topic<T> >(subscriber.participant(), topic_name, dds::core::Duration::zero());
-        if (topic.is_nil()) {
-            ISOCPP_THROW_EXCEPTION(ISOCPP_ERROR, "Could not find builtin topic \"%s\"", topic_name.c_str());
-        }
-    }
+    dds::topic::Topic<T> topic(subscriber.participant(), topic_name);
     subscriber.default_datareader_qos(rQos);
     rQos = topic.qos();
     dds::sub::DataReader<T> reader(subscriber.wrapper(), topic, rQos);
@@ -137,13 +130,13 @@ org::eclipse::cyclonedds::sub::BuiltinSubscriberDelegate::get_builtin_reader(
     org::eclipse::cyclonedds::sub::AnyDataReaderDelegate::ref_type builtin_reader;
 
     if (topic_name == "DCPSParticipant") {
-        builtin_reader = create_builtin_reader<dds::topic::ParticipantBuiltinTopicData>(subscriber, topic_name).delegate();
+        builtin_reader = org::eclipse::cyclonedds::sub::create_builtin_reader<dds::topic::ParticipantBuiltinTopicData>(subscriber, topic_name).delegate();
     } else if (topic_name == "DCPSTopic") {
-        builtin_reader = create_builtin_reader<dds::topic::TopicBuiltinTopicData>(subscriber, topic_name).delegate();
+        builtin_reader = org::eclipse::cyclonedds::sub::create_builtin_reader<dds::topic::TopicBuiltinTopicData>(subscriber, topic_name).delegate();
     } else if (topic_name == "DCPSPublication") {
-        builtin_reader = create_builtin_reader<dds::topic::PublicationBuiltinTopicData>(subscriber, topic_name).delegate();
+        builtin_reader = org::eclipse::cyclonedds::sub::create_builtin_reader<dds::topic::PublicationBuiltinTopicData>(subscriber, topic_name).delegate();
     } else if (topic_name == "DCPSSubscription") {
-        builtin_reader = create_builtin_reader<dds::topic::SubscriptionBuiltinTopicData>(subscriber, topic_name).delegate();
+        builtin_reader = org::eclipse::cyclonedds::sub::create_builtin_reader<dds::topic::SubscriptionBuiltinTopicData>(subscriber, topic_name).delegate();
     }
 
     return builtin_reader;

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/BuiltinDataTopic.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/BuiltinDataTopic.cpp
@@ -5,272 +5,177 @@
 #include "org/eclipse/cyclonedds/topic/TopicTraits.hpp"
 #include "org/eclipse/cyclonedds/topic/BuiltinDataTopic.hpp"
 
-bool builtin_serdata_eqkey(const ddsi_serdata* a, const ddsi_serdata* b)
+#define unsupported_method_throw ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.")
+
+bool builtin_serdata_eqkey(
+  const ddsi_serdata*,
+  const ddsi_serdata*)
 {
-  (void)a;
-  (void)b;
-
-  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
-
+  unsupported_method_throw;
   return false;
 }
 
-uint32_t builtin_serdata_size(const ddsi_serdata* dcmn)
+uint32_t builtin_serdata_size(
+  const ddsi_serdata*)
 {
-  (void)dcmn;
-
-  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
-
+  unsupported_method_throw;
   return 0;
 }
 
 ddsi_serdata *builtin_serdata_from_ser(
-  const ddsi_sertype* type,
-  enum ddsi_serdata_kind kind,
-  const struct nn_rdata* fragchain,
-  size_t size)
+  const ddsi_sertype*,
+  enum ddsi_serdata_kind,
+  const struct nn_rdata*,
+  size_t)
 {
-  (void)type;
-  (void)kind;
-  (void)fragchain;
-  (void)size;
-
-  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
-
+  unsupported_method_throw;
   return nullptr;
 }
 
 ddsi_serdata *builtin_serdata_from_ser_iov(
-  const ddsi_sertype* type,
-  enum ddsi_serdata_kind kind,
-  ddsrt_msg_iovlen_t niov,
-  const ddsrt_iovec_t* iov,
-  size_t size)
+  const ddsi_sertype*,
+  enum ddsi_serdata_kind,
+  ddsrt_msg_iovlen_t,
+  const ddsrt_iovec_t*,
+  size_t)
 {
-  (void)type;
-  (void)kind;
-  (void)niov;
-  (void)iov;
-  (void)size;
-
-  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
-
+  unsupported_method_throw;
   return nullptr;
 
 }
 
 ddsi_serdata *builtin_serdata_from_keyhash(
-  const ddsi_sertype* type,
-  const struct ddsi_keyhash* keyhash)
+  const ddsi_sertype*,
+  const struct ddsi_keyhash*)
 {
-  (void)keyhash;
-  (void)type;
-
-  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
-
+  unsupported_method_throw;
   return nullptr;
 }
 
 ddsi_serdata *builtin_serdata_from_sample(
-  const ddsi_sertype* typecmn,
-  enum ddsi_serdata_kind kind,
-  const void* sample)
+  const ddsi_sertype*,
+  enum ddsi_serdata_kind,
+  const void*)
 {
-  (void)typecmn;
-  (void)kind;
-  (void)sample;
-
-  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
-
+  unsupported_method_throw;
   return nullptr;
 }
 
-void builtin_serdata_to_ser(const ddsi_serdata* dcmn, size_t off, size_t sz, void* buf)
+void builtin_serdata_to_ser(
+  const ddsi_serdata*,
+  size_t,
+  size_t,
+  void*)
 {
-  (void)dcmn;
-  (void)off;
-  (void)sz;
-  (void)buf;
-
-  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
+  unsupported_method_throw;
 }
 
 ddsi_serdata *builtin_serdata_to_ser_ref(
-  const ddsi_serdata* dcmn, size_t off,
-  size_t sz, ddsrt_iovec_t* ref)
+  const ddsi_serdata*,
+  size_t,
+  size_t,
+  ddsrt_iovec_t*)
 {
-  (void)dcmn;
-  (void)off;
-  (void)sz;
-  (void)ref;
-
-  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
-
+  unsupported_method_throw;
   return nullptr;
 }
 
-void builtin_serdata_to_ser_unref(ddsi_serdata* dcmn, const ddsrt_iovec_t* ref)
+void builtin_serdata_to_ser_unref(
+  ddsi_serdata*,
+  const ddsrt_iovec_t*)
 {
-  (void)dcmn;
-  (void)ref;
-
-  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
+  unsupported_method_throw;
 }
 
 bool builtin_serdata_to_sample(
-  const ddsi_serdata* dcmn, void* sample, void** bufptr,
-  void* buflim)
+  const ddsi_serdata*,
+  void*,
+  void**,
+  void*)
 {
-  (void)bufptr;
-  (void)buflim;
-  (void)dcmn;
-  (void)sample;
-
-  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
-
+  unsupported_method_throw;
   return false;
 }
 
-ddsi_serdata *builtin_serdata_to_untyped(const ddsi_serdata* dcmn)
+ddsi_serdata *builtin_serdata_to_untyped(
+  const ddsi_serdata*)
 {
-  (void)dcmn;
-
-  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
-
+  unsupported_method_throw;
   return nullptr;
 }
 
 bool builtin_serdata_untyped_to_sample(
-  const ddsi_sertype* type,
-  const ddsi_serdata* dcmn, void* sample,
-  void** bufptr, void* buflim)
+  const ddsi_sertype*,
+  const ddsi_serdata*,
+  void*,
+  void**,
+  void*)
 {
-  (void)type;
-  (void)dcmn;
-  (void)sample;
-  (void)bufptr;
-  (void)buflim;
-
-  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
-
+  unsupported_method_throw;
   return false;
 }
 
 void builtin_serdata_get_keyhash(
-  const ddsi_serdata* d, struct ddsi_keyhash* buf,
-  bool force_md5)
+  const ddsi_serdata*,
+  struct ddsi_keyhash*,
+  bool)
 {
-  (void)d;
-  (void)buf;
-  (void)force_md5;
-
-  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
+  unsupported_method_throw;
 }
 
-template <>
-dds::topic::ParticipantBuiltinTopicData* ddscxx_serdata<dds::topic::ParticipantBuiltinTopicData>::getT()
+#ifdef DDSCXX_HAS_SHM
+uint32_t builtin_serdata_iox_size(
+  const struct ddsi_serdata*)
 {
-  dds::topic::ParticipantBuiltinTopicData *t
-    = m_t.load(std::memory_order_acquire);
-  if (t == nullptr) {
-    t = new dds::topic::ParticipantBuiltinTopicData();
-      dds::topic::ParticipantBuiltinTopicData* exp = nullptr;
-      if (!m_t.compare_exchange_strong(exp, t, std::memory_order_seq_cst)) {
-        delete t;
-        t = exp;
-      }
-  }
-  return t;
+  unsupported_method_throw;
+  return 0;
 }
 
-template <>
-dds::topic::TopicBuiltinTopicData* ddscxx_serdata<dds::topic::TopicBuiltinTopicData>::getT()
+ddsi_serdata * builtin_serdata_from_iox_buffer(
+  const struct ddsi_sertype *,
+  enum ddsi_serdata_kind,
+  void *,
+  void *)
 {
-  dds::topic::TopicBuiltinTopicData *t
-    = m_t.load(std::memory_order_acquire);
-  if (t == nullptr) {
-    t = new dds::topic::TopicBuiltinTopicData();
-      dds::topic::TopicBuiltinTopicData* exp = nullptr;
-      if (!m_t.compare_exchange_strong(exp, t, std::memory_order_seq_cst)) {
-        delete t;
-        t = exp;
-      }
-  }
-  return t;
+  unsupported_method_throw;
+  return nullptr;
 }
+#endif
 
-template <>
-dds::topic::PublicationBuiltinTopicData* ddscxx_serdata<dds::topic::PublicationBuiltinTopicData>::getT()
-{
-  dds::topic::PublicationBuiltinTopicData *t
-    = m_t.load(std::memory_order_acquire);
-  if (t == nullptr) {
-    t = new dds::topic::PublicationBuiltinTopicData();
-      dds::topic::PublicationBuiltinTopicData* exp = nullptr;
-      if (!m_t.compare_exchange_strong(exp, t, std::memory_order_seq_cst)) {
-        delete t;
-        t = exp;
-      }
-  }
-  return t;
-}
+#ifdef _WIN32
+#define builtin_topic_ops_impl(builtin_topic_type)
+#else
+#define builtin_topic_ops_impl(builtin_topic_type)\
+builtin_topic_ops(builtin_topic_type)
+#endif
 
-template <>
-dds::topic::SubscriptionBuiltinTopicData* ddscxx_serdata<dds::topic::SubscriptionBuiltinTopicData>::getT()
-{
-  dds::topic::SubscriptionBuiltinTopicData *t
-    = m_t.load(std::memory_order_acquire);
-  if (t == nullptr) {
-    t = new dds::topic::SubscriptionBuiltinTopicData();
-      dds::topic::SubscriptionBuiltinTopicData* exp = nullptr;
-      if (!m_t.compare_exchange_strong(exp, t, std::memory_order_seq_cst)) {
-        delete t;
-        t = exp;
-      }
-  }
-  return t;
-}
+#define builtin_topic_impl(builtin_topic_type)\
+template <> \
+dds::topic::builtin_topic_type* ddscxx_serdata<dds::topic::builtin_topic_type>::getT() {\
+  dds::topic::builtin_topic_type *t = m_t.load(std::memory_order_acquire);\
+  if (t == nullptr) {\
+    t = new dds::topic::builtin_topic_type();\
+    dds::topic::builtin_topic_type* exp = nullptr;\
+    if (!m_t.compare_exchange_strong(exp, t, std::memory_order_seq_cst)) {\
+      delete t;\
+      t = exp;\
+    }\
+  }\
+  return t;\
+}\
+template <> \
+bool sertype_serialize_into<dds::topic::builtin_topic_type>(const ddsi_sertype*, const void*, void*, size_t) {\
+  unsupported_method_throw;\
+  return false;\
+}\
+template <> \
+size_t sertype_get_serialized_size<dds::topic::builtin_topic_type>(const ddsi_sertype*, const void*) {\
+  unsupported_method_throw;\
+  return 0;\
+}\
+builtin_topic_ops_impl(builtin_topic_type)
 
-#ifndef _WIN32
-
-template<typename T>
-struct builtin_serdata_ops: public ddsi_serdata_ops {
-  builtin_serdata_ops(): ddsi_serdata_ops({
-  &builtin_serdata_eqkey,
-  &builtin_serdata_size,
-  &builtin_serdata_from_ser,
-  &builtin_serdata_from_ser_iov,
-  &builtin_serdata_from_keyhash,
-  &builtin_serdata_from_sample,
-  &builtin_serdata_to_ser,
-  &builtin_serdata_to_ser_ref,
-  &builtin_serdata_to_ser_unref,
-  &builtin_serdata_to_sample,
-  &builtin_serdata_to_untyped,
-  &builtin_serdata_untyped_to_sample,
-  &serdata_free<T>,
-  &serdata_print<T>,
-  &builtin_serdata_get_keyhash,
-  #ifdef DDS_HAS_SHM
-  NULL, //get_sample_size
-  NULL  //from_iox_buffer
-  #endif
-}) {;}
-};
-
-template <>
-const ddsi_serdata_ops ddscxx_serdata<dds::topic::ParticipantBuiltinTopicData>::ddscxx_serdata_ops =
-  builtin_serdata_ops<dds::topic::ParticipantBuiltinTopicData>();
-
-template <>
-const ddsi_serdata_ops ddscxx_serdata<dds::topic::TopicBuiltinTopicData>::ddscxx_serdata_ops =
-  builtin_serdata_ops<dds::topic::TopicBuiltinTopicData>();
-
-template <>
-const ddsi_serdata_ops ddscxx_serdata<dds::topic::SubscriptionBuiltinTopicData>::ddscxx_serdata_ops =
-  builtin_serdata_ops<dds::topic::SubscriptionBuiltinTopicData>();
-
-template <>
-const ddsi_serdata_ops ddscxx_serdata<dds::topic::PublicationBuiltinTopicData>::ddscxx_serdata_ops =
-  builtin_serdata_ops<dds::topic::PublicationBuiltinTopicData>();
-#endif /* !_WIN32 */
+builtin_topic_impl(ParticipantBuiltinTopicData)
+builtin_topic_impl(TopicBuiltinTopicData)
+builtin_topic_impl(PublicationBuiltinTopicData)
+builtin_topic_impl(SubscriptionBuiltinTopicData)

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/BuiltinDataTopic.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/BuiltinDataTopic.cpp
@@ -1,0 +1,276 @@
+#include <cstdint>
+#include <vector>
+#include <string>
+
+#include "org/eclipse/cyclonedds/topic/TopicTraits.hpp"
+#include "org/eclipse/cyclonedds/topic/BuiltinDataTopic.hpp"
+
+bool builtin_serdata_eqkey(const ddsi_serdata* a, const ddsi_serdata* b)
+{
+  (void)a;
+  (void)b;
+
+  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
+
+  return false;
+}
+
+uint32_t builtin_serdata_size(const ddsi_serdata* dcmn)
+{
+  (void)dcmn;
+
+  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
+
+  return 0;
+}
+
+ddsi_serdata *builtin_serdata_from_ser(
+  const ddsi_sertype* type,
+  enum ddsi_serdata_kind kind,
+  const struct nn_rdata* fragchain,
+  size_t size)
+{
+  (void)type;
+  (void)kind;
+  (void)fragchain;
+  (void)size;
+
+  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
+
+  return nullptr;
+}
+
+ddsi_serdata *builtin_serdata_from_ser_iov(
+  const ddsi_sertype* type,
+  enum ddsi_serdata_kind kind,
+  ddsrt_msg_iovlen_t niov,
+  const ddsrt_iovec_t* iov,
+  size_t size)
+{
+  (void)type;
+  (void)kind;
+  (void)niov;
+  (void)iov;
+  (void)size;
+
+  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
+
+  return nullptr;
+
+}
+
+ddsi_serdata *builtin_serdata_from_keyhash(
+  const ddsi_sertype* type,
+  const struct ddsi_keyhash* keyhash)
+{
+  (void)keyhash;
+  (void)type;
+
+  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
+
+  return nullptr;
+}
+
+ddsi_serdata *builtin_serdata_from_sample(
+  const ddsi_sertype* typecmn,
+  enum ddsi_serdata_kind kind,
+  const void* sample)
+{
+  (void)typecmn;
+  (void)kind;
+  (void)sample;
+
+  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
+
+  return nullptr;
+}
+
+void builtin_serdata_to_ser(const ddsi_serdata* dcmn, size_t off, size_t sz, void* buf)
+{
+  (void)dcmn;
+  (void)off;
+  (void)sz;
+  (void)buf;
+
+  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
+}
+
+ddsi_serdata *builtin_serdata_to_ser_ref(
+  const ddsi_serdata* dcmn, size_t off,
+  size_t sz, ddsrt_iovec_t* ref)
+{
+  (void)dcmn;
+  (void)off;
+  (void)sz;
+  (void)ref;
+
+  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
+
+  return nullptr;
+}
+
+void builtin_serdata_to_ser_unref(ddsi_serdata* dcmn, const ddsrt_iovec_t* ref)
+{
+  (void)dcmn;
+  (void)ref;
+
+  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
+}
+
+bool builtin_serdata_to_sample(
+  const ddsi_serdata* dcmn, void* sample, void** bufptr,
+  void* buflim)
+{
+  (void)bufptr;
+  (void)buflim;
+  (void)dcmn;
+  (void)sample;
+
+  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
+
+  return false;
+}
+
+ddsi_serdata *builtin_serdata_to_untyped(const ddsi_serdata* dcmn)
+{
+  (void)dcmn;
+
+  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
+
+  return nullptr;
+}
+
+bool builtin_serdata_untyped_to_sample(
+  const ddsi_sertype* type,
+  const ddsi_serdata* dcmn, void* sample,
+  void** bufptr, void* buflim)
+{
+  (void)type;
+  (void)dcmn;
+  (void)sample;
+  (void)bufptr;
+  (void)buflim;
+
+  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
+
+  return false;
+}
+
+void builtin_serdata_get_keyhash(
+  const ddsi_serdata* d, struct ddsi_keyhash* buf,
+  bool force_md5)
+{
+  (void)d;
+  (void)buf;
+  (void)force_md5;
+
+  ISOCPP_DDSC_RESULT_CHECK_AND_THROW(DDS_RETCODE_NOT_ENABLED, "Unsupported method for builtin topics.");
+}
+
+template <>
+dds::topic::ParticipantBuiltinTopicData* ddscxx_serdata<dds::topic::ParticipantBuiltinTopicData>::getT()
+{
+  dds::topic::ParticipantBuiltinTopicData *t
+    = m_t.load(std::memory_order_acquire);
+  if (t == nullptr) {
+    t = new dds::topic::ParticipantBuiltinTopicData();
+      dds::topic::ParticipantBuiltinTopicData* exp = nullptr;
+      if (!m_t.compare_exchange_strong(exp, t, std::memory_order_seq_cst)) {
+        delete t;
+        t = exp;
+      }
+  }
+  return t;
+}
+
+template <>
+dds::topic::TopicBuiltinTopicData* ddscxx_serdata<dds::topic::TopicBuiltinTopicData>::getT()
+{
+  dds::topic::TopicBuiltinTopicData *t
+    = m_t.load(std::memory_order_acquire);
+  if (t == nullptr) {
+    t = new dds::topic::TopicBuiltinTopicData();
+      dds::topic::TopicBuiltinTopicData* exp = nullptr;
+      if (!m_t.compare_exchange_strong(exp, t, std::memory_order_seq_cst)) {
+        delete t;
+        t = exp;
+      }
+  }
+  return t;
+}
+
+template <>
+dds::topic::PublicationBuiltinTopicData* ddscxx_serdata<dds::topic::PublicationBuiltinTopicData>::getT()
+{
+  dds::topic::PublicationBuiltinTopicData *t
+    = m_t.load(std::memory_order_acquire);
+  if (t == nullptr) {
+    t = new dds::topic::PublicationBuiltinTopicData();
+      dds::topic::PublicationBuiltinTopicData* exp = nullptr;
+      if (!m_t.compare_exchange_strong(exp, t, std::memory_order_seq_cst)) {
+        delete t;
+        t = exp;
+      }
+  }
+  return t;
+}
+
+template <>
+dds::topic::SubscriptionBuiltinTopicData* ddscxx_serdata<dds::topic::SubscriptionBuiltinTopicData>::getT()
+{
+  dds::topic::SubscriptionBuiltinTopicData *t
+    = m_t.load(std::memory_order_acquire);
+  if (t == nullptr) {
+    t = new dds::topic::SubscriptionBuiltinTopicData();
+      dds::topic::SubscriptionBuiltinTopicData* exp = nullptr;
+      if (!m_t.compare_exchange_strong(exp, t, std::memory_order_seq_cst)) {
+        delete t;
+        t = exp;
+      }
+  }
+  return t;
+}
+
+#ifndef _WIN32
+
+template<typename T>
+struct builtin_serdata_ops: public ddsi_serdata_ops {
+  builtin_serdata_ops(): ddsi_serdata_ops({
+  &builtin_serdata_eqkey,
+  &builtin_serdata_size,
+  &builtin_serdata_from_ser,
+  &builtin_serdata_from_ser_iov,
+  &builtin_serdata_from_keyhash,
+  &builtin_serdata_from_sample,
+  &builtin_serdata_to_ser,
+  &builtin_serdata_to_ser_ref,
+  &builtin_serdata_to_ser_unref,
+  &builtin_serdata_to_sample,
+  &builtin_serdata_to_untyped,
+  &builtin_serdata_untyped_to_sample,
+  &serdata_free<T>,
+  &serdata_print<T>,
+  &builtin_serdata_get_keyhash,
+  #ifdef DDS_HAS_SHM
+  NULL, //get_sample_size
+  NULL  //from_iox_buffer
+  #endif
+}) {;}
+};
+
+template <>
+const ddsi_serdata_ops ddscxx_serdata<dds::topic::ParticipantBuiltinTopicData>::ddscxx_serdata_ops =
+  builtin_serdata_ops<dds::topic::ParticipantBuiltinTopicData>();
+
+template <>
+const ddsi_serdata_ops ddscxx_serdata<dds::topic::TopicBuiltinTopicData>::ddscxx_serdata_ops =
+  builtin_serdata_ops<dds::topic::TopicBuiltinTopicData>();
+
+template <>
+const ddsi_serdata_ops ddscxx_serdata<dds::topic::SubscriptionBuiltinTopicData>::ddscxx_serdata_ops =
+  builtin_serdata_ops<dds::topic::SubscriptionBuiltinTopicData>();
+
+template <>
+const ddsi_serdata_ops ddscxx_serdata<dds::topic::PublicationBuiltinTopicData>::ddscxx_serdata_ops =
+  builtin_serdata_ops<dds::topic::PublicationBuiltinTopicData>();
+#endif /* !_WIN32 */

--- a/src/ddscxx/tests/BuiltinTopic.cpp
+++ b/src/ddscxx/tests/BuiltinTopic.cpp
@@ -1,0 +1,401 @@
+/*
+ * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+#include <chrono>
+#include <thread>
+#include <map>
+
+#include "dds/dds.hpp"
+#include "Space.hpp"
+
+using namespace org::eclipse::cyclonedds;
+
+/**
+ * Fixture for the BuiltinTopic tests
+ */
+class BuiltinTopic : public ::testing::Test
+{
+public:
+    const std::string topic_name;
+
+    static const std::string type_name;
+
+    static const std::string test_prefix;
+
+    static const std::map<std::string, std::string> builtins;
+
+    static const size_t max_samples = 16;
+
+    dds::domain::DomainParticipant participant;
+    dds::topic::Topic<Space::Type1> topic;
+
+    dds::pub::Publisher publisher;
+    dds::pub::DataWriter<Space::Type1> writer;
+
+    dds::sub::Subscriber subscriber;
+    dds::sub::DataReader<Space::Type1> reader;
+
+    const dds::sub::Subscriber builtinsubscriber;
+
+    BuiltinTopic():
+        topic_name(test_prefix +
+            testing::UnitTest::GetInstance()->current_test_info()->test_suite_name() +
+            "_" + testing::UnitTest::GetInstance()->current_test_info()->name()),
+        participant(domain::default_id()),
+        topic(participant, topic_name),
+        publisher(participant),
+        writer(publisher,topic),
+        subscriber(participant),
+        reader(subscriber,topic),
+        builtinsubscriber(dds::sub::builtin_subscriber(participant))
+    {
+    }
+
+    void GetPartReader(dds::sub::DataReader<dds::topic::ParticipantBuiltinTopicData> &participantreader)
+    {
+        const std::string name = "DCPSParticipant";
+        std::vector<dds::sub::DataReader<dds::topic::ParticipantBuiltinTopicData> > dpv;
+        size_t cnt = dds::sub::find<dds::sub::DataReader<dds::topic::ParticipantBuiltinTopicData>,
+            std::back_insert_iterator<std::vector<dds::sub::DataReader<dds::topic::ParticipantBuiltinTopicData> > > >
+                (builtinsubscriber, name,
+                 std::back_inserter<std::vector<dds::sub::DataReader<dds::topic::ParticipantBuiltinTopicData> > >(dpv));
+        ASSERT_GT(cnt,0);
+        participantreader = dpv[0];
+        ASSERT_NE(participantreader, dds::core::null);
+    }
+
+    void GetPubReader(dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData> &publicationreader)
+    {
+        const std::string name = "DCPSPublication";
+        std::vector<dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData> > dpv;
+        size_t cnt = dds::sub::find<dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData>,
+            std::back_insert_iterator<std::vector<dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData> > > >
+                (builtinsubscriber, name,
+                std::back_inserter<std::vector<dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData> > >(dpv));
+        ASSERT_GT(cnt,0);
+        publicationreader = dpv[0];
+        ASSERT_NE(publicationreader, dds::core::null);
+    }
+
+    void GetSubReader(dds::sub::DataReader<dds::topic::SubscriptionBuiltinTopicData> &subscriptionreader)
+    {
+        const std::string name = "DCPSSubscription";
+        std::vector<dds::sub::DataReader<dds::topic::SubscriptionBuiltinTopicData> > dpv;
+        size_t cnt = dds::sub::find<dds::sub::DataReader<dds::topic::SubscriptionBuiltinTopicData>,
+            std::back_insert_iterator<std::vector<dds::sub::DataReader<dds::topic::SubscriptionBuiltinTopicData> > > >
+                (builtinsubscriber, name,
+                std::back_inserter<std::vector<dds::sub::DataReader<dds::topic::SubscriptionBuiltinTopicData> > >(dpv));
+        ASSERT_GT(cnt,0);
+        subscriptionreader = dpv[0];
+        ASSERT_NE(subscriptionreader, dds::core::null);
+    }
+
+    void GetTopReader(dds::sub::DataReader<dds::topic::TopicBuiltinTopicData> &topicreader)
+    {
+        const std::string name = "DCPSTopic";
+        std::vector<dds::sub::DataReader<dds::topic::TopicBuiltinTopicData> > dpv;
+
+        /** when topic discovery is not enabled, creating a reader for the builtin topic topic will fail in cyclonedds */
+        try {
+            size_t cnt = dds::sub::find<dds::sub::DataReader<dds::topic::TopicBuiltinTopicData>,
+                  std::back_insert_iterator<std::vector<dds::sub::DataReader<dds::topic::TopicBuiltinTopicData> > > >
+                      (builtinsubscriber, name,
+                      std::back_inserter<std::vector<dds::sub::DataReader<dds::topic::TopicBuiltinTopicData> > >(dpv));
+            #if defined(DDS_HAS_TOPIC_DISCOVERY)
+            ASSERT_GT(cnt,0);
+            topicreader = dpv[0];
+            ASSERT_NE(topicreader, dds::core::null);
+            #else
+            ASSERT_EQ(cnt,0);
+            topicreader = dds::core::null;
+            ASSERT_TRUE(false);
+            #endif
+        } catch (const dds::core::UnsupportedError& ex) {
+            #if defined(DDS_HAS_TOPIC_DISCOVERY)
+            ASSERT_FALSE(true);
+            #else
+            ASSERT_EQ(std::string(ex.what()).find("Error Unsupported - Could not create DataReader."), 0);
+            #endif
+        }
+    }
+
+    void SetUp()
+    {
+        while (writer.publication_matched_status().current_count() == 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+
+        ASSERT_NE(participant, dds::core::null);
+        ASSERT_NE(topic, dds::core::null);
+
+        ASSERT_NE(publisher, dds::core::null);
+        ASSERT_NE(writer, dds::core::null);
+
+        ASSERT_NE(subscriber, dds::core::null);
+        ASSERT_NE(reader, dds::core::null);
+
+        ASSERT_NE(builtinsubscriber, dds::core::null);
+    }
+
+    void TearDown()
+    {
+        /** setting the participant to null should clean up all its children (topic etc.) */
+        participant = dds::core::null;
+    }
+
+    template<typename H>
+    void validate_participants(const H &samples, size_t n_expect)
+    {
+        auto length = static_cast<size_t>(std::distance(samples.begin(), samples.end()));
+        if (n_expect) {
+            ASSERT_GE(length, n_expect);
+        } else {
+            ASSERT_EQ(length, 0);
+        }
+
+        for (const auto & sam:samples) {
+            auto info = sam.info();
+            ASSERT_TRUE(info.valid());
+        }
+    }
+
+    template<typename H>
+    void validate_topics(const H &samples, size_t n_expect)
+    {
+        auto length = static_cast<size_t>(std::distance(samples.begin(), samples.end()));
+        if (n_expect) {
+            ASSERT_GE(length, n_expect);
+        } else {
+            ASSERT_EQ(length, 0);
+        }
+
+        size_t seen = 0;
+        for (const auto & sam:samples) {
+            auto info = sam.info();
+            ASSERT_TRUE(info.valid());
+            auto data = sam.data();
+            //none of the builting topic should appear here
+            ASSERT_EQ(builtins.find(data.name()), builtins.end());
+
+            if (data.name() == topic_name) {
+                ASSERT_EQ(data.type_name(), type_name);
+                seen++;
+            }
+        }
+        ASSERT_GE(seen, n_expect);
+    }
+
+    template<typename H>
+    void validate_pubs(const H &samples, size_t n_expect)
+    {
+        auto length = static_cast<size_t>(std::distance(samples.begin(), samples.end()));
+        if (n_expect) {
+            ASSERT_GE(length, n_expect);
+        } else {
+            ASSERT_EQ(length, 0);
+        }
+
+        size_t topic_found = 0;
+        for (const auto & sam:samples) {
+            auto info = sam.info();
+            ASSERT_TRUE(info.valid());
+            auto data = sam.data();
+
+            if (data.topic_name() == topic_name) {
+                ASSERT_EQ(data.type_name(), type_name);
+                topic_found++;
+            }
+        }
+        ASSERT_GE(topic_found, n_expect);
+    }
+
+    template<typename H>
+    void validate_subs(const H &samples, size_t n_expect)
+    {
+        auto length = static_cast<size_t>(std::distance(samples.begin(), samples.end()));
+        if (n_expect) {
+            ASSERT_GE(length, n_expect);
+        } else {
+            ASSERT_EQ(length, 0);
+        }
+
+        size_t topic_found = 0, sub_found = 0;
+        for (const auto & sam:samples) {
+            auto info = sam.info();
+            ASSERT_TRUE(info.valid());
+            auto data = sam.data();
+
+            if (data.topic_name() == topic_name) {
+                ASSERT_EQ(data.type_name(), type_name);
+                topic_found++;
+            }
+
+            if (data.topic_name() == "DCPSSubscription") {
+                ASSERT_EQ(data.type_name(), "org::eclipse::cyclonedds::builtin::DCPSSubscription");
+                sub_found++;
+            }
+        }
+        ASSERT_GE(topic_found, n_expect);
+        ASSERT_GE(sub_found, n_expect);
+    }
+};
+
+const std::map<std::string, std::string> BuiltinTopic::builtins =
+    { {"DCPSPublication",   "org::eclipse::cyclonedds::builtin::DCPSPublication"},
+      {"DCPSSubscription",  "org::eclipse::cyclonedds::builtin::DCPSSubscription"},
+      {"DCPSTopic",         "org::eclipse::cyclonedds::builtin::DCPSTopic"},
+      {"DCPSParticipant",   "org::eclipse::cyclonedds::builtin::DCPSParticipant"} };
+
+const std::string BuiltinTopic::type_name = org::eclipse::cyclonedds::topic::TopicTraits<Space::Type1>::getTypeName();
+
+const std::string BuiltinTopic::test_prefix = "Builtin_test_";
+
+#define test_loaned_samples(TYPE, GFNCTN, VFNCTN)\
+dds::sub::DataReader<TYPE> reader(dds::core::null);\
+GFNCTN(reader);\
+auto samples = reader.read();\
+VFNCTN(samples, 1);\
+samples = reader.read();\
+VFNCTN(samples, 1);\
+samples = reader.take();\
+VFNCTN(samples, 1);\
+samples = reader.take();\
+VFNCTN(samples, 0);
+
+#define test_forward_iterators(TYPE, GFNCTN, VFNCTN)\
+dds::sub::DataReader<TYPE> reader(dds::core::null);\
+GFNCTN(reader);\
+{   std::vector<dds::sub::Sample<TYPE> > samples(max_samples);\
+    samples.resize(reader.read(samples.begin(), max_samples));\
+    VFNCTN(samples, 1);}\
+{   std::vector<dds::sub::Sample<TYPE> > samples(max_samples);\
+    samples.resize(reader.read(samples.begin(), max_samples));\
+    VFNCTN(samples, 1);}\
+{   std::vector<dds::sub::Sample<TYPE> > samples(max_samples);\
+    samples.resize(reader.take(samples.begin(), max_samples));\
+    VFNCTN(samples, 1);}\
+{   std::vector<dds::sub::Sample<TYPE> > samples(max_samples);\
+    samples.resize(reader.take(samples.begin(), max_samples));\
+    VFNCTN(samples, 0);}
+
+#define test_back_insert_iterators(TYPE, GFNCTN, VFNCTN)\
+dds::sub::DataReader<TYPE> reader(dds::core::null);\
+GFNCTN(reader);\
+{   std::vector<dds::sub::Sample<TYPE> > samples;\
+    std::back_insert_iterator<std::vector<dds::sub::Sample<TYPE> > > it(samples);\
+    samples.resize(reader.read(it));\
+    VFNCTN(samples, 1);}\
+{   std::vector<dds::sub::Sample<TYPE> > samples;\
+    std::back_insert_iterator<std::vector<dds::sub::Sample<TYPE> > > it(samples);\
+    samples.resize(reader.read(it));\
+    VFNCTN(samples, 1);}\
+{   std::vector<dds::sub::Sample<TYPE> > samples;\
+    std::back_insert_iterator<std::vector<dds::sub::Sample<TYPE> > > it(samples);\
+    samples.resize(reader.take(it));\
+    VFNCTN(samples, 1);}\
+{   std::vector<dds::sub::Sample<TYPE> > samples;\
+    std::back_insert_iterator<std::vector<dds::sub::Sample<TYPE> > > it(samples);\
+    samples.resize(reader.take(it));\
+    VFNCTN(samples, 0);}
+
+/**
+ * Testing builtin topic for participants
+ */
+TEST_F(BuiltinTopic, participant)
+{
+    test_loaned_samples(dds::topic::ParticipantBuiltinTopicData, GetPartReader, validate_participants);
+}
+
+TEST_F(BuiltinTopic, participant_forward_iterator)
+{
+    test_forward_iterators(dds::topic::ParticipantBuiltinTopicData, GetPartReader, validate_participants);
+}
+
+TEST_F(BuiltinTopic, participant_back_insert_iterator)
+{
+    test_back_insert_iterators(dds::topic::ParticipantBuiltinTopicData, GetPartReader, validate_participants);
+}
+
+/**
+ * Testing builtin topic for topics
+ */
+TEST_F(BuiltinTopic, topic)
+{
+    #if defined(DDS_HAS_TOPIC_DISCOVERY)
+    test_loaned_samples(dds::topic::TopicBuiltinTopicData, GetTopReader, validate_topics);
+    #else
+    dds::sub::DataReader<dds::topic::TopicBuiltinTopicData> topicreader(dds::core::null);
+    GetTopReader(topicreader);
+    #endif
+}
+
+TEST_F(BuiltinTopic, topic_forward_iterator)
+{
+    #if defined(DDS_HAS_TOPIC_DISCOVERY)
+    test_forward_iterators(dds::topic::TopicBuiltinTopicData, GetTopReader, validate_topics);
+    #else
+    dds::sub::DataReader<dds::topic::TopicBuiltinTopicData> topicreader(dds::core::null);
+    GetTopReader(topicreader);
+    #endif
+}
+
+TEST_F(BuiltinTopic, topic_back_insert_iterator)
+{
+    #if defined(DDS_HAS_TOPIC_DISCOVERY)
+    test_back_insert_iterators(dds::topic::TopicBuiltinTopicData, GetTopReader, validate_topics);
+    #else
+    dds::sub::DataReader<dds::topic::TopicBuiltinTopicData> topicreader(dds::core::null);
+    GetTopReader(topicreader);
+    #endif
+}
+
+/**
+ * Testing builtin topic for publication
+ */
+TEST_F(BuiltinTopic, publication)
+{
+    test_loaned_samples(dds::topic::PublicationBuiltinTopicData, GetPubReader, validate_pubs);
+}
+
+TEST_F(BuiltinTopic, publication_forward_iterator)
+{
+    test_forward_iterators(dds::topic::PublicationBuiltinTopicData, GetPubReader, validate_pubs);
+}
+
+TEST_F(BuiltinTopic, publication_back_insert_iterator)
+{
+    test_back_insert_iterators(dds::topic::PublicationBuiltinTopicData, GetPubReader, validate_pubs);
+}
+
+/**
+ * Testing builtin topic for subscription
+ */
+TEST_F(BuiltinTopic, subscription)
+{
+    test_loaned_samples(dds::topic::SubscriptionBuiltinTopicData, GetSubReader, validate_subs);
+}
+
+TEST_F(BuiltinTopic, subscription_forward_iterator)
+{
+    test_forward_iterators(dds::topic::SubscriptionBuiltinTopicData, GetSubReader, validate_subs);
+}
+
+TEST_F(BuiltinTopic, subscription_back_insert_iterator)
+{
+    test_back_insert_iterators(dds::topic::SubscriptionBuiltinTopicData, GetSubReader, validate_subs);
+}
+
+#undef test_loaned_samples
+#undef test_forward_iterators
+#undef test_back_insert_iterators

--- a/src/ddscxx/tests/CMakeLists.txt
+++ b/src/ddscxx/tests/CMakeLists.txt
@@ -47,7 +47,8 @@ set(sources
   WaitSet.cpp
   Qos.cpp
   Condition.cpp
-  Util.cpp)
+  Util.cpp
+  BuiltinTopic.cpp)
 
 if(ENABLE_SHM)
   # Add shared memory tests

--- a/src/ddscxx/tests/Subscriber.cpp
+++ b/src/ddscxx/tests/Subscriber.cpp
@@ -230,7 +230,5 @@ TEST_F(Subscriber, use_after_deletion)
 TEST_F(Subscriber, builtin)
 {
     this->CreateSubscriber();
-    ASSERT_THROW({
-        dds::sub::builtin_subscriber(this->participant);
-    }, dds::core::UnsupportedError);
+    ASSERT_NE(dds::sub::builtin_subscriber(this->participant), dds::core::null);
 }


### PR DESCRIPTION
This will add builtin topics support for C++.

While the C++ message classes for the builtin topic were already created, there was no way to create a reader or a topic for them.

This PR adds:
- the creation of the C++ builtin topics
- the creation of the C++ readers for the builtin topics
- translation from the C to the C++ builtin topic message representation
- unittests for the builtin topics

@e-hndrks, @k0ekk0ek, @sumanth-nirmal:
Could you please check whether this adds the correct functionality and follows the correct locations and structuring of the features?