### PR TITLE
Add option to skip IDL module building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,15 @@ if(CMAKE_VERSION VERSION_LESS 3.13)
   endmacro()
 endif()
 
+if(CMAKE_CROSSCOMPILING)
+  set(not_crosscompiling OFF)
+else()
+  set(not_crosscompiling ON)
+endif()
+
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
+
+option(BUILD_IDLLIB "Build IDL preprocessor lib" ${not_crosscompiling})
 
 # Make it easy to enable MSVC, Clang's/gcc's analyzers
 set(ANALYZER "" CACHE STRING "Analyzer to enable on the build.")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,5 +9,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-add_subdirectory(idlcxx)
+if (BUILD_IDLLIB)
+  add_subdirectory(idlcxx)
+endif()
 add_subdirectory(ddscxx)


### PR DESCRIPTION
Similar to cyclonedds (the C project) do not build the IDL compiler
module in case of cross-compiling. In that case the native IDL compiler
(build separately) should be used.