### PR TITLE
Serialization improvements

### DIFF
--- a/docs/manual/idlcxx.rst
+++ b/docs/manual/idlcxx.rst
@@ -67,6 +67,8 @@ std::vector:
 
 - resize
 
+- data
+
 - operator==
 
 - operator[]
@@ -110,7 +112,7 @@ std::string:
 
 - assign
 
-  - the variant using two input iterators specifying the range to initialize with
+  - the variant taking an input pointer and a length
 
 - operator==
 
@@ -151,6 +153,8 @@ std::array:
 - support auto-range for loops
 
   - having begin() and end() functions returning iterators to the begin and end of the array
+
+- the function data()
 
 The command line options for custom array containers are:
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp
@@ -190,6 +190,8 @@ inline void write_many(basic_cdr_stream& str, const T* in, size_t N)
   if (str.abort_status())
     return;
 
+  str.align(sizeof(T), true);
+
   T *out = static_cast<T*>(str.get_cursor());
 
   memcpy(out, in, sizeof(T)*N);

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp
@@ -101,7 +101,7 @@ inline void read_swapped(basic_cdr_stream &str, T& toread)
 template<typename T, std::enable_if_t<std::is_arithmetic<T>::value && !std::is_enum<T>::value, bool> = true >
 inline void read_many(basic_cdr_stream &str, T *out, size_t N)
 {
-  if (str.abort_status())
+  if (str.abort_status() || N == 0)
     return;
 
   str.align(sizeof(T), false);
@@ -116,7 +116,7 @@ inline void read_many(basic_cdr_stream &str, T *out, size_t N)
 template<typename T, std::enable_if_t<std::is_arithmetic<T>::value && !std::is_enum<T>::value, bool> = true >
 inline void read_many_swapped(basic_cdr_stream &str, T *out, size_t N)
 {
-  if (str.abort_status())
+  if (str.abort_status() || N == 0)
     return;
 
   str.align(sizeof(T), false);
@@ -187,7 +187,7 @@ inline void write_swapped(basic_cdr_stream& str, const T& towrite)
 template<typename T, std::enable_if_t<std::is_arithmetic<T>::value && !std::is_enum<T>::value, bool> = true >
 inline void write_many(basic_cdr_stream& str, const T* in, size_t N)
 {
-  if (str.abort_status())
+  if (str.abort_status() || N == 0)
     return;
 
   str.align(sizeof(T), true);
@@ -202,7 +202,7 @@ inline void write_many(basic_cdr_stream& str, const T* in, size_t N)
 template<typename T, std::enable_if_t<std::is_arithmetic<T>::value && !std::is_enum<T>::value, bool> = true >
 inline void write_many_swapped(basic_cdr_stream& str, const T* in, size_t N)
 {
-  if (str.abort_status())
+  if (str.abort_status() || N == 0)
     return;
 
   str.align(sizeof(T), true);

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -26,6 +26,11 @@
 #include "dds/ddsi/ddsi_keyhash.h"
 #include "org/eclipse/cyclonedds/topic/hash.hpp"
 
+using org::eclipse::cyclonedds::core::cdr::endianness;
+using org::eclipse::cyclonedds::core::cdr::native_endianness;
+using org::eclipse::cyclonedds::core::cdr::swap_necessary;
+using org::eclipse::cyclonedds::core::cdr::basic_cdr_stream;
+
 template<class streamer, typename T>
 bool to_key(streamer& str, const T& tokey, ddsi_keyhash_t& hash)
 {
@@ -37,6 +42,10 @@ bool to_key(streamer& str, const T& tokey, ddsi_keyhash_t& hash)
   std::vector<unsigned char> buffer(sz + padding);
   memset(buffer.data() + sz, 0x0, padding);
   str.set_buffer(buffer.data());
+  /* TODO: what is key endianness to be used here?
+   * since, this may be different between nodes, and if this value is used
+   * for global lookups or the like, this
+   * may cause discrepancies. */
   key_write(str, tokey);
   static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t&) = NULL;
   if (fptr == NULL)
@@ -119,18 +128,25 @@ public:
     T *t = m_t.load(std::memory_order_acquire);
     if (t == nullptr) {
       t = new T();
-      org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str(
-          *(static_cast<unsigned char*>(data())+1) == 0x1 ?
-              org::eclipse::cyclonedds::core::cdr::endianness::little_endian :
-              org::eclipse::cyclonedds::core::cdr::endianness::big_endian);
+      endianness stream_endianness  = endianness::big_endian;
+      if (*(static_cast<unsigned char*>(data())+1) == 0x1)
+        stream_endianness = endianness::little_endian;
+
+      org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str;
       str.set_buffer(calc_offset(data(),4));
       switch (kind)
       {
       case SDK_KEY:
-        key_read(str,*t);
+        if (swap_necessary(stream_endianness))
+          key_read_swapped(str,*t);
+        else
+          key_read(str,*t);
         break;
       case SDK_DATA:
-        read(str,*t);
+        if (swap_necessary(stream_endianness))
+          read_swapped(str,*t);
+        else
+          read(str,*t);
         break;
       case SDK_EMPTY:
         assert(0);
@@ -329,7 +345,7 @@ ddsi_serdata *serdata_from_sample(
   d->resize(sz);
   ptr = static_cast<unsigned char*>(d->data());
   memset(ptr, 0x0, 4);
-  if (str.local_endianness() == org::eclipse::cyclonedds::core::cdr::endianness::little_endian)
+  if (native_endianness() == endianness::little_endian)
     *(ptr + 1) = 0x1;
 
   str.set_buffer(calc_offset(d->data(), 4));
@@ -394,13 +410,17 @@ bool serdata_to_sample(
   (void)buflim;
   auto ptr = static_cast<const ddscxx_serdata<T>*>(dcmn);
 
-  org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str(
-          *(static_cast<unsigned char*>(ptr->data())+1) == 0x1 ?
-              org::eclipse::cyclonedds::core::cdr::endianness::little_endian :
-              org::eclipse::cyclonedds::core::cdr::endianness::big_endian);
+  endianness stream_endianness = endianness::big_endian;
+  if (*(static_cast<unsigned char*>(ptr->data())+1) == 0x1)
+    stream_endianness = endianness::little_endian;
+
+  org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str;
   str.set_buffer(calc_offset(ptr->data(), 4));
   auto& msg = *static_cast<T*>(sample);
-  read(str, msg);
+  if (swap_necessary(stream_endianness))
+    read_swapped(str, msg);
+  else
+    read(str, msg);
   return str.abort_status(); //is true this the correct return value for failure state??
 }
 
@@ -416,7 +436,7 @@ ddsi_serdata *serdata_to_untyped(const ddsi_serdata* dcmn)
   unsigned char *ptr = nullptr;
   d1->type = nullptr;
 
-  org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str;
+  basic_cdr_stream str;
   auto t = d->getT();
   if (t == nullptr)
     goto failure;
@@ -428,7 +448,7 @@ ddsi_serdata *serdata_to_untyped(const ddsi_serdata* dcmn)
 
   ptr = static_cast<unsigned char*>(d1->data());
   memset(ptr, 0x0, 4);
-  if (str.stream_endianness() == org::eclipse::cyclonedds::core::cdr::endianness::little_endian)
+  if (native_endianness() == endianness::little_endian)
     *(ptr + 1) = 0x1;
 
   str.set_buffer(calc_offset(d1->data(), 4));  //4 offset due to header field
@@ -460,12 +480,17 @@ bool serdata_untyped_to_sample(
   auto d = static_cast<const ddscxx_serdata<T>*>(dcmn);
 
   T* ptr = static_cast<T*>(sample);
-  org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str(
-          *(static_cast<unsigned char*>(d->data())+1) == 0x1 ?
-              org::eclipse::cyclonedds::core::cdr::endianness::little_endian :
-              org::eclipse::cyclonedds::core::cdr::endianness::big_endian);
+
+  basic_cdr_stream str;
+  endianness stream_endianness = endianness::big_endian;
+  if (*(static_cast<unsigned char*>(d->data())+1) == 0x1)
+    stream_endianness = endianness::little_endian;
+
   str.set_buffer(calc_offset(d->data(), 4));
-  key_read(str, *ptr);
+  if (swap_necessary(stream_endianness))
+    key_read_swapped(str, *ptr);
+  else
+    key_read(str, *ptr);
 
   return !str.abort_status();  //is true the correct value for no errors in streaming?
 }

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/cdr_stream.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/cdr_stream.cpp
@@ -35,7 +35,7 @@ size_t cdr_stream::align(size_t newalignment, bool add_zeroes)
 
   size_t tomove = (m_current_alignment - m_position % m_current_alignment) % m_current_alignment;
   if (tomove && add_zeroes && m_buffer) {
-    char *cursor = get_cursor();
+    auto cursor = get_cursor();
     assert(cursor);
     memset(cursor, 0, tomove);
   }

--- a/src/ddscxx/tests/Bounded.cpp
+++ b/src/ddscxx/tests/Bounded.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 #include <string>
 
+#include "Util.hpp"
 #include "dds/dds.hpp"
 #include "Serialization.hpp"
 
@@ -57,7 +58,9 @@ public:
         subscriber = dds::sub::Subscriber(participant, subQos);
         ASSERT_NE(subscriber, dds::core::null);
 
-        topic = dds::topic::Topic<Bounded::Msg>(participant, "bounds_test_topic");
+        char topicname[64];
+        create_unique_topic_name("bounds_test_topic",topicname,sizeof(topicname));
+        topic = dds::topic::Topic<Bounded::Msg>(participant, topicname);
         ASSERT_NE(topic, dds::core::null);
 
         dds::pub::qos::DataWriterQos writerQos =

--- a/src/ddscxx/tests/Bounded.cpp
+++ b/src/ddscxx/tests/Bounded.cpp
@@ -183,7 +183,7 @@ TEST_F(Bounds, strings)
     char arr[16];
     str.set_buffer(arr);
     write(str,uint32_t(0));
-    str.position(0);
+    str.reset_position();
 
     Bounded::Msg msg;
     read(str, msg);

--- a/src/ddscxx/tests/DataReaderSelector.cpp
+++ b/src/ddscxx/tests/DataReaderSelector.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 
 #include "dds/dds.hpp"
+#include "Util.hpp"
 #include "Space.hpp"
 
 /**
@@ -56,8 +57,11 @@ public:
         dds::topic::qos::TopicQos topic_qos = this->participant.default_topic_qos();
         topic_qos << dds::core::policy::Reliability::Reliable() <<
                      dds::core::policy::History::KeepAll();
+
+        char topicname[128];
+        create_unique_topic_name("selector_test_topic",topicname,sizeof(topicname));
         this->topic = dds::topic::Topic<Space::Type1>(this->participant,
-                                                      "selector_test_topic",
+                                                      topicname,
                                                       topic_qos);
         ASSERT_NE(this->topic, dds::core::null);
 

--- a/src/ddscxx/tests/Serdata.cpp
+++ b/src/ddscxx/tests/Serdata.cpp
@@ -65,7 +65,36 @@ public:
         return *(sd->getT());
     }
 
+    template<typename T>
+    void validate(const T &msg, const std::vector<uint8_t> &exp_le, const std::vector<uint8_t> &exp_be) {
+        bool le_is_swapped = (native_endianness() != endianness::little_endian);
+        validate_impl(msg, exp_le, le_is_swapped);
+        validate_impl(msg, exp_be, !le_is_swapped);
+    }
+
 private:
+
+    template<typename T>
+    void validate_impl(const T &msg, const std::vector<uint8_t> &exp, bool swap) {
+        basic_cdr_stream str;
+
+        if (swap)
+          move_swapped(str, msg);
+        else
+          move(str, msg);
+
+        size_t sz = str.position();
+        ASSERT_EQ(sz, exp.size());
+        std::vector<uint8_t> buffer(sz, 0x0);
+        str.set_buffer(buffer.data());
+
+        if (swap)
+          write_swapped(str, msg);
+        else
+          write(str, msg);
+
+        ASSERT_EQ(buffer, exp);
+    }
 
     ddscxx_serdata<Endianness::Msg> *sd = nullptr;
     unsigned char *ptr = nullptr;
@@ -78,11 +107,14 @@ TEST_F(Serdata, alignment)
 {
     Endianness::Msg msg({16,25,36},65535);
 
-    basic_cdr_stream str(endianness::little_endian);
+    basic_cdr_stream str;
     std::vector<unsigned char> vec(8,0x0);
     str.set_buffer(vec.data());
 
-    write(str,msg);
+    if (native_endianness() == endianness::little_endian)
+      write(str,msg);
+    else
+      write_swapped(str,msg);
 
     ASSERT_EQ(vec, std::vector<unsigned char>({16,25,36,0,255,255,0,0}));
 }
@@ -136,4 +168,81 @@ TEST_F(Serdata, serialization_big_endianness)
       ASSERT_EQ(0,memcmp(d->data(),std::vector<unsigned char>({0x0,0x1,0x0,0x0,0x4,0x5,0x6,0x0,0x00,0xFF,0x00,0xFF}).data(), 12));
 
     delete d;
+}
+
+/*
+ * Checking correct (non-)byteswapping serialization of sequence types.
+ */
+TEST_F(Serdata, serialization_sequences)
+{
+    std::vector<bool> b_seq({true,false,true,false});
+    std::vector<char> c_seq({'a','b','c','d'});
+    std::vector<int16_t> s_seq({1234,2345,3456,4567});
+    std::vector<int32_t> l_seq({12345678,23456789,34567890});
+    std::vector<int64_t> ll_seq({1234567823456789,2345678934567890});
+
+    std::vector<uint8_t> le =
+        {0x04, 0x00, 0x00, 0x00,/* b_seq.length */  0x01, 0x00, 0x01, 0x00, /* b_seq.data */
+         0x04, 0x00, 0x00, 0x00,/* c_seq.length */   'a',  'b',  'c',  'd', /* c_seq.data */
+         0x04, 0x00, 0x00, 0x00,/* s_seq.length */  0xD2, 0x04,  0x29, 0x09,  0x80, 0x0D,  0xD7, 0x11, /* s_seq.data */
+         0x03, 0x00, 0x00, 0x00,/* l_seq.length */  0x4E, 0x61, 0xBC, 0x00,  0x15, 0xEC, 0x65, 0x01,  0xD2, 0x76, 0x0F, 0x02, /* l_seq */
+         0x02, 0x00, 0x00, 0x00,/* ll_seq.length */  0x15, 0x7A, 0x91, 0x38, 0xD5, 0x62, 0x04, 0x00,  0xD2, 0xEB, 0xA6, 0xEF, 0x61, 0x55, 0x08, 0x00 /* ll_seq.data */},
+        be =
+        {0x00, 0x00, 0x00, 0x04,/* b_seq.length */  0x01, 0x00, 0x01, 0x00, /* b_seq.data */
+         0x00, 0x00, 0x00, 0x04,/* c_seq.length */   'a',  'b',  'c',  'd', /* c_seq.data */
+         0x00, 0x00, 0x00, 0x04,/* s_seq.length */  0x04, 0xD2,  0x09, 0x29,  0x0D, 0x80,  0x11, 0xD7, /* s_seq.data */
+         0x00, 0x00, 0x00, 0x03,/* l_seq.length */  0x00, 0xBC, 0x61, 0x4E,  0x01, 0x65, 0xEC, 0x15,  0x02, 0x0F, 0x76, 0xD2, /* l_seq.data */
+         0x00, 0x00, 0x00, 0x02,/* ll_seq.length */  0x00, 0x04, 0x62, 0xD5, 0x38, 0x91, 0x7A, 0x15,  0x00, 0x08, 0x55, 0x61, 0xEF, 0xA6, 0xEB, 0xD2 /* ll_seq.data */};
+
+    Endianness::Seqs msg(b_seq, c_seq, s_seq, l_seq, ll_seq);
+
+    validate(msg, le, be);
+}
+
+/*
+ * Checking correct (non-)byteswapping serialization of enum types.
+ */
+TEST_F(Serdata, serialization_enums)
+{
+    typedef Endianness::test_enum test_enum;
+
+    Endianness::Enums msg(
+        test_enum::first,
+        {test_enum::second, test_enum::third, test_enum::fourth, test_enum::fifth});
+
+    std::vector<uint8_t> le1 =
+        {0x01, 0x00, 0x00, 0x00,  /* e_1 */
+         0x02, 0x00, 0x00, 0x00,  0x03, 0x00, 0x00, 0x00,  0x04, 0x00, 0x00, 0x00,  0x05, 0x00, 0x00, 0x00} /* e_arr */,
+        be1 = {0x00, 0x00, 0x00, 0x01,  /* e_1 */
+         0x00, 0x00, 0x00, 0x02,  0x00, 0x00, 0x00, 0x03,  0x00, 0x00, 0x00, 0x04,  0x00, 0x00, 0x00, 0x05} /* e_arr */;
+
+    validate(msg, le1, be1);
+
+    Endianness::SeqEnums msg2({test_enum::zeroth, test_enum::first, test_enum::second, test_enum::third, test_enum::fourth, test_enum::fifth});
+
+    std::vector<uint8_t> le2 =
+        {0x06, 0x00, 0x00, 0x00,  /* e_seq.length */
+         0x00, 0x00, 0x00, 0x00,  0x01, 0x00, 0x00, 0x00,  0x02, 0x00, 0x00, 0x00,  0x03, 0x00, 0x00, 0x00,  0x04, 0x00, 0x00, 0x00,  0x05, 0x00, 0x00, 0x00 /* e_seq.data */},
+        be2 =
+        {0x00, 0x00, 0x00, 0x06,  /* e_seq.length */
+         0x00, 0x00, 0x00, 0x00,  0x00, 0x00, 0x00, 0x01,  0x00, 0x00, 0x00, 0x02,  0x00, 0x00, 0x00, 0x03,  0x00, 0x00, 0x00, 0x04,  0x00, 0x00, 0x00, 0x05 /* e_seq.data */};
+
+    validate(msg2, le2, be2);
+}
+
+/*
+ * Checking correct (non-)byteswapping serialization of unions.
+ */
+TEST_F(Serdata, serialization_unions)
+{
+    Endianness::UnionStr Ustr;
+    Ustr.u().s(1234,5678);
+
+    std::vector<uint8_t> le =
+        {0x2E, 0x16, 0x00, 0x00,  /* discriminator */
+         0xD2, 0x04} /* s */,
+        be = {0x00, 0x00, 0x16, 0x2E,  /* discriminator */
+         0x04, 0xD2} /* s */;
+
+    validate(Ustr, le, be);
 }

--- a/src/ddscxx/tests/data/Serialization.idl
+++ b/src/ddscxx/tests/data/Serialization.idl
@@ -19,4 +19,45 @@ module Endianness
     unsigned long l;
   };
 
+  struct Seqs
+  {
+    sequence<boolean> b_seq;
+    sequence<char> c_seq;
+    sequence<short> s_seq;
+    sequence<long> l_seq;
+    sequence<long long> ll_seq;
+  };
+
+  enum test_enum {
+    zeroth,
+    first,
+    second,
+    third,
+    fourth,
+    fifth
+  };
+
+  struct Enums
+  {
+    test_enum e_1, e_arr[4];
+  };
+
+  struct SeqEnums
+  {
+    sequence<test_enum> e_seq;
+  };
+
+  union U switch (long) {
+    case 0:
+    case 3:
+    case 6: double d;
+    case 1:
+    case 4:
+    case 7: string str;
+    default: short s;
+  };
+
+  struct UnionStr {
+    U u;
+  };
 };

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -127,6 +127,7 @@ struct streams {
   size_t keys;
   bool key_max_sz_unlimited;
   bool max_sz_unlimited;
+  bool swapped;
 };
 
 static void setup_streams(struct streams* str, struct generator* gen)
@@ -204,6 +205,8 @@ write_string_streaming_functions(
   uint32_t maximum = ((const idl_string_t*)type_spec)->maximum;
 
   const char* fmt = "  %2$s_string(streamer, %1$s, %3$u);\n";
+  if (streams->swapped)
+    fmt = "  %2$s_string_swapped(streamer, %1$s, %3$u);\n";
 
   if ((loc.type & NORMAL_INSTANCE) &&
       (putf(&streams->write, fmt, accessor, "write", maximum)
@@ -242,6 +245,9 @@ write_typedef_streaming_functions(
   instance_location_t loc)
 {
   const char* fmt = "  %2$s_%3$s(streamer, %1$s);\n";
+  if (streams->swapped)
+    fmt = "  %2$s_%3$s_swapped(streamer, %1$s);\n";
+
   char* name = NULL;
   if (IDL_PRINTA(&name, get_cpp11_name_typedef, type_spec, streams->generator) < 0)
     return IDL_RETCODE_NO_MEMORY;
@@ -276,6 +282,9 @@ write_basic_type_streaming_functions(
   instance_location_t loc)
 {
   const char* fmt = "  %2$s(streamer, %1$s);\n";
+  if (streams->swapped)
+    fmt = "  %2$s_swapped(streamer, %1$s);\n";
+
   const char* read_fmt = fmt;
   if ((idl_type(type_spec) == IDL_BOOL) &&
       (loc.type & SEQUENCE)) {
@@ -324,6 +333,8 @@ write_constructed_type_streaming_functions(
   instance_location_t loc)
 {
   const char* fmt = "  %2$s(streamer, %1$s);\n";
+  if (streams->swapped)
+    fmt = "  %2$s_swapped(streamer, %1$s);\n";
 
   if ((loc.type & NORMAL_INSTANCE) &&
       (putf(&streams->write, fmt, accessor, "write")
@@ -339,7 +350,11 @@ write_constructed_type_streaming_functions(
 
   if (idl_is_constr_type(type_spec) &&
       !idl_is_keyless(type_spec, pstate->flags & IDL_FLAG_KEYLIST))
+  {
     fmt = "  key_%2$s(streamer, %1$s);\n";
+    if (streams->swapped)
+      fmt = "  key_%2$s_swapped(streamer, %1$s);\n";
+  }
 
   if (putf(&streams->key_write, fmt, accessor, "write")
    || putf(&streams->key_read, fmt, read_accessor, "read")
@@ -370,6 +385,56 @@ write_streaming_functions(
 }
 
 static idl_retcode_t
+insert_sequence_primitives_copy(
+  struct streams *streams,
+  const char *accessor,
+  const char *read_accessor,
+  instance_location_t loc,
+  size_t depth,
+  size_t max)
+{
+  const char *fmt = "  %1$s_many(streamer, %2$s.data(), se_%3$u);\n";
+  const char *mfmt = "  %1$s_many(streamer, %2$s.data(), %3$u);\n";
+  if (streams->swapped)
+  {
+    fmt = "  %1$s_many_swapped(streamer, %2$s.data(), se_%3$u);\n";
+    mfmt = "  %1$s_many_swapped(streamer, %2$s.data(), %3$u);\n";
+  }
+
+  if ((loc.type & NORMAL_INSTANCE) &&
+      (putf(&streams->write, fmt, "write", accessor, depth)
+    || putf(&streams->read, fmt, "read", read_accessor, depth)
+    || putf(&streams->move, fmt, "move", accessor, depth)
+    || putf(&streams->max, mfmt, "max", accessor, max)))
+    return IDL_RETCODE_NO_MEMORY;
+
+  if ((loc.type & KEY_INSTANCE) &&
+      (putf(&streams->key_write, fmt, "write", accessor, depth)
+    || putf(&streams->key_read, fmt, "read", read_accessor, depth)
+    || putf(&streams->key_move, fmt, "move", accessor, depth)
+    || putf(&streams->key_max, mfmt, "max", accessor, max)))
+    return IDL_RETCODE_NO_MEMORY;
+
+  fmt = "  }\n";
+
+  if ((loc.type & NORMAL_INSTANCE) &&
+      (putf(&streams->read, fmt)
+    || putf(&streams->write, fmt)
+    || putf(&streams->move, fmt)
+    || putf(&streams->max, fmt)))
+    return IDL_RETCODE_NO_MEMORY;
+
+  if ((loc.type & KEY_INSTANCE) &&
+      (putf(&streams->key_read, fmt)
+    || putf(&streams->key_write, fmt)
+    || putf(&streams->key_move, fmt)
+    || putf(&streams->key_max, fmt)))
+    return IDL_RETCODE_NO_MEMORY;
+
+  return IDL_RETCODE_OK;
+}
+
+static idl_retcode_t
 unroll_sequence(const idl_pstate_t* pstate,
   struct streams* streams,
   const idl_sequence_t* seq,
@@ -380,45 +445,94 @@ unroll_sequence(const idl_pstate_t* pstate,
 {
   uint32_t maximum = seq->maximum;
 
+  if (maximum == 0) {
+    if (loc.type & NORMAL_INSTANCE)
+      streams->max_sz_unlimited = true;
+    if (loc.type & KEY_INSTANCE)
+      streams->key_max_sz_unlimited = true;
+  }
+
   const char* wfmt = maximum ? "  {\n"\
                                "  uint32_t se_%1$u = uint32_t(%2$s.size());\n"\
                                "  if (se_%1$u > %4$u &&\n"
                                "      streamer.status(serialization_status::%3$s_bound_exceeded))\n"
                                "        return;\n"\
-                               "  %3$s(streamer, se_%1$u);\n"\
-                               "  for (uint32_t i_%1$u = 0; i_%1$u < se_%1$u; i_%1$u++) {\n"
+                               "  %3$s(streamer, se_%1$u);\n"
                              : "  {\n"\
                                "  uint32_t se_%1$u = uint32_t(%2$s.size());\n"\
-                               "  %3$s(streamer, se_%1$u);\n"\
-                               "  for (uint32_t i_%1$u = 0; i_%1$u < se_%1$u; i_%1$u++) {\n";
+                               "  %3$s(streamer, se_%1$u);\n";
   const char* rfmt = maximum ? "  {\n"\
                                "  uint32_t se_%1$u = 0;\n"\
                                "  read(streamer, se_%1$u);\n"\
                                "  if (se_%1$u > %3$u &&\n"
                                "      streamer.status(serialization_status::read_bound_exceeded))\n"
                                "        return;\n"\
-                               "  %2$s.resize(se_%1$u);\n"\
-                               "  for (uint32_t i_%1$u = 0; i_%1$u < se_%1$u; i_%1$u++) {\n"\
+                               "  %2$s.resize(se_%1$u);\n"
                              : "  {\n"\
                                "  uint32_t se_%1$u = 0;\n"\
                                "  read(streamer, se_%1$u);\n"\
-                               "  %2$s.resize(se_%1$u);\n"\
-                               "  for (uint32_t i_%1$u = 0; i_%1$u < se_%1$u; i_%1$u++) {\n";
+                               "  %2$s.resize(se_%1$u);\n";
   const char* mfmt = "  {\n"\
-                     "  max(streamer, uint32_t(0));\n"\
-                     "  for (uint32_t i_%1$u = 0; i_%1$u < %2$u; i_%1$u++) {\n";
+                     "  max(streamer, uint32_t(0));\n";
+  if (streams->swapped)
+  {
+    wfmt = maximum ?  "  {\n"\
+                      "  uint32_t se_%1$u = uint32_t(%2$s.size());\n"\
+                      "  if (se_%1$u > %4$u &&\n"
+                      "      streamer.status(serialization_status::%3$s_bound_exceeded))\n"
+                      "        return;\n"\
+                      "  %3$s_swapped(streamer, se_%1$u);\n"
+                    : "  {\n"\
+                      "  uint32_t se_%1$u = uint32_t(%2$s.size());\n"\
+                      "  %3$s_swapped(streamer, se_%1$u);\n";
+    rfmt = maximum ?  "  {\n"\
+                      "  uint32_t se_%1$u = 0;\n"\
+                      "  read_swapped(streamer, se_%1$u);\n"\
+                      "  if (se_%1$u > %3$u &&\n"
+                      "      streamer.status(serialization_status::read_bound_exceeded))\n"
+                      "        return;\n"\
+                      "  %2$s.resize(se_%1$u);\n"
+                    : "  {\n"\
+                      "  uint32_t se_%1$u = 0;\n"\
+                      "  read_swapped(streamer, se_%1$u);\n"\
+                      "  %2$s.resize(se_%1$u);\n";
+    mfmt = "  {\n"\
+           "  max_swapped(streamer, uint32_t(0));\n";
+  }
 
   if ((loc.type & NORMAL_INSTANCE) &&
       (putf(&streams->read, rfmt, depth, read_accessor, maximum)
     || putf(&streams->write, wfmt, depth, accessor, "write", maximum)
     || putf(&streams->move, wfmt, depth, accessor, "move", maximum)
-    || putf(&streams->max, mfmt, depth, maximum)))
+    || putf(&streams->max, mfmt)))
     return IDL_RETCODE_NO_MEMORY;
 
   if ((loc.type & KEY_INSTANCE) &&
       (putf(&streams->key_read, rfmt, depth, read_accessor, maximum)
     || putf(&streams->key_write, wfmt, depth, accessor, "write", maximum)
     || putf(&streams->key_move, wfmt, depth, accessor, "move", maximum)
+    || putf(&streams->key_max, mfmt)))
+    return IDL_RETCODE_NO_MEMORY;
+
+  if (!idl_is_sequence(seq->type_spec)
+   && idl_is_base_type(seq->type_spec)
+   && !(idl_type(seq->type_spec) == IDL_BOOL))
+    return insert_sequence_primitives_copy(streams, accessor, read_accessor, loc, depth, maximum);
+
+  mfmt = "  for (uint32_t i_%1$u = 0; i_%1$u < %2$u; i_%1$u++) {\n";
+  const char *fmt = "  for (uint32_t i_%1$u = 0; i_%1$u < se_%1$u; i_%1$u++) {\n";
+
+  if ((loc.type & NORMAL_INSTANCE) &&
+      (putf(&streams->read, fmt, depth)
+    || putf(&streams->write, fmt, depth)
+    || putf(&streams->move, fmt, depth)
+    || putf(&streams->max, mfmt, depth, maximum)))
+    return IDL_RETCODE_NO_MEMORY;
+
+  if ((loc.type & KEY_INSTANCE) &&
+      (putf(&streams->key_read, fmt, depth)
+    || putf(&streams->key_write, fmt, depth)
+    || putf(&streams->key_move, fmt, depth)
     || putf(&streams->key_max, mfmt, depth, maximum)))
     return IDL_RETCODE_NO_MEMORY;
 
@@ -441,13 +555,6 @@ unroll_sequence(const idl_pstate_t* pstate,
 
   if (ret != IDL_RETCODE_OK)
     return ret;
-
-  if (maximum == 0) {
-    if (loc.type & NORMAL_INSTANCE)
-      streams->max_sz_unlimited = true;
-    if (loc.type & KEY_INSTANCE)
-      streams->key_max_sz_unlimited = true;
-  }
 
   //close sequence
   wfmt = "  } //i_%1$u\n  }\n";
@@ -510,6 +617,41 @@ unroll_array(
 }
 
 static idl_retcode_t
+insert_array_primitives_copy(
+  struct streams *streams,
+  const idl_declarator_t* declarator,
+  const idl_literal_t *lit,
+  instance_location_t loc,
+  size_t n_arr,
+  char *accessor)
+{
+  uint32_t a_size = lit->value.uint32;
+
+  if (n_arr && IDL_PRINTA(&accessor, get_array_accessor, declarator, &n_arr) < 0)
+    return IDL_RETCODE_NO_MEMORY;
+
+  const char *fmt = "  %1$s_many(streamer, %2$s.data(), %3$u);\n";
+  if (streams->swapped)
+    fmt = "  %1$s_many_swapped(streamer, %2$s.data(), %3$u);\n";
+
+  if ((loc.type & NORMAL_INSTANCE) &&
+      (putf(&streams->write, fmt, "write", accessor, a_size)
+    || putf(&streams->read, fmt, "read", accessor, a_size)
+    || putf(&streams->move, fmt, "move", accessor, a_size)
+    || putf(&streams->max, fmt, "max", accessor, a_size)))
+    return IDL_RETCODE_NO_MEMORY;
+
+  if ((loc.type & KEY_INSTANCE) &&
+      (putf(&streams->key_write, fmt, "write", accessor, a_size)
+    || putf(&streams->key_read, fmt, "read", accessor, a_size)
+    || putf(&streams->key_move, fmt, "move", accessor, a_size)
+    || putf(&streams->key_max, fmt, "max", accessor, a_size)))
+    return IDL_RETCODE_NO_MEMORY;
+
+  return IDL_RETCODE_OK;
+}
+
+static idl_retcode_t
 process_instance(
   const idl_pstate_t *pstate,
   struct streams *streams,
@@ -529,11 +671,18 @@ process_instance(
     const idl_literal_t* lit = (const idl_literal_t*)declarator->const_expr;
     idl_retcode_t ret = IDL_RETCODE_OK;
     while (lit) {
-      if ((ret = unroll_array(streams, accessor, n_arr++, loc)) != IDL_RETCODE_OK)
-        return ret;
+      const idl_literal_t* next = (const idl_literal_t*)((const idl_node_t*)lit)->next;
 
-      lit = (const idl_literal_t*)((const idl_node_t*)lit)->next;
+      if (next == NULL &&
+          idl_is_base_type(type_spec)) {
+        return insert_array_primitives_copy(streams, declarator, lit, loc, n_arr, accessor);
+      } else if ((ret = unroll_array(streams, accessor, n_arr++, loc)) != IDL_RETCODE_OK) {
+        return ret;
+      }
+
+      lit = next;
     }
+
     //update accessor to become "a_$n_arr$"
     if (IDL_PRINTA(&accessor, get_array_accessor, declarator, &n_arr) < 0)
       return IDL_RETCODE_NO_MEMORY;
@@ -681,6 +830,11 @@ process_inherit_spec(
   char *type = NULL;
   const char *fmt = "  %2$s(streamer,dynamic_cast<%1$s&>(instance));\n";
   const char *constfmt = "  %2$s(streamer,dynamic_cast<const %1$s&>(instance));\n";
+  if (streams->swapped)
+  {
+    fmt = "  %2$s(streamer,dynamic_cast<%1$s&>(instance));\n";
+    constfmt = "  %2$s(streamer,dynamic_cast<const %1$s&>(instance));\n";
+  }
 
   (void)pstate;
   (void)revisit;
@@ -802,6 +956,15 @@ print_constructed_type_open(struct streams *streams, const idl_node_t *node)
   const char *constfmt =
     "template<typename T>\n"
     "void %2$s(T& streamer, const %1$s& instance)\n{\n";
+  if (streams->swapped)
+  {
+    fmt =
+      "template<typename T>\n"
+      "void %2$s_swapped(T& streamer, %1$s& instance)\n{\n";
+    constfmt =
+      "template<typename T>\n"
+      "void %2$s_swapped(T& streamer, const %1$s& instance)\n{\n";
+  }
 
   if (putf(&streams->write, constfmt, name, "write")
    || putf(&streams->read, fmt, name, "read")
@@ -865,6 +1028,14 @@ process_struct(
     "  streamer.position(SIZE_MAX);\n"
     "}\n\n";
 
+  if (streams->swapped)
+    fmt =
+      "template<typename T>\n"
+      "void %1$smax_swapped(T& streamer, const %2$s& instance) {\n"
+      "  (void)instance;\n"
+      "  streamer.position(SIZE_MAX);\n"
+      "}\n\n";
+
   char *fullname = NULL;
   if (IDL_PRINTA(&fullname, get_cpp11_fully_scoped_name, node, streams->generator) < 0)
     return IDL_RETCODE_NO_MEMORY;
@@ -908,23 +1079,43 @@ process_switch_type_spec(
   const void *node,
   void *user_data)
 {
-  static const char writefmt[] =
+  struct streams *streams = user_data;
+
+  const char *writefmt =
     "  auto d = instance._d();\n"
     "  write(streamer, d);\n";
-  static const char readfmt[] =
+  const char *readfmt =
     "  auto d = instance._d();\n"
     "  read(streamer, d);\n";
-  static const char movefmt[] =
+  const char *movefmt =
     "  auto d = instance._d();\n"
     "  move(streamer, d);\n";
-  static const char maxfmt[] =
+  const char *maxfmt =
     "  max(streamer, instance._d());\n"
     "  size_t union_max = streamer.position();\n"
     "  size_t alignment_max = streamer.alignment();\n";
-  static const char key_maxfmt[] =
+  const char *key_maxfmt =
     "  max(streamer, instance._d());\n";
 
-  struct streams *streams = user_data;
+  if (streams->swapped)
+  {
+    writefmt =
+      "  auto d = instance._d();\n"
+      "  write_swapped(streamer, d);\n";
+    readfmt =
+      "  auto d = instance._d();\n"
+      "  read_swapped(streamer, d);\n";
+    movefmt =
+      "  auto d = instance._d();\n"
+      "  move_swapped(streamer, d);\n";
+    maxfmt =
+      "  max_swapped(streamer, instance._d());\n"
+      "  size_t union_max = streamer.position();\n"
+      "  size_t alignment_max = streamer.alignment();\n";
+    key_maxfmt =
+      "  max_swapped(streamer, instance._d());\n";
+  }
+
   const idl_switch_type_spec_t *switch_type_spec = node;
 
   (void)pstate;
@@ -966,12 +1157,21 @@ process_union(
   static const char *pfmt =
     "  streamer.position(union_max);\n"
     "  streamer.alignment(alignment_max);\n";
-  static const char *ffmt =
+  const char *ffmt =
     "template<typename T>\n"
     "void max(T& streamer, const %1$s& instance) {\n"
     "  (void)instance;\n"
     "  streamer.position(SIZE_MAX);\n"
     "}\n\n";
+  if (streams->swapped)
+  {
+    ffmt =
+      "template<typename T>\n"
+      "void max_swapped(T& streamer, const %1$s& instance) {\n"
+      "  (void)instance;\n"
+      "  streamer.position(SIZE_MAX);\n"
+      "}\n\n";
+  }
 
   char *fullname = NULL;
   if (IDL_PRINTA(&fullname, get_cpp11_fully_scoped_name, node, streams->generator) < 0)
@@ -1064,6 +1264,16 @@ process_typedef_decl(
     "  (void)instance;\n"
     "  streamer.position(SIZE_MAX);\n"
     "}\n\n";
+  if (streams->swapped)
+  {
+      fmt =
+        "template<typename T>\n"
+        "inline void %1$s_%2$s_swapped(T& streamer, %3$s& instance)\n{\n";
+      constfmt =
+        "template<typename T>\n"
+        "inline void %1$s_%2$s_swapped(T& streamer, const %3$s& instance)\n{\n";
+
+  }
   char* name = NULL;
   if (IDL_PRINTA(&name, get_cpp11_name_typedef, declarator, streams->generator) < 0)
     return IDL_RETCODE_NO_MEMORY;
@@ -1164,8 +1374,15 @@ generate_streamers(const idl_pstate_t* pstate, struct generator *gen)
   visitor.accept[IDL_ACCEPT_TYPEDEF] = &process_typedef;
 
   idl_retcode_t ret = IDL_RETCODE_OK;
-  if ((ret = idl_visit(pstate, pstate->root, &visitor, &streams)) == IDL_RETCODE_OK)
-    ret = flush(gen, &streams);
+  if ((ret = idl_visit(pstate, pstate->root, &visitor, &streams)) != IDL_RETCODE_OK ||
+      (ret = flush(gen, &streams)) != IDL_RETCODE_OK)
+    return ret;
+
+  streams.swapped = true;
+
+  if ((ret = idl_visit(pstate, pstate->root, &visitor, &streams)) != IDL_RETCODE_OK ||
+      (ret = flush(gen, &streams)) != IDL_RETCODE_OK)
+    return ret;
 
   if (idl_fprintf(gen->header.handle,
                   "} //namespace cdr\n"


### PR DESCRIPTION
Improved CDR serialization performance by:
- only checking whether byte swaps need to be done at the start of serialization of the entire message, and then invoking the correct streaming function, in stead of checking for byte swapping at each primitive
- copying contiguous blocks of primitives (sequences/array) is now no longer done by iterating over each entry

Added unittests for serialization and byteswapping.