### PR TITLE
Integrate usage of iceoryx user header

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -145,7 +145,7 @@ public:
 # pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
 #endif
-      return static_cast<T*>(SHIFT_PAST_ICEORYX_HEADER(this->iox_chunk));
+      return static_cast<T*>(this->iox_chunk);
 #ifndef _WIN32
 #ifndef __clang__
 # pragma GCC diagnostic pop


### PR DESCRIPTION
Please merge right after the merge of https://github.com/eclipse-cyclonedds/cyclonedds/pull/943

It seems that the cause of the shared memory unit test failure is due to the fact that use-iceoryx-custom-header is not yet merged on cyclonedds:master and therefore the header is in the wrong place. 
A rerun after the merge of cyclonedds:master should solve the issue.