### PR TITLE
Replace idl_unalias and update sertype ops

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -807,12 +807,11 @@ const ddsi_sertype_ops ddscxx_sertype<T>::ddscxx_sertype_ops = {
   sertype_free_samples<T>,
   sertype_equal<T>,
   sertype_hash<T>,
-  nullptr, // typeid_hash
-  nullptr, // serialized_size
-  nullptr, // serialize
-  nullptr, // deserialize
+  nullptr, // type_id
+  nullptr, // type_map
+  nullptr, // type_info
   nullptr, // assignable_from
-  nullptr, //derive_sertype sertype_default_derive_sertype?
+  nullptr, // derive_sertype
   sertype_get_serialized_size<T>,
   sertype_serialize_into<T>
 };

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -349,7 +349,7 @@ int get_cpp11_default_value(
 {
   struct generator *gen = user_data;
   const idl_enumerator_t *enumerator;
-  const idl_type_spec_t *unaliased = idl_unalias(node, 0u);
+  const idl_type_spec_t *unaliased = idl_strip(node, IDL_STRIP_ALIASES | IDL_STRIP_FORWARD);
   const char *value = NULL;
 
   if (idl_is_array(unaliased))
@@ -569,7 +569,7 @@ register_types(
   (void)revisit;
   (void)path;
 
-  type_spec = idl_unalias(idl_type_spec(node), 0);
+  type_spec = idl_strip(idl_type_spec(node), IDL_STRIP_ALIASES | IDL_STRIP_FORWARD);
   loc = idl_location(type_spec);
   assert(type_spec && loc);
   if (pstate->sources)
@@ -581,7 +581,7 @@ register_types(
   if (idl_is_array(node) || idl_is_array(type_spec))
     gen->uses_array = true;
 
-  type_spec = idl_unalias(idl_type_spec(node), IDL_UNALIAS_IGNORE_ARRAY);
+  type_spec = idl_strip(idl_type_spec(node), IDL_STRIP_ALIASES | IDL_STRIP_ALIASES_ARRAY | IDL_STRIP_FORWARD);
   loc = idl_location(type_spec);
   assert(type_spec && loc);
   /* do not include headers if required by types in includes */

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -861,7 +861,7 @@ process_inherit_spec(
 static const idl_declarator_t*
 resolve_member(const idl_struct_t *type_spec, const char *member_name)
 {
-  type_spec = idl_unalias(type_spec, 0u);
+  type_spec = idl_strip(type_spec, IDL_STRIP_ALIASES | IDL_STRIP_FORWARD);
 
   if (idl_is_struct(type_spec)) {
     const idl_struct_t *_struct = (const idl_struct_t *)type_spec;

--- a/src/idlcxx/src/types.c
+++ b/src/idlcxx/src/types.c
@@ -48,7 +48,7 @@ emit_member(
   name = get_cpp11_name(node);
   if (IDL_PRINTA(&type, get_cpp11_type, type_spec, gen) < 0)
     return IDL_RETCODE_NO_MEMORY;
-  type_spec = idl_unalias(type_spec, 0);
+  type_spec = idl_strip(type_spec, IDL_STRIP_ALIASES | IDL_STRIP_FORWARD);
   if (idl_is_array(type_spec))
     value = "{ }";
   else if (!idl_is_enum(type_spec) && !idl_is_base_type(type_spec))
@@ -95,7 +95,7 @@ emit_parameter(
   else
     type_spec = idl_type_spec(node);
 
-  simple = idl_mask(idl_unalias(type_spec, 0)) & (IDL_BASE_TYPE|IDL_ENUM);
+  simple = idl_mask(idl_strip(type_spec, IDL_STRIP_ALIASES | IDL_STRIP_FORWARD)) & (IDL_BASE_TYPE|IDL_ENUM);
   sep = is_first(node) ? "" : ",\n";
   fmt = simple ? "%s    %s %s"
                : "%s    const %s& %s";
@@ -158,7 +158,7 @@ emit_member_methods(
   if (IDL_PRINTA(&type, get_cpp11_type, type_spec, gen) < 0)
     return IDL_RETCODE_NO_MEMORY;
 
-  type_spec = idl_unalias(type_spec, 0);
+  type_spec = idl_strip(type_spec, IDL_STRIP_ALIASES | IDL_STRIP_FORWARD);
   if (idl_mask(type_spec) & (IDL_BASE_TYPE | IDL_ENUM))
     fmt = "  %1$s %2$s() const { return this->%2$s_; }\n"
           "  %1$s& %2$s() { return this->%2$s_; }\n"
@@ -646,7 +646,7 @@ emit_case_methods(
   if (IDL_PRINTA(&value, get_cpp11_value, branch->labels->const_expr, gen) < 0)
     return IDL_RETCODE_NO_MEMORY;
 
-  simple = (idl_mask(idl_unalias(branch->type_spec, 0)) & (IDL_BASE_TYPE|IDL_ENUM)) != 0;
+  simple = (idl_mask(idl_strip(branch->type_spec, IDL_STRIP_ALIASES | IDL_STRIP_FORWARD)) & (IDL_BASE_TYPE|IDL_ENUM)) != 0;
 
   /* const-getter */
   fmt = simple ? "  %1$s %2$s() const\n  {\n"


### PR DESCRIPTION
Replace `idl_unalias` by `idl_strip` ([Cyclone DDS #1068](https://github.com/eclipse-cyclonedds/cyclonedds/pull/1068)) and update sertype ops (XTypes implementation [Cyclone DDS #904](https://github.com/eclipse-cyclonedds/cyclonedds/pull/904))