### PR TITLE
C++ serdata hash: mix in serdata_basehash

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright(c) 2022 ZettaScale Technology and others
  * Copyright(c) 2020 ADLINK Technology Limited and others
  *
  * This program and the accompanying materials are made available under the
@@ -433,6 +434,7 @@ void ddscxx_serdata<T>::populate_hash()
     memcpy(&(hash), key().value, 4);
   }
 
+  hash ^= type->serdata_basehash;
   hash_populated = true;
 }
 


### PR DESCRIPTION
Each type gets its own specialised functions, and consequently the tkmap
hash table (in the core) will never consider two samples of different
types as equal.

The serdata hash is currently computed as the MD5 hash of the key value,
and so without mixing in "serdata_basehash" all samples with the same
key value end up with the same hash despite not comparing as equal.  In
other words, if there are many topics there are many hash collisions.
The "hopscotch" hash table used by tkmap blows up if it is fed too many
collisions.

Mixing in "serdata_basehash" addresses that problem.

Fixes #201 

Signed-off-by: Erik Boasson <eb@ilities.com>