### PR TITLE
Update sertype interfaces to support dynamic types with SHM

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -23,6 +23,7 @@
 #include "dds/ddsi/q_radmin.h"
 #include "dds/ddsi/q_xmsg.h"
 #include "dds/ddsi/ddsi_serdata.h"
+#include "dds/ddsi/shm_types.h"
 #include "org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp"
 #include "dds/ddsi/ddsi_keyhash.h"
 #include "org/eclipse/cyclonedds/topic/hash.hpp"
@@ -141,7 +142,7 @@ public:
     if (iox_chunk != nullptr && data() == nullptr) {
       auto iox_header = iceoryx_header_from_chunk(iox_chunk);
 
-      if (iox_header->data_state == IOX_CHUNK_CONTAINS_SERIALIZED_DATA) {
+      if (iox_header->shm_data_state == IOX_CHUNK_CONTAINS_SERIALIZED_DATA) {
         T *t = m_t.load(std::memory_order_acquire);
         if (t == nullptr) {
           t = new T();

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -23,11 +23,14 @@
 #include "dds/ddsi/q_radmin.h"
 #include "dds/ddsi/q_xmsg.h"
 #include "dds/ddsi/ddsi_serdata.h"
-#include "dds/ddsi/shm_transport.h"
 #include "org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp"
 #include "dds/ddsi/ddsi_keyhash.h"
 #include "org/eclipse/cyclonedds/topic/hash.hpp"
 #include "dds/features.hpp"
+
+#ifdef DDSCXX_HAS_SHM
+#include "dds/ddsi/shm_transport.h"
+#endif
 
 constexpr size_t CDR_HEADER_SIZE = 4U;
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -758,7 +758,8 @@ size_t sertype_get_serialized_size(const ddsi_sertype*, const void * sample)
   move(str, msg);
 
   if (str.abort_status()) {
-    // TODO(Sumanth) handle this error
+    // the max value is treated as an error in the Cyclone core
+    return std::numeric_limits<size_t>::max();
   }
 
   return str.position() + CDR_HEADER_SIZE;  // Include the additional bytes for the CDR header

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -628,13 +628,11 @@ ddsi_serdata * serdata_from_iox_buffer(
       d->iox_subscriber = sub;
     }
 
-    //TODO(Sumanth) fix the key hash handling, no point of calling setT()
     // key handling
-    //org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str;
-    //const auto& msg = *static_cast<const T*>(d->iox_chunk);
-    //d->key_md5_hashed() = to_key(str, msg, d->key());
-    //d->setT(&msg);
-    //d->populate_hash();
+    org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str;
+    const auto& msg = *static_cast<const T*>(d->iox_chunk);
+    d->key_md5_hashed() = to_key(str, msg, d->key());
+    d->populate_hash();
 
     return d;
   }

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -780,14 +780,17 @@ void sertype_serialize_into(const ddsi_sertype*,
   // cast to the type
   const auto& msg = *static_cast<const T*>(sample);
 
+  // set the endianess
+  auto ptr = static_cast<unsigned char*>(dst_buffer);
+  memset(ptr, 0x0, 4);
+  if (native_endianness() == endianness::little_endian)
+    *(ptr + 1) = 0x1;
+
   // serialize the sample into the destination buffer
   org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str;
   // TODO(Sumanth), considering the header offset
   str.set_buffer(calc_offset(dst_buffer, 4));
   write(str, msg);
-  // TODO(Sumanth), we should also handle endianness, based on the endiannes we need to call
-  //  read_swapped, but this should be done as part of another issue as there is some cleanup to
-  //  be done with respect to this issue
 
   // TODO(Sumanth), do we need to handle the key hash?
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -751,6 +751,79 @@ uint32_t sertype_hash(const ddsi_sertype* tpcmn)
 }
 
 template <typename T>
+uint32_t sertype_get_serialized_size(const ddsi_sertype* tpcmn, void * sample)
+{
+  // cast to the type
+  const auto& msg = *static_cast<const T*>(sample);
+
+  // get the serialized size of the sample (with out serializing)
+  org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str;
+  move(str, msg);
+
+  // TODO(Sumanth), do we need to handle the key hash?
+
+  if (str.abort_status())
+    // handle error
+
+  // TODO(Sumanth), 4 bytes for header should also be considered?
+  return str.position() + 4;  //4 bytes extra to also include the header
+}
+
+// TODO(Sumanth), cleanup the below functions based on the updated C sertype interface and add
+//  the error handling
+uint32_t sertype_serialize(const ddsi_sertype* tpcmn, void * sample)
+{
+  const auto& msg = *static_cast<const T*>(sample);
+
+  // get the serialized size of the sample (with out serializing)
+  org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str;
+  move(str, msg);
+
+  // TODO(Sumanth), do we need to handle the key hash?
+
+  if (str.abort_status())
+    // TODO(Sumanth) handle this error
+
+  // TODO(Sumanth), 4 bytes for header should also be considered?
+  return str.position() + 4;  //4 bytes extra to also include the header
+}
+
+bool sertype_serialize(const ddsi_sertype* tpcmn, void * sample, void * dst_buffer)
+{
+  // cast to the type
+  const auto& msg = *static_cast<const T*>(sample);
+
+  // serialize the sample into the destination buffer
+  org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str;
+  // TODO(Sumanth), considering the header offset
+  str.set_buffer(calc_offset(dst_buffer, 4));
+  read(str, msg);
+  // TODO(Sumanth), we should also handle endianness, based on the endiannes we need to call
+  //  read_swapped, but this should be done as part of another issue as there is some cleanup to
+  //  be done with respect to this issue
+
+  // TODO(Sumanth), do we need to handle the key hash?
+
+  return !str.abort_status()
+}
+
+bool sertype_deserialize(const ddsi_sertype* tpcmn, const void * src_buffer, void * sample)
+{
+  // cast to the type
+  const auto& msg = *static_cast<const T*>(sample);
+
+  // deserialize the buffer into the sample
+  org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str;
+  // TODO(Sumanth), considering the header offset
+  str.set_buffer(calc_offset(dst_buffer, 4));
+  write(str, sample);
+
+  // TODO(Sumanth), do we need to handle the key hash?
+
+  return !str.abort_status()
+}
+
+template <typename T>
 const ddsi_sertype_ops ddscxx_sertype<T>::ddscxx_sertype_ops = {
   ddsi_sertype_v0,
   nullptr,

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -819,7 +819,7 @@ size_t sertype_get_serialized_size(const ddsi_sertype*, const void * sample)
 }
 
 template <typename T>
-void sertype_serialize_into(const ddsi_sertype*,
+bool sertype_serialize_into(const ddsi_sertype*,
                             const void * sample,
                             void * dst_buffer,
                             size_t)
@@ -841,8 +841,7 @@ void sertype_serialize_into(const ddsi_sertype*,
 
   // TODO(Sumanth), do we need to handle the key hash?
 
-  // TODO(Sumanth) update function signature to return bool
-  !str.abort_status();
+  return !str.abort_status();
 }
 
 template <typename T>

--- a/src/ddscxx/tests/SharedMemory.cpp
+++ b/src/ddscxx/tests/SharedMemory.cpp
@@ -298,19 +298,8 @@ public:
           // Since the data in iceoryx chunk is in the serialized form, take the
           // sample and deserialize the data and then compare with the sent data
           auto buf_ptr = reinterpret_cast<unsigned char *>(const_cast<T *>(iceoryx_data));
-          endianness stream_endianness = endianness::big_endian;
-          if (*(buf_ptr + 1) == 0x1) {
-            stream_endianness = endianness::little_endian;
-          }
-
-          org::eclipse::cyclonedds::core::cdr::basic_cdr_stream str;
-          str.set_buffer(calc_offset(buf_ptr, 4));
           T msg;
-          if (swap_necessary(stream_endianness)) {
-            read_swapped(str, msg);
-          } else {
-            read(str, msg);
-          }
+          deserialize_sample_from_buffer(buf_ptr, msg);
           ASSERT_EQ(msg, test_data[count]);
         } else if (header.shm_data_state == IOX_CHUNK_CONTAINS_RAW_DATA) {
           // the chunk already has deserialized data and can be compared directly

--- a/src/ddscxx/tests/data/Serialization.idl
+++ b/src/ddscxx/tests/data/Serialization.idl
@@ -10,6 +10,18 @@ module Bounded
 
 };
 
+module UnBounded
+{
+
+  struct Msg
+  {
+    string unbounded_string;
+    sequence<long> unbounded_sequence_long;
+    sequence<boolean> unbounded_sequence_bool;
+  };
+
+};
+
 module Endianness
 {
 


### PR DESCRIPTION
This PR adds support for dynamic types (linked sequences, strings both bounded and unbounded) with SHM and modifies the shared memory tests to test the same.

This is built on top of https://github.com/eclipse-cyclonedds/cyclonedds/pull/1000/ and the former needs to be merged before merging this.

Closes #165 

@eboasson @MatthiasKillat