### PR TITLE
Add IgnoreLocal reader, writer QoS setting

### DIFF
--- a/src/ddscxx/include/dds/core/policy/CorePolicy.hpp
+++ b/src/ddscxx/include/dds/core/policy/CorePolicy.hpp
@@ -148,6 +148,9 @@ TypeConsistencyEnforcement;
 typedef dds::core::policy::detail::PSMXInstances
 PSMXInstances;
 
+typedef dds::core::policy::detail::IgnoreLocal
+IgnoreLocal;
+
 typedef dds::core::policy::detail::UserData
 UserData;
 
@@ -199,6 +202,7 @@ OMG_DDS_POLICY_TRAITS(TypeConsistencyEnforcement, 24)
 #endif  // OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
 OMG_DDS_POLICY_TRAITS(WriterBatching,       25)
 OMG_DDS_POLICY_TRAITS(PSMXInstances,        34)
+OMG_DDS_POLICY_TRAITS(IgnoreLocal,          35)
 
 }
 }

--- a/src/ddscxx/include/dds/core/policy/PolicyKind.hpp
+++ b/src/ddscxx/include/dds/core/policy/PolicyKind.hpp
@@ -253,6 +253,17 @@ struct TypeConsistencyKind_def
 
 typedef dds::core::safe_enum<TypeConsistencyKind_def> TypeConsistencyKind;
 
+struct IgnoreLocalKind_def
+{
+    enum Type
+    {
+        NONE,
+        PARTICIPANT,
+        PROCESS
+    };
+};
+typedef dds::core::safe_enum<IgnoreLocalKind_def> IgnoreLocalKind;
+
 }
 }
 }

--- a/src/ddscxx/include/dds/core/policy/TCorePolicy.hpp
+++ b/src/ddscxx/include/dds/core/policy/TCorePolicy.hpp
@@ -1939,6 +1939,73 @@ public:
     const dds::core::StringSeq instances() const;
 };
 
+//==============================================================================
+
+/**
+ * \copydoc DCPS_QoS_Durability
+ */
+template <typename D>
+class TIgnoreLocal : public dds::core::Value<D>
+{
+public:
+    /**
+     * Creates a IgnoreLocal QoS instance
+     *
+     * @param kind the kind
+     */
+    explicit TIgnoreLocal(
+        dds::core::policy::IgnoreLocalKind::Type kind = dds::core::policy::IgnoreLocalKind::NONE);
+
+    /**
+     * Copies a IgnoreLocal QoS instance
+     *
+     * @param other the IgnoreLocal QoS instance to copy
+     */
+    TIgnoreLocal(const TIgnoreLocal& other);
+
+    /**
+     * Copies a IgnoreLocal QoS instance
+     *
+     * @param other the IgnoreLocal QoS instance to copy
+     *
+     * @return reference to the IgnoreLocal QoS that was copied to
+     */
+    TIgnoreLocal& operator=(const TIgnoreLocal& other) = default;
+
+public:
+    /**
+    * Set the kind
+     *
+     * @param kind the kind to set
+     *
+     * @return the kind that was set
+    */
+    TIgnoreLocal& kind(dds::core::policy::IgnoreLocalKind::Type kind);
+
+    /**
+     * Get the kind
+     *
+     * @return the kind
+     */
+    dds::core::policy::IgnoreLocalKind::Type  kind() const;
+
+public:
+    /**
+     * @return a IgnoreLocal QoS instance with the kind set to NONE
+     */
+    static TIgnoreLocal None();
+
+    /**
+     * @return a IgnoreLocal QoS instance with the kind set to PARTICIPANT
+     */
+    static TIgnoreLocal Participant();
+
+    /**
+     * @return a IgnoreLocal QoS instance with the kind set to PROCESS
+     */
+    static TIgnoreLocal Process();
+};
+
 }
 }
 }

--- a/src/ddscxx/include/dds/core/policy/detail/CorePolicy.hpp
+++ b/src/ddscxx/include/dds/core/policy/detail/CorePolicy.hpp
@@ -109,6 +109,9 @@ namespace dds { namespace core { namespace policy { namespace detail {
 
     typedef dds::core::policy::TWriterBatching<org::eclipse::cyclonedds::core::policy::WriterBatchingDelegate>
     WriterBatching;
+
+    typedef dds::core::policy::TIgnoreLocal<org::eclipse::cyclonedds::core::policy::IgnoreLocalDelegate>
+    IgnoreLocal;
 } } } } // namespace dds::core::policy::detail
 
 

--- a/src/ddscxx/include/dds/core/policy/detail/TCorePolicyImpl.hpp
+++ b/src/ddscxx/include/dds/core/policy/detail/TCorePolicyImpl.hpp
@@ -1174,6 +1174,45 @@ const dds::core::StringSeq TPSMXInstances<D>::instances() const
     return this->delegate().instances();
 }
 
+//TIgnoreLocal
+
+template <typename D>
+TIgnoreLocal<D>::TIgnoreLocal(dds::core::policy::IgnoreLocalKind::Type kind) : dds::core::Value<D>(kind) { }
+
+template <typename D>
+TIgnoreLocal<D>::TIgnoreLocal(const TIgnoreLocal& other) : dds::core::Value<D>(other.delegate()) { }
+
+template <typename D>
+TIgnoreLocal<D>& TIgnoreLocal<D>::kind(dds::core::policy::IgnoreLocalKind::Type kind)
+{
+    this->delegate().kind(kind);
+    return *this;
+}
+
+template <typename D>
+dds::core::policy::IgnoreLocalKind::Type TIgnoreLocal<D>::kind() const
+{
+    return this->delegate().kind();
+}
+
+template <typename D>
+TIgnoreLocal<D> TIgnoreLocal<D>::None()
+{
+    return TIgnoreLocal(dds::core::policy::IgnoreLocalKind::NONE);
+}
+
+template <typename D>
+TIgnoreLocal<D> TIgnoreLocal<D>::Participant()
+{
+    return TIgnoreLocal(dds::core::policy::IgnoreLocalKind::PARTICIPANT);
+}
+
+template <typename D>
+TIgnoreLocal<D> TIgnoreLocal<D>::Process()
+{
+    return TIgnoreLocal(dds::core::policy::IgnoreLocalKind::PROCESS);
+}
+
 }
 }
 }

--- a/src/ddscxx/include/dds/pub/qos/detail/DataWriterQos.hpp
+++ b/src/ddscxx/include/dds/pub/qos/detail/DataWriterQos.hpp
@@ -54,6 +54,7 @@
  * dds::core::policy::DataRepresentation   | Supported data representation kinds (@ref DCPS_QoS_DataRepresentation "info") | DataRepresentation::DataRepresentation(dds::core::policy::DataRepresentationId::XCDR1)
  * dds::core::policy::TypeConsistencyEnforcement | Type consistency enforcement policies (@ref DCPS_QoS_TypeConsistencyEnforcement "info") | dds::core::policy::TypeConsistencyKind::DISALLOW_TYPE_COERCION
  * dds::core::policy::WriterBatching       | Writer data batching                                                       | dds::core::policy::WriterBatching::DoNotBatchUpdates()
+ * dds::core::policy::IgnoreLocal          | Ignore local readers                                                       | dds::core::policy::IgnoreLocal::None()
  *
  * A QosPolicy can be set when the DataWriter is created or modified with the set
  * qos operation.

--- a/src/ddscxx/include/dds/sub/qos/detail/DataReaderQos.hpp
+++ b/src/ddscxx/include/dds/sub/qos/detail/DataReaderQos.hpp
@@ -50,6 +50,7 @@
  * dds::core::policy::ReaderDataLifecycle         | Instance state changes and notifications (@ref DCPS_QoS_ReaderDataLifecycle "info") | ReaderDataLifecycle::NoAutoPurgeDisposedSamples()
  * dds::core::policy::DataRepresentation          | Supported data representation kinds (@ref DCPS_QoS_DataRepresentation "info")  | DataRepresentation::DataRepresentation(dds::core::policy::DataRepresentationId::XCDR1)
  * dds::core::policy::TypeConsistencyEnforcement | Type consistency enforcement policies (@ref DCPS_QoS_TypeConsistencyEnforcement "info") | dds::core::policy::TypeConsistencyKind::DISALLOW_TYPE_COERCION
+ * dds::core::policy::IgnoreLocal                 | Ignore local readers                                                                | dds::core::policy::IgnoreLocal::None()
  *
  * A QosPolicy can be set when the DataReader is created or modified with the set
  * qos operation.

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/Policy.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/Policy.hpp
@@ -39,6 +39,33 @@
         static const std::string& name(); \
     };
 
+namespace org
+{
+namespace eclipse
+{
+namespace cyclonedds
+{
+namespace core
+{
+namespace policy
+{
+template <typename Policy>
+class policy_id;
+template <typename Policy>
+class policy_name;
+
+/*
+ * Proprietary policies values
+ */
+typedef dds::core::policy::TIgnoreLocal<org::eclipse::cyclonedds::core::policy::IgnoreLocalDelegate> IgnoreLocal;
+
+}
+}
+}
+}
+}
+
+
 namespace dds
 {
 namespace core
@@ -49,6 +76,7 @@ template <typename Policy>
 class policy_id;
 template <typename Policy>
 class policy_name;
+
 }
 }
 }

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/PolicyDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/PolicyDelegate.hpp
@@ -916,6 +916,31 @@ private:
     bool batch_updates_;
 };
 
+//==============================================================================
+
+class OMG_DDS_API IgnoreLocalDelegate
+{
+public:
+    IgnoreLocalDelegate(const IgnoreLocalDelegate& other);
+    explicit IgnoreLocalDelegate(dds::core::policy::IgnoreLocalKind::Type kind);
+
+    IgnoreLocalDelegate& operator=(const IgnoreLocalDelegate& other) = default;
+
+    void kind(dds::core::policy::IgnoreLocalKind::Type kind);
+    dds::core::policy::IgnoreLocalKind::Type kind() const;
+
+    bool operator ==(const IgnoreLocalDelegate& other) const;
+
+    void check() const;
+
+    void set_iso_policy(const dds_qos_t* qos);
+    void set_c_policy(dds_qos_t* qos) const;
+
+public:
+    dds::core::policy::IgnoreLocalKind::Type kind_;
+};
+
+//==============================================================================
 
 #ifdef  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.hpp
@@ -62,6 +62,7 @@ public:
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
     void policy(const dds::core::policy::WriterBatching&    writerbatching);
     void policy(const dds::core::policy::PSMXInstances&     psmxinstances);
+    void policy(const dds::core::policy::IgnoreLocal& ignorelocal);
 
     template <typename POLICY> const POLICY& policy() const;
     template <typename POLICY> POLICY& policy();
@@ -106,6 +107,7 @@ private:
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
     dds::core::policy::WriterBatching          writerbatching_;
     dds::core::policy::PSMXInstances           psmxinstances_;
+    dds::core::policy::IgnoreLocal             ignorelocal_;
 };
 
 
@@ -293,6 +295,16 @@ DataWriterQosDelegate::policy<dds::core::policy::PSMXInstances>() const
 {
     return psmxinstances_;
 }
+
+template<> inline const dds::core::policy::IgnoreLocal&
+DataWriterQosDelegate::policy<dds::core::policy::IgnoreLocal>() const
+{
+    return ignorelocal_;
+}
+
+template<> OMG_DDS_API dds::core::policy::IgnoreLocal&
+DataWriterQosDelegate::policy<dds::core::policy::IgnoreLocal>();
+
 
 }
 }

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.hpp
@@ -54,6 +54,7 @@ public:
     void policy(const dds::core::policy::TypeConsistencyEnforcement& typeconsistencyenforcement);
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
     void policy(const dds::core::policy::PSMXInstances&       psmxinstances);
+    void policy(const dds::core::policy::IgnoreLocal&         ignorelocal);
 
     template <typename POLICY> const POLICY& policy() const;
     template <typename POLICY> POLICY& policy();
@@ -90,6 +91,7 @@ private:
     dds::core::policy::TypeConsistencyEnforcement typeconsistencyenforcement_;
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
     dds::core::policy::PSMXInstances           psmxinstances_;
+    dds::core::policy::IgnoreLocal             ignorelocal_;
 };
 
 
@@ -250,6 +252,19 @@ DataReaderQosDelegate::policy<dds::core::policy::PSMXInstances>() const
 {
     return psmxinstances_;
 }
+
+
+template<>
+inline const dds::core::policy::IgnoreLocal&
+DataReaderQosDelegate::policy<dds::core::policy::IgnoreLocal>() const
+{
+    return ignorelocal_;
+}
+
+template<>
+OMG_DDS_API dds::core::policy::IgnoreLocal&
+DataReaderQosDelegate::policy<dds::core::policy::IgnoreLocal>();
+
 
 }
 }

--- a/src/ddscxx/src/dds/core/policy/CorePolicy.cpp
+++ b/src/ddscxx/src/dds/core/policy/CorePolicy.cpp
@@ -49,3 +49,4 @@ OMG_DDS_DEFINE_POLICY_TRAITS(dds::core::policy::DurabilityService,   DurabilityS
 #endif  // OMG_DDS_PERSISTENCE_SUPPORT
 OMG_DDS_DEFINE_POLICY_TRAITS(dds::core::policy::WriterBatching,      WriterBatching)
 OMG_DDS_DEFINE_POLICY_TRAITS(dds::core::policy::PSMXInstances,       PSMXInstances)
+OMG_DDS_DEFINE_POLICY_TRAITS(dds::core::policy::IgnoreLocal,         IgnoreLocal)

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/policy/PolicyDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/policy/PolicyDelegate.cpp
@@ -21,6 +21,10 @@
 #include "dds/ddsc/dds_public_qos.h"
 #include "dds/ddsc/dds_psmx.h"
 
+/*
+ * Proprietary policies traits.
+ */
+
 namespace org
 {
 namespace eclipse
@@ -1624,6 +1628,80 @@ void WriterDataLifecycleDelegate::set_c_policy(dds_qos_t* qos) const
     dds_qset_writer_data_lifecycle(qos, autodispose_);
 }
 
+//==============================================================================
+
+IgnoreLocalDelegate::IgnoreLocalDelegate(const IgnoreLocalDelegate& other)
+    : kind_(other.kind_)
+{
+}
+
+IgnoreLocalDelegate::IgnoreLocalDelegate(dds::core::policy::IgnoreLocalKind::Type kind)
+    : kind_(kind)
+{
+    this->check();
+}
+
+void IgnoreLocalDelegate::kind(dds::core::policy::IgnoreLocalKind::Type kind)
+{
+    kind_ = kind;
+}
+
+dds::core::policy::IgnoreLocalKind::Type IgnoreLocalDelegate::kind() const
+{
+    return kind_;
+}
+
+bool IgnoreLocalDelegate::operator ==(const IgnoreLocalDelegate& other) const
+{
+    return other.kind() == kind_;
+}
+
+void IgnoreLocalDelegate::check() const
+{
+    /* The kind correctness is enforced by the compiler: nothing to check. */
+}
+
+void IgnoreLocalDelegate::set_iso_policy(const dds_qos_t* qos)
+{
+    dds_ignorelocal_kind_t kind;
+    if (dds_qget_ignorelocal(qos, &kind)) {
+        switch (kind) {
+            case DDS_IGNORELOCAL_NONE:
+                kind_ = dds::core::policy::IgnoreLocalKind::NONE;
+                break;
+            case DDS_IGNORELOCAL_PARTICIPANT:
+                kind_ = dds::core::policy::IgnoreLocalKind::PARTICIPANT;
+                break;
+            case DDS_IGNORELOCAL_PROCESS:
+                kind_ = dds::core::policy::IgnoreLocalKind::PROCESS;
+                break;
+            default:
+                assert(0);
+                break;
+        }
+    }
+}
+
+void IgnoreLocalDelegate::set_c_policy(dds_qos_t* qos) const
+{
+    switch(kind_)
+    {
+    case dds::core::policy::IgnoreLocalKind::NONE:
+        dds_qset_ignorelocal(qos, DDS_IGNORELOCAL_NONE);
+        break;
+    case dds::core::policy::IgnoreLocalKind::PARTICIPANT:
+        dds_qset_ignorelocal(qos, DDS_IGNORELOCAL_PARTICIPANT);
+        break;
+    case dds::core::policy::IgnoreLocalKind::PROCESS:
+        dds_qset_ignorelocal(qos, DDS_IGNORELOCAL_PROCESS);
+        break;
+    default:
+        assert(0);
+        break;
+    }
+}
+
+//==============================================================================
 
 //==============================================================================
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.cpp
@@ -201,6 +201,14 @@ DataWriterQosDelegate::policy(const dds::core::policy::PSMXInstances& psmxinstan
     psmxinstances_ = psmxinstances;
 }
 
+void
+DataWriterQosDelegate::policy(const dds::core::policy::IgnoreLocal& ignorelocal)
+{
+    ignorelocal.delegate().check();
+    present_ |= DDSI_QP_CYCLONE_IGNORELOCAL;
+    ignorelocal_ = ignorelocal;
+}
+
 dds_qos_t*
 DataWriterQosDelegate::ddsc_qos() const
 {
@@ -252,6 +260,8 @@ DataWriterQosDelegate::ddsc_qos() const
         writerbatching_.delegate().set_c_policy(qos);
     if (present_ & DDSI_QP_PSMX)
         psmxinstances_.delegate().set_c_policy(qos);
+    if (present_ & DDSI_QP_CYCLONE_IGNORELOCAL)
+        ignorelocal_.delegate().set_c_policy(qos);
     return qos;
 }
 
@@ -305,6 +315,8 @@ DataWriterQosDelegate::ddsc_qos(const dds_qos_t* qos, bool copy_flags)
         writerbatching_.delegate().set_iso_policy(qos);
     if (qos->present & DDSI_QP_PSMX)
         psmxinstances_.delegate().set_iso_policy(qos);
+    if (qos->present & DDSI_QP_CYCLONE_IGNORELOCAL)
+        ignorelocal_.delegate().set_iso_policy(qos);
 }
 
 void
@@ -341,6 +353,7 @@ DataWriterQosDelegate::named_qos(const struct _DDS_NamedDataWriterQos &qos)
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
     writerbatching_.delegate().v_policy((v_writerbatchingPolicy&)(q->writer_batching)     );
     psmxinstances_.delegate().v_policy((v_psmxinstancesPolicy&)(q->psmxinstances)     );
+    ignorelocal_.delegate().v_policy((v_ignorelocalPolicy&)(q->ignorelocal)          );
 #endif
 }
 
@@ -380,7 +393,8 @@ DataWriterQosDelegate::operator ==(const DataWriterQosDelegate& other) const
            other.typeconsistencyenforcement_ == typeconsistencyenforcement_ &&
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
            other.writerbatching_ == writerbatching_ &&
-           other.psmxinstances_ == psmxinstances_
+           other.psmxinstances_ == psmxinstances_ &&
+           other.ignorelocal_ == ignorelocal_
            ;
 }
 
@@ -559,6 +573,13 @@ DataWriterQosDelegate::policy<dds::core::policy::PSMXInstances>()
 {
     present_ |= DDSI_QP_PSMX;
     return psmxinstances_;
+}
+
+template<> dds::core::policy::IgnoreLocal&
+DataWriterQosDelegate::policy<dds::core::policy::IgnoreLocal>()
+{
+    present_ |= DDSI_QP_CYCLONE_IGNORELOCAL;
+    return ignorelocal_;
 }
 
 }

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.cpp
@@ -165,6 +165,14 @@ DataReaderQosDelegate::policy(const dds::core::policy::PSMXInstances& psmxinstan
     psmxinstances_ = psmxinstances;
 }
 
+void
+DataReaderQosDelegate::policy(const dds::core::policy::IgnoreLocal& ignorelocal)
+{
+    ignorelocal.delegate().check();
+    present_ |= DDSI_QP_CYCLONE_IGNORELOCAL;
+    ignorelocal_ = ignorelocal;
+}
+
 dds_qos_t*
 DataReaderQosDelegate::ddsc_qos() const
 {
@@ -204,6 +212,8 @@ DataReaderQosDelegate::ddsc_qos() const
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
     if (present_ & DDSI_QP_PSMX)
         psmxinstances_.delegate().set_c_policy(qos);
+    if (present_ & DDSI_QP_CYCLONE_IGNORELOCAL)
+        ignorelocal_.delegate().set_c_policy(qos);
     return qos;
 }
 
@@ -245,6 +255,8 @@ DataReaderQosDelegate::ddsc_qos(const dds_qos_t* qos, bool copy_flags)
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
     if (qos->present & DDSI_QP_PSMX)
         psmxinstances_.delegate().set_iso_policy(qos);
+    if (qos->present & DDSI_QP_CYCLONE_IGNORELOCAL)
+        ignorelocal_.delegate().set_iso_policy(qos);
 }
 
 void
@@ -274,6 +286,7 @@ DataReaderQosDelegate::named_qos(const struct _DDS_NamedDataReaderQos &qos)
     typeconsistencyenforcement_.delegate().v_policy((v_typeConsistencyEnforcementPolicy&)(q->typeconsistencyenforcement));
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
     psmxinstances_.delegate().v_policy((v_psmxinstancesPolicy&)(q->psmxinstances)     );
+    ignorelocal_ .delegate().v_policy((v_ignorelocalPolicy&)(q->ignorelocal)          );
 #endif
 }
 
@@ -306,7 +319,8 @@ DataReaderQosDelegate::operator==(const DataReaderQosDelegate& other) const
            other.datarepresentation_ == datarepresentation_ &&
            other.typeconsistencyenforcement_ == typeconsistencyenforcement_ &&
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
-           other.psmxinstances_ == psmxinstances_
+           other.psmxinstances_ == psmxinstances_ &&
+           other.ignorelocal_ == ignorelocal_
            ;
 }
 
@@ -459,6 +473,12 @@ DataReaderQosDelegate::policy<dds::core::policy::PSMXInstances>()
     return psmxinstances_;
 }
 
+template<> dds::core::policy::IgnoreLocal&
+DataReaderQosDelegate::policy<dds::core::policy::IgnoreLocal>()
+{
+    present_ |= DDSI_QP_CYCLONE_IGNORELOCAL;
+    return ignorelocal_;
+}
 }
 }
 }

--- a/src/ddscxx/tests/Qos.cpp
+++ b/src/ddscxx/tests/Qos.cpp
@@ -72,6 +72,7 @@ TypeConsistencyEnforcement nonDefaultTypeConsistencyEnforcement(dds::core::polic
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
 WriterBatching         nonDefaultWriterBatching(true);
 PSMXInstances          nonDefaultPSMXInstances({"some_psmx_name"});
+IgnoreLocal            nonDefaultIgnoreLocal(dds::core::policy::IgnoreLocalKind::PROCESS);
 
 
 
@@ -110,6 +111,7 @@ TypeConsistencyEnforcement  tmpEnforcement;
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
 WriterBatching      tmpWriterBatching;
 PSMXInstances       tmpPSMXInstances;
+IgnoreLocal         tmpIgnoreLocal;
 
 TEST(Qos, DomainParticipant)
 {
@@ -360,9 +362,10 @@ TEST(Qos, DataWriter)
                  << nonDefaultRepresentation
                  << nonDefaultTypeConsistencyEnforcement
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
-                << nonDefaultWriterBatching
-                << nonDefaultPSMXInstances
-                  ;
+                 << nonDefaultWriterBatching
+                 << nonDefaultPSMXInstances
+                 << nonDefaultIgnoreLocal
+                 ;
     DataWriterQos dwQosWConstructed(dwQosShifted);
     DataWriterQos dwQosWAssigned1 = dwQosShifted; /* Actually calls copy constructor. */
     DataWriterQos dwQosWAssigned2;
@@ -411,6 +414,7 @@ TEST(Qos, DataWriter)
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
     dwQosShifted >> tmpWriterBatching;
     dwQosShifted >> tmpPSMXInstances;
+    dwQosShifted >> tmpIgnoreLocal;
     ASSERT_EQ(nonDefaultUserData,    tmpUserData);
     ASSERT_EQ(nonDefaultDurability,  tmpDurability);
 #ifdef  OMG_DDS_PERSISTENCE_SUPPORT
@@ -433,6 +437,7 @@ TEST(Qos, DataWriter)
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
     ASSERT_EQ(nonDefaultWriterBatching, tmpWriterBatching);
     ASSERT_EQ(nonDefaultPSMXInstances, tmpPSMXInstances);
+    ASSERT_EQ(nonDefaultIgnoreLocal, tmpIgnoreLocal);
 
     ASSERT_EQ(nonDefaultUserData,    dwQosWConstructed.policy<UserData>());
     ASSERT_EQ(nonDefaultDurability,  dwQosWConstructed.policy<Durability>());
@@ -456,6 +461,7 @@ TEST(Qos, DataWriter)
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
     ASSERT_EQ(nonDefaultWriterBatching, dwQosWConstructed.policy<WriterBatching>());
     ASSERT_EQ(nonDefaultPSMXInstances, dwQosWConstructed.policy<PSMXInstances>());
+    ASSERT_EQ(nonDefaultIgnoreLocal, dwQosWConstructed->policy<IgnoreLocal>());
 
 #ifdef  OMG_DDS_OWNERSHIP_SUPPORT
     dwQosShifted >> tmpStrength;
@@ -508,8 +514,9 @@ TEST(Qos, DataReader)
                  << nonDefaultRepresentation
                  << nonDefaultTypeConsistencyEnforcement
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
-                << nonDefaultPSMXInstances
-                  ;
+                 << nonDefaultPSMXInstances
+                 << nonDefaultIgnoreLocal
+                 ;
     DataReaderQos drQosRConstructed(drQosShifted);
     DataReaderQos drQosRAssigned1 = drQosShifted; /* Actually calls copy constructor. */
     DataReaderQos drQosRAssigned2;
@@ -550,6 +557,7 @@ TEST(Qos, DataReader)
     drQosShifted >> tmpEnforcement;
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
     drQosShifted >> tmpPSMXInstances;
+    drQosShifted >> tmpIgnoreLocal;
     ASSERT_EQ(nonDefaultUserData,    tmpUserData);
     ASSERT_EQ(nonDefaultDurability,  tmpDurability);
     ASSERT_EQ(nonDefaultDeadline,    tmpDeadline);
@@ -567,6 +575,7 @@ TEST(Qos, DataReader)
     ASSERT_EQ(nonDefaultTypeConsistencyEnforcement, tmpEnforcement);
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
     ASSERT_EQ(nonDefaultPSMXInstances, tmpPSMXInstances);
+    ASSERT_EQ(nonDefaultIgnoreLocal, tmpIgnoreLocal);
 
     ASSERT_EQ(nonDefaultUserData,    drQosRConstructed.policy<UserData>());
     ASSERT_EQ(nonDefaultDurability,  drQosRConstructed.policy<Durability>());
@@ -585,6 +594,7 @@ TEST(Qos, DataReader)
     ASSERT_EQ(nonDefaultTypeConsistencyEnforcement, drQosRConstructed.policy<TypeConsistencyEnforcement>());
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
     ASSERT_EQ(nonDefaultPSMXInstances, drQosRConstructed.policy<PSMXInstances>());
+    ASSERT_EQ(nonDefaultIgnoreLocal, drQosRConstructed.policy<IgnoreLocal>());
 }
 
 TEST(Qos, invalid_values)
@@ -683,4 +693,5 @@ TEST(Qos, policy_name)
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
     ASSERT_EQ(dds::core::policy::policy_name<WriterBatching>::name(),      "WriterBatching");
     ASSERT_EQ(dds::core::policy::policy_name<PSMXInstances>::name(),       "PSMXInstances");
+    ASSERT_EQ(dds::core::policy::policy_name<IgnoreLocal>::name(),         "IgnoreLocal");
 }


### PR DESCRIPTION
This adds Cyclone's "ignore local" QoS setting to the C++ API. Fixes #139.

Something strikes me as odd, and that's that adding a very simple QoS policy to what is no more than a C++ wrapper around the C API touches 10 files/+275/-12 lines. The original introduction of the policy in Cyclone (that is, API *and* implementation) touched 5 files/+103 lines (https://github.com/eclipse-cyclonedds/cyclonedds/commit/4778d6c5dfb6853f07f81ac59ae0d65afc5e3c93).

Maybe I did something wrong, I don't know. @e-hndrks, perhaps you can have a look?