### PR TITLE
Add missing ddsi_sertype_ops initializers

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -764,7 +764,8 @@ const ddsi_sertype_ops ddscxx_sertype<T>::ddscxx_sertype_ops = {
   nullptr, // serialized_size
   nullptr, // serialize
   nullptr, // deserialize
-  nullptr  // assignable_from
+  nullptr, // assignable_from
+  nullptr  //derive_sertype sertype_default_derive_sertype?
 };
 
 #endif  // DDSCXXDATATOPIC_HPP_


### PR DESCRIPTION
The latest changes to cyclonedds have added new functions to ddsi_sertype_ops
and these pointers must be explicitly initialized to not generate warnings

Signed-off-by: Martijn Reicher <martijn.reicher@adlinktech.com>