### PR TITLE
examples: fix build error when cross compiling examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+gen
+gen.*
+.cproject
+.project
+.settings/
+.vs/
+.vscode/
+build/

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,6 +11,8 @@
 #
 set(CMAKE_INSTALL_EXAMPLESDIR "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/examples")
 
+include("${CMAKE_SOURCE_DIR}/src/idlcxx/Generate.cmake")
+
 install(
   FILES helloworld/publisher.cpp
         helloworld/subscriber.cpp

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,6 +11,9 @@
 #
 set(CMAKE_INSTALL_EXAMPLESDIR "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/examples")
 
+# this is a work-around for cross-builds failing with:
+#   CMake Error at examples/helloworld/CMakeLists.txt:19 (idlcxx_generate):
+#   Unknown CMake command "idlcxx_generate".
 include("${CMAKE_SOURCE_DIR}/src/idlcxx/Generate.cmake")
 
 install(


### PR DESCRIPTION
This commit fixes build error when trying to cross compile helloworld example:
 -- Detecting CXX compiler ABI info
 -- Detecting CXX compiler ABI info - done
 -- Detecting CXX compile features
 -- Detecting CXX compile features - done
 -- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
 -- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
 -- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
 -- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
 -- Performing Test COMPILER_HAS_DEPRECATED_ATTR
 -- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
 CMake Error at examples/helloworld/CMakeLists.txt:19 (idlcxx_generate):
   Unknown CMake command "idlcxx_generate".

Signed-off-by: Matija Tudan <tudan.matija@gmail.com>