### PR TITLE
IDLC generator config and default extensibility

### DIFF
--- a/examples/helloworld/CMakeLists.txt
+++ b/examples/helloworld/CMakeLists.txt
@@ -16,7 +16,7 @@ if(NOT TARGET CycloneDDS-CXX::ddscxx)
   find_package(CycloneDDS-CXX REQUIRED)
 endif()
 
-idlcxx_generate(TARGET helloworlddata FILES HelloWorldData.idl)
+idlcxx_generate(TARGET helloworlddata FILES HelloWorldData.idl WARNINGS no-implicit-extensibility)
 
 add_executable(ddscxxHelloworldPublisher publisher.cpp)
 add_executable(ddscxxHelloworldSubscriber subscriber.cpp)

--- a/src/ddscxx/tests/CMakeLists.txt
+++ b/src/ddscxx/tests/CMakeLists.txt
@@ -11,7 +11,7 @@
 #
 find_package(GTest REQUIRED)
 
-idlcxx_generate(TARGET ddscxx_test_types FILES data/Space.idl data/HelloWorldData.idl data/Serialization.idl)
+idlcxx_generate(TARGET ddscxx_test_types FILES data/Space.idl data/HelloWorldData.idl data/Serialization.idl WARNINGS no-implicit-extensibility)
 
 configure_file(
   config_simple.xml.in config_simple.xml @ONLY)

--- a/src/idlcxx/Generate.cmake
+++ b/src/idlcxx/Generate.cmake
@@ -11,8 +11,8 @@
 #
 
 function(IDLCXX_GENERATE)
-  set(one_value_keywords TARGET)
-  set(multi_value_keywords FILES FEATURES INCLUDES)
+  set(one_value_keywords TARGET DEFAULT_EXTENSIBILITY)
+  set(multi_value_keywords FILES FEATURES INCLUDES WARNINGS)
   cmake_parse_arguments(
     IDLCXX "" "${one_value_keywords}" "${multi_value_keywords}" "" ${ARGN})
 
@@ -37,6 +37,8 @@ function(IDLCXX_GENERATE)
     FILES ${IDLCXX_FILES}
     FEATURES ${IDLCXX_FEATURES}
     INCLUDES ${IDLCXX_INCLUDES}
+    WARNINGS ${IDLCXX_WARNINGS}
+    DEFAULT_EXTENSIBILITY ${IDLC_DEFAULT_EXTENSIBILITY}
     SUFFIXES .hpp
     DEPENDS ${_idlcxx_depends}
   )

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -743,7 +743,7 @@ static const char *bnd_str_flags[] = { PRIu32, NULL };
 #if _WIN32
 __declspec(dllexport)
 #endif
-idl_retcode_t generate(const idl_pstate_t *pstate)
+idl_retcode_t generate(const idl_pstate_t *pstate, const idlc_generator_config_t *config)
 {
   idl_retcode_t ret = IDL_RETCODE_NO_MEMORY;
   char *dir = NULL, *basename = NULL, *empty = "";
@@ -754,6 +754,7 @@ idl_retcode_t generate(const idl_pstate_t *pstate)
   assert(pstate->paths->name);
   path = pstate->sources->path->name;
   assert(path);
+  (void) config;
 
   /* use relative directory if user provided a relative path, use current
      word directory otherwise */

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -349,7 +349,7 @@ write_constructed_type_streaming_functions(
   streams->keys++;
 
   if (idl_is_constr_type(type_spec) &&
-      !idl_is_keyless(type_spec, pstate->flags & IDL_FLAG_KEYLIST))
+      !idl_is_keyless(type_spec, pstate->config.flags & IDL_FLAG_KEYLIST))
   {
     fmt = "  key_%2$s(streamer, %1$s);\n";
     if (streams->swapped)
@@ -718,7 +718,7 @@ process_member(
 
   type_spec = ((const idl_member_t *)node)->type_spec;
   /* only use the @key annotations when you do not use the keylist */
-  if (!(pstate->flags & IDL_FLAG_KEYLIST) &&
+  if (!(pstate->config.flags & IDL_FLAG_KEYLIST) &&
       ((const idl_member_t *)node)->key.value)
     loc.type |= KEY_INSTANCE;
 
@@ -1063,7 +1063,7 @@ process_struct(
     bool keylist;
     const idl_struct_t *_struct = ((const idl_struct_t *)node);
 
-    keylist = (pstate->flags & IDL_FLAG_KEYLIST) && _struct->keylist;
+    keylist = (pstate->config.flags & IDL_FLAG_KEYLIST) && _struct->keylist;
 
     if (print_constructed_type_open(user_data, node))
       return IDL_RETCODE_NO_MEMORY;

--- a/src/idlcxx/src/traits.c
+++ b/src/idlcxx/src/traits.c
@@ -140,7 +140,7 @@ emit_traits(
         "};\n\n";
   if (IDL_PRINTA(&name, get_cpp11_fully_scoped_name, _struct, gen) < 0)
     return IDL_RETCODE_NO_MEMORY;
-  if (!idl_is_keyless(node, pstate->flags & IDL_FLAG_KEYLIST))
+  if (!idl_is_keyless(node, pstate->config.flags & IDL_FLAG_KEYLIST))
     keyless = "false";
   if (!sc_struct(_struct))
     selfcontained = "false";


### PR DESCRIPTION
In eclipse-cyclonedds/cyclonedds#989 a parameter is added to the IDLC `generate` function signature, and the configuration in `pstate` is moved to `.config`. This PR adds the parameter to the c++ generator function and updates the accessors for flags in pstate, and it adds the default-extensibility and (no-)warning option to the `idlcxx_generate` cmake function. 