### PR TITLE
Add IDL compiler option to specify the output directory for the generated code (requires cyclonedds PR #922)

### DIFF
--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -766,7 +766,12 @@ idl_retcode_t generate(const idl_pstate_t *pstate)
   }
 
   file = sep ? sep + 1 : path;
-  if (idl_isabsolute(path) || !sep)
+  if (pstate->outdir) {
+    if (!(dir = idl_strdup(pstate->outdir))) {
+      goto err_dir;
+    }
+  }
+  else if (idl_isabsolute(path) || !sep)
     dir = empty;
   else if (!(dir = idl_strndup(path, (size_t)(sep-path))))
     goto err_dir;


### PR DESCRIPTION
This adds support for `idl_pstate->outdir` to idlcxx.

Requires https://github.com/eclipse-cyclonedds/cyclonedds/pull/922
