### PR TITLE
Add config option to skip idlcxx building if crosscompiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,14 @@ endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
 
+if(CMAKE_CROSSCOMPILING)
+  set(not_crosscompiling OFF)
+else()
+  set(not_crosscompiling ON)
+endif()
+
+option(BUILD_IDLCXX "Build IDL preprocessor" ${not_crosscompiling})
+
 # Make it easy to enable MSVC, Clang's/gcc's analyzers
 set(ANALYZER "" CACHE STRING "Analyzer to enable on the build.")
 if(ANALYZER)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,6 +11,8 @@
 #
 set(CMAKE_INSTALL_EXAMPLESDIR "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/examples")
 
+include("${CMAKE_SOURCE_DIR}/src/idlcxx/Generate.cmake")
+
 install(
   FILES helloworld/publisher.cpp
         helloworld/subscriber.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,5 +9,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-add_subdirectory(idlcxx)
+if (BUILD_IDLCXX)
+  add_subdirectory(idlcxx)
+endif()
 add_subdirectory(ddscxx)


### PR DESCRIPTION
Skip idlcxx module building if crosscompiling. A native one should
be used in that case.

Signed-off-by: Matija Tudan <tudan.matija@gmail.com>