### PR TITLE
Bump to 0.8.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 cmake_minimum_required(VERSION 3.7)
-project(CycloneDDS-CXX VERSION 0.8.1 LANGUAGES C CXX)
+project(CycloneDDS-CXX VERSION 0.8.2 LANGUAGES C CXX)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
 


### PR DESCRIPTION
To remain in sync with `cyclonedds` repository.