### PR TITLE
Make cyclonedds-cxx compatible with the changes for IDL in cyclonedds

### DIFF
--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -719,7 +719,7 @@ process_member(
   type_spec = ((const idl_member_t *)node)->type_spec;
   /* only use the @key annotations when you do not use the keylist */
   if (!(pstate->flags & IDL_FLAG_KEYLIST) &&
-      ((const idl_member_t *)node)->key == IDL_TRUE)
+      ((const idl_member_t *)node)->key.value)
     loc.type |= KEY_INSTANCE;
 
   IDL_FOREACH(declarator, ((const idl_member_t *)node)->declarators) {
@@ -1129,7 +1129,7 @@ process_switch_type_spec(
     return IDL_RETCODE_NO_MEMORY;
 
   /* short-circuit if switch type specifier is not a key */
-  if (switch_type_spec->key != IDL_TRUE)
+  if (!switch_type_spec->key.value)
     return IDL_RETCODE_OK;
 
   if (putf(&streams->key_write, writefmt)

--- a/src/idlcxx/src/types.c
+++ b/src/idlcxx/src/types.c
@@ -340,7 +340,7 @@ emit_enum(
 
   IDL_FOREACH(enumerator, _enum->enumerators) {
     name = get_cpp11_name(enumerator);
-    value = enumerator->value;
+    value = enumerator->value.value;
     fmt = (value == skip) ? "%s%s" : "%s%s = %" PRIu32 "\n";
     if (idl_fprintf(gen->header.handle, fmt, sep, name, value) < 0)
       return IDL_RETCODE_NO_MEMORY;


### PR DESCRIPTION
This PR makes the `cyclonedds-cxx` compatible with the latest `cyclonedds`

Closes #154 