### PR TITLE
Fix write_cdr/take_cdr with SHM

### DIFF
--- a/src/ddscxx/include/dds/sub/detail/SamplesHolder.hpp
+++ b/src/ddscxx/include/dds/sub/detail/SamplesHolder.hpp
@@ -166,6 +166,7 @@ public:
                 "The received sample over SHM is not in serialized form");
             }
             // release the chunk
+            free_iox_chunk(static_cast<iox_sub_t *>(current_blob->iox_subscriber), &current_blob->iox_chunk);
           }
         } else
 #endif

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -29,7 +29,7 @@
 #include "dds/features.hpp"
 
 #ifdef DDSCXX_HAS_SHM
-#include "dds/ddsi/shm_transport.h"
+#include "dds/ddsi/ddsi_shm_transport.h"
 #endif
 
 constexpr size_t CDR_HEADER_SIZE = 4U;

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -173,51 +173,57 @@ public:
   T* getT() {
     // check if m_t is already set
     T *t = m_t.load(std::memory_order_acquire);
+    // if m_t is not set
     if (t == nullptr) {
-#ifdef DDSCXX_HAS_SHM
-      if (iox_chunk != nullptr && data() == nullptr) {
-        auto shm_data_state = shm_get_data_state(iox_chunk);
-        // if the iox chunk has the data in serialized form
-        if (shm_data_state == IOX_CHUNK_CONTAINS_SERIALIZED_DATA) {
-          t = new T();
-          // if deserialization failed
-          if(!deserialize_sample_from_buffer(static_cast<unsigned char *>(iox_chunk), *t, kind)) {
-            delete t;
-            t = nullptr;
-          }
-
-          T *exp = nullptr;
-          if (!m_t.compare_exchange_strong(exp, t, std::memory_order_seq_cst)) {
-            delete t;
-            t = exp;
-          }
-          return t;
-        } else if (shm_data_state == IOX_CHUNK_CONTAINS_RAW_DATA) {
-          // return the chunk directly
-          return static_cast<T*>(this->iox_chunk);
-        } else {
-          // Data is in un-initialized state, which shouldn't happen
-          return nullptr;
-        }
-      } else
-#endif  // DDSCXX_HAS_SHM
-      {
-        t = new T();
-        // if deserialization failed
-        if(!deserialize_sample_from_buffer(static_cast<unsigned char *>(data()), *t, kind)) {
-          delete t;
-          t = nullptr;
-        }
-
-        T* exp = nullptr;
-        if (!m_t.compare_exchange_strong(exp, t, std::memory_order_seq_cst)) {
-          delete t;
-          t = exp;
-        }
-        return t;
+      // if the data is available on iox_chunk, update and get the sample
+      update_sample_from_iox_chunk(t);
+      // if its not possible to get the sample from iox_chunk
+      if(t == nullptr) {
+        // deserialize and get the sample
+        deserialize_and_update_sample(static_cast<uint8_t *>(data()), t);
       }
     }
     return t;
+  }
+
+private:
+  void deserialize_and_update_sample(uint8_t * buffer, T *& t) {
+    t = new T();
+    // if deserialization failed
+    if(!deserialize_sample_from_buffer(buffer, *t, kind)) {
+      delete t;
+      t = nullptr;
+    }
+
+    T* exp = nullptr;
+    if (!m_t.compare_exchange_strong(exp, t, std::memory_order_seq_cst)) {
+      delete t;
+      t = exp;
+    }
+  }
+
+  void update_sample_from_iox_chunk(T *& t) {
+#ifdef DDSCXX_HAS_SHM
+    // if data is available on the iox_chunk (and doesn't have a serialized representation)
+    if (iox_chunk != nullptr && data() == nullptr) {
+        auto shm_data_state = shm_get_data_state(iox_chunk);
+        // if the iox chunk has the data in serialized form
+        if (shm_data_state == IOX_CHUNK_CONTAINS_SERIALIZED_DATA) {
+          deserialize_and_update_sample(static_cast<uint8_t *>(iox_chunk), t);
+        } else if (shm_data_state == IOX_CHUNK_CONTAINS_RAW_DATA) {
+          // get the chunk directly without any copy
+          t = static_cast<T*>(this->iox_chunk);
+        } else {
+          // Data is in un-initialized state, which shouldn't happen
+          t = nullptr;
+        }
+      } else {
+      // data is not available on iox_chunk
+      t = nullptr;
+    }
+#else
+    t = nullptr;
+#endif  // DDSCXX_HAS_SHM
   }
 };
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -173,10 +173,8 @@ public:
   T* getT() {
 #ifdef DDSCXX_HAS_SHM
     if (iox_chunk != nullptr && data() == nullptr) {
-      auto iox_header = iceoryx_header_from_chunk(iox_chunk);
-
       // if the iox chunk has the data in serialized form
-      if (iox_header->shm_data_state == IOX_CHUNK_CONTAINS_SERIALIZED_DATA) {
+      if (shm_get_data_state(iox_chunk) == IOX_CHUNK_CONTAINS_SERIALIZED_DATA) {
         T *t = m_t.load(std::memory_order_acquire);
         if (t == nullptr) {
           t = new T();

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
@@ -22,7 +22,7 @@
 #include <org/eclipse/cyclonedds/core/ScopedLock.hpp>
 #include <org/eclipse/cyclonedds/topic/BuiltinTopicCopy.hpp>
 #include <dds/dds.h>
-#include <dds/ddsc/dds_data_allocator.h>
+#include <dds/ddsc/dds_loan_api.h>
 
 #include "dds/ddsi/ddsi_sertopic.h"
 #include "dds/ddsi/q_protocol.h"

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
@@ -131,6 +131,9 @@ AnyDataWriterDelegate::write_cdr(
     memcpy(iox_chunk, data->encoding().data(), data->encoding().size());
     // copy the actual data
     memcpy(static_cast<unsigned char *>(iox_chunk) + data->encoding().size(), data->payload().data(), data->payload().size());
+    // update SHM data state to serialized, since this API is used to publish the serialized data
+    auto iox_header = iceoryx_header_from_chunk(iox_chunk);
+    iox_header->shm_data_state = IOX_CHUNK_CONTAINS_SERIALIZED_DATA;
     // update the loaned iox chunk in serdata
     ser_data->iox_chunk = iox_chunk;
 #endif

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
@@ -125,12 +125,13 @@ AnyDataWriterDelegate::write_cdr(
 #ifdef DDSCXX_HAS_SHM
     // TODO(Sumanth) we need an API to check if iceoryx is enabled for the writer
     // (meaning if QOS constraints are met, and iox_pub is set)
+    dds_data_allocator_t data_alloc;
+    void *iox_chunk ;
     if(true) {
         // TODO(Sumanth), update this if we have a better API, if not clean this
-        dds_data_allocator_t data_alloc;
         ret = dds_data_allocator_init(writer, &data_alloc);
         ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ret, "write_cdr dds_data_allocator init failed");
-        void *iox_chunk = dds_data_allocator_alloc(&data_alloc, data->payload().size() + 4);
+        iox_chunk = dds_data_allocator_alloc(&data_alloc, data->payload().size() + 4);
         ISOCPP_BOOL_CHECK_AND_THROW(iox_chunk, ISOCPP_NULL_REFERENCE_ERROR, "write_cdr - Loaning of chunk failed");
         // copy the header
         memcpy(iox_chunk, data->encoding().data(), data->encoding().size());
@@ -162,6 +163,8 @@ AnyDataWriterDelegate::write_cdr(
     }
     ret = dds_data_allocator_fini(&data_alloc);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ret, "write_cdr dds_data_allocator free failed");
+#else
+    ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ret, "write_cdr failed.");
 #endif
 }
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
@@ -122,9 +122,9 @@ AnyDataWriterDelegate::write_cdr(
 
     ser_data->statusinfo = statusinfo;
 
-#ifdef DDSCXX_HAS_SHM
     // if shared memory is supported by the writer
     if(dds_is_shared_memory_available(writer)) {
+#ifdef DDSCXX_HAS_SHM
         void *iox_chunk ;
         // request a loan from the shared memory buffer
         ret = dds_loan_shared_memory_buffer(writer,
@@ -141,8 +141,8 @@ AnyDataWriterDelegate::write_cdr(
         shm_set_data_state(iox_chunk, IOX_CHUNK_CONTAINS_SERIALIZED_DATA);
         // update the loaned iox chunk in serdata
         ser_data->iox_chunk = iox_chunk;
-    }
 #endif
+    }
 
     if (timestamp != dds::core::Time::invalid()) {
         dds_time_t ddsc_time = org::eclipse::cyclonedds::core::convertTime(timestamp);

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
@@ -29,7 +29,7 @@
 #include "dds/features.hpp"
 
 #ifdef DDSCXX_HAS_SHM
-#include <dds/ddsi/shm_transport.h>
+#include <dds/ddsi/ddsi_shm_transport.h>
 #endif
 
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
@@ -123,21 +123,26 @@ AnyDataWriterDelegate::write_cdr(
     ser_data->statusinfo = statusinfo;
 
 #ifdef DDSCXX_HAS_SHM
-    // TODO(Sumanth), update this if we have a better API, if not clean this
-    dds_data_allocator_t data_alloc;
-    ret = dds_data_allocator_init(writer, &data_alloc);
-    ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ret, "write_cdr dds_data_allocator init failed");
-    void * iox_chunk = dds_data_allocator_alloc(&data_alloc, data->payload().size() + 4);
-    ISOCPP_BOOL_CHECK_AND_THROW(iox_chunk, ISOCPP_NULL_REFERENCE_ERROR, "write_cdr - Loaning of chunk failed");
-    // copy the header
-    memcpy(iox_chunk, data->encoding().data(), data->encoding().size());
-    // copy the actual data
-    memcpy(static_cast<unsigned char *>(iox_chunk) + data->encoding().size(), data->payload().data(), data->payload().size());
-    // update SHM data state to serialized, since this API is used to publish the serialized data
-    auto iox_header = iceoryx_header_from_chunk(iox_chunk);
-    iox_header->shm_data_state = IOX_CHUNK_CONTAINS_SERIALIZED_DATA;
-    // update the loaned iox chunk in serdata
-    ser_data->iox_chunk = iox_chunk;
+    // TODO(Sumanth) we need an API to check if iceoryx is enabled for the writer
+    // (meaning if QOS constraints are met, and iox_pub is set)
+    if(true) {
+        // TODO(Sumanth), update this if we have a better API, if not clean this
+        dds_data_allocator_t data_alloc;
+        ret = dds_data_allocator_init(writer, &data_alloc);
+        ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ret, "write_cdr dds_data_allocator init failed");
+        void *iox_chunk = dds_data_allocator_alloc(&data_alloc, data->payload().size() + 4);
+        ISOCPP_BOOL_CHECK_AND_THROW(iox_chunk, ISOCPP_NULL_REFERENCE_ERROR, "write_cdr - Loaning of chunk failed");
+        // copy the header
+        memcpy(iox_chunk, data->encoding().data(), data->encoding().size());
+        // copy the actual data
+        memcpy(static_cast<unsigned char *>(iox_chunk) + data->encoding().size(),
+               data->payload().data(), data->payload().size());
+        // update SHM data state to serialized, since this API is used to publish the serialized data
+        auto iox_header = iceoryx_header_from_chunk(iox_chunk);
+        iox_header->shm_data_state = IOX_CHUNK_CONTAINS_SERIALIZED_DATA;
+        // update the loaned iox chunk in serdata
+        ser_data->iox_chunk = iox_chunk;
+    }
 #endif
 
     if (timestamp != dds::core::Time::invalid()) {

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
@@ -26,7 +26,7 @@
 #include <org/eclipse/cyclonedds/topic/BuiltinTopicCopy.hpp>
 
 #include "dds/dds.h"
-#include "dds/ddsc/dds_data_allocator.h"
+#include "dds/ddsc/dds_loan_api.h"
 #include "dds/ddsc/dds_internal_api.h"
 
 namespace org

--- a/src/ddscxx/tests/SharedMemory.cpp
+++ b/src/ddscxx/tests/SharedMemory.cpp
@@ -13,7 +13,7 @@
 
 #include "dds/dds.hpp"
 #include "dds/ddsrt/environ.h"
-#include "dds/ddsi/shm_transport.h"
+#include "dds/ddsi/ddsi_shm_transport.h"
 #include "iceoryx_posh/testing/roudi_gtest.hpp"
 #include "HelloWorldData.hpp"
 #include "Space.hpp"
@@ -21,7 +21,6 @@
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/popo/sample.hpp"
 #include "iceoryx_utils/cxx/optional.hpp"
-#include "dds/ddsi/shm_transport.h"
 
 #include <random>
 


### PR DESCRIPTION
This MR fixes the data path for `write_cdr`/`take_cdr` with SHM

### Details

1. With SHM enabled in `write_cdr`, when constructing the `serdata`, memory is loaned from `iceoryx` and copies the user-provided serialized data into this loaned memory and updates the `serdata` with the loaned chunk
2. While receiving the sample in the `CDRSamplesHolder` if the data is over iceoryx the data is taken from the iceoryx chunk, copied into the `CDRBlob` for the user, and the loaned chunk is released

Closes #175 

This should be merged after https://github.com/eclipse-cyclonedds/cyclonedds/pull/1031