### PR TITLE
Add support for StatusMask | StatusMask

### DIFF
--- a/src/ddscxx/include/dds/core/status/State.hpp
+++ b/src/ddscxx/include/dds/core/status/State.hpp
@@ -208,6 +208,13 @@ public:
         return *this;
     }
 
+    inline StatusMask operator | (const dds::core::status::StatusMask& mask) const
+    {
+        auto res = StatusMask(*this);
+        res |= mask;
+        return res;
+    }
+
     /**
      * Get all StatusMasks
      *


### PR DESCRIPTION
Even though `StatusMask` inherits from `std::bitset`, if you attempt to do
`StatusMask|StatusMask` it complains because the resulting type is
a bitset, not a StatusMask. Also the expected operator supported for
a StatusMask should be OR not bitshift that accumulates.

    error: could not convert ‘std::operator|<32>(std::operator|<32>(std::operator|<32>(std::operator|<32>(dds::core::status::StatusMask::none(), dds::core::status::StatusMask::offered_deadline_missed()), dds::core::status::StatusMask::dds::core::status::StatusMask::liveliness_lost()), dds::core::status::StatusMask::publication_matched())’ from ‘std::bitset<32>’ to ‘dds::core::status::StatusMask’