### PR TITLE
Added some changes to the idlcxx/CMakeLists.txt and to inttypes.h to …

### DIFF
--- a/src/ddscxx/include/dds/core/detail/inttypes.hpp
+++ b/src/ddscxx/include/dds/core/detail/inttypes.hpp
@@ -27,7 +27,7 @@
 #define __STDC_FORMAT_MACROS
 #endif
 
-//#include <stdint.h>
+#include <stdint.h>
 #include <inttypes.h>
 
 // End of implementation

--- a/src/ddscxx/include/dds/core/detail/inttypes.hpp
+++ b/src/ddscxx/include/dds/core/detail/inttypes.hpp
@@ -23,7 +23,12 @@
  * simply include that one. Under toolchains that do not, this header must
  * provide equivalent definitions.
  */
-#include <stdint.h>
+#if defined(__GNUC__) && __GNUC__ < 5
+#define __STDC_FORMAT_MACROS
+#endif
+
+//#include <stdint.h>
+#include <inttypes.h>
 
 // End of implementation
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
@@ -56,10 +56,6 @@ org::eclipse::cyclonedds::domain::DomainParticipantDelegate::DomainParticipantDe
     dds_domainid_t did;
     dds_return_t ret;
 
-    if ((id != org::eclipse::cyclonedds::domain::default_id()) && (id > 230)) {
-        ISOCPP_THROW_EXCEPTION(ISOCPP_INVALID_ARGUMENT_ERROR, "Invalid domain_id: %d", static_cast<int>(id));
-    }
-
     /* Validate the qos and get the corresponding ddsc qos. */
     qos.delegate().check();
 
@@ -130,10 +126,6 @@ org::eclipse::cyclonedds::domain::DomainParticipantDelegate::DomainParticipantDe
     dds_qos_t * ddsc_qos;
     dds_domainid_t did;
     dds_return_t ret;
-
-    if ((id != org::eclipse::cyclonedds::domain::default_id()) && (id > 230)) {
-      ISOCPP_THROW_EXCEPTION(ISOCPP_INVALID_ARGUMENT_ERROR, "Invalid domain_id: %" PRIu32, id);
-    }
 
     /* Validate the qos and get the corresponding ddsc qos. */
     qos.delegate().check();

--- a/src/ddscxx/tests/DomainParticipant.cpp
+++ b/src/ddscxx/tests/DomainParticipant.cpp
@@ -212,17 +212,6 @@ TEST(DomainParticipant, create_multiple)
     ASSERT_NE(dp2, dds::core::null);
 }
 
-/* Try creating multiple domain participants at the same time. */
-TEST(DomainParticipant, create_invalid)
-{
-    dds::domain::DomainParticipant dp = dds::core::null;
-
-    /* Maximum id is 230. */
-    ASSERT_THROW({
-        dp = dds::domain::DomainParticipant(231);
-    }, dds::core::InvalidArgumentError);
-}
-
 /* Try re-creating domain participant after last one was deleted. */
 TEST(DomainParticipant, recreate_after_delete)
 {

--- a/src/idlcxx/CMakeLists.txt
+++ b/src/idlcxx/CMakeLists.txt
@@ -22,7 +22,7 @@ set_target_properties(idlcxx PROPERTIES
    OUTPUT_NAME "cycloneddsidlcxx"
    VERSION ${PROJECT_VERSION}
    SOVERSION ${PROJECT_VERSION_MAJOR}
-   C_STANDARD 11)
+   C_STANDARD 99)
 
 target_link_libraries(idlcxx PUBLIC CycloneDDS::idl)
 

--- a/src/idlcxx/CMakeLists.txt
+++ b/src/idlcxx/CMakeLists.txt
@@ -21,7 +21,8 @@ add_library(
 set_target_properties(idlcxx PROPERTIES
    OUTPUT_NAME "cycloneddsidlcxx"
    VERSION ${PROJECT_VERSION}
-   SOVERSION ${PROJECT_VERSION_MAJOR})
+   SOVERSION ${PROJECT_VERSION_MAJOR}
+   C_STANDARD 11)
 
 target_link_libraries(idlcxx PUBLIC CycloneDDS::idl)
 


### PR DESCRIPTION
…allow

older systems, ie pre-gcc5, to build.

Removed the obsolete limitation of a maximum of 230 for the domain_id. Now it can
be any uint32_t value.

NOTE: these changes have only been tested on CentOS7.1 and Ubuntu 20.04. They should be tested on systems with other  tool sets. Also the test suite has not been run because GoogleTest required GCC5 or greater and the CentOS7.1 system I have uses GCC4.8.