### PR TITLE
Add external field handling

### DIFF
--- a/src/ddscxx/include/dds/core/External.hpp
+++ b/src/ddscxx/include/dds/core/External.hpp
@@ -1,0 +1,114 @@
+#ifndef OMG_DDS_CORE_EXTERNAL_HPP_
+#define OMG_DDS_CORE_EXTERNAL_HPP_
+
+/*
+ * Copyright(c) 2022 ZettaScale Technology and others
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <memory>
+#include <dds/core/Exception.hpp>
+
+namespace dds
+{
+namespace core
+{
+
+template <typename T>
+class external {
+  public:
+    external() = default;
+    external(T* p, bool locked = false): ptr_(p), locked_(locked) {;}
+    external(std::shared_ptr<T> p): ptr_(p) {;}
+    external(const external& other);
+    ~external() = default;
+    external& operator=(const external& other);
+    T& operator*();
+    const T& operator*() const;
+    T* get() {return ptr_.get();}
+    const T* get() const {return ptr_.get();}
+    std::shared_ptr<T> get_shared_ptr() {return ptr_;}
+    T* operator->() {return get();}
+    const T* operator->() const {return get();}
+    bool operator==(const external<T>& other) const {return other.ptr_ == ptr_;}
+    bool operator!=(const external<T>& other) const {return !(*this == other);}
+    operator bool() const {return static_cast<bool>(ptr_);}
+    bool is_locked() const {return locked_;}
+    void lock();
+  private:
+    std::shared_ptr<T> ptr_;
+    bool locked_ = false;
+};
+
+template <typename T>
+external<T>::external(const external<T>& other)
+{
+  if (other.is_locked())
+    ptr_ = std::make_shared<T>(*other);  //if other is locked, this implies that it can be dereferenced, and deep copy
+  else
+    ptr_ = other.ptr_;  //unlocked means shallow copy
+}
+
+template <typename T>
+external<T>& external<T>::operator=(const external<T>& other)
+{
+  if (is_locked())
+    throw InvalidDataError("attempting to assign to locked external field");  //assignments to locked externals are not allowed
+
+  if (other.is_locked()) {
+    if (ptr_)
+      *ptr_ = *other;  //copy over existing object
+    else
+      ptr_ = std::make_shared<T>(*other); //deep copy into new object
+  } else {
+    ptr_ = other.ptr_;  //shallow copy
+  }
+
+  return *this;
+}
+
+template <typename T>
+T& external<T>::operator*()
+{
+  auto p = get();
+  if (!p)
+    throw NullReferenceError("attempting to dereference unset external field");  //dereferencing unset externals is not allowed
+
+  return *p;
+}
+
+template <typename T>
+const T& external<T>::operator*() const
+{
+  auto p = get();
+  if (!p)
+    throw NullReferenceError("attempting to dereference unset external field");  //dereferencing unset externals is not allowed
+
+  return *p;
+}
+
+template <typename T>
+void external<T>::lock()
+{
+  if (!*this)
+    throw NullReferenceError("attempting to lock unset external field");  //locking unbound externals is not allowed
+
+  locked_ = true;
+}
+
+}
+}
+
+#endif /* !defined(OMG_DDS_CORE_EXTERNAL_HPP_) */

--- a/src/ddscxx/tests/CMakeLists.txt
+++ b/src/ddscxx/tests/CMakeLists.txt
@@ -61,7 +61,8 @@ set(sources
   CDRStreamer.cpp
   GeneratedEntities.cpp
   ExtendedTypes.cpp
-  Regression.cpp)
+  Regression.cpp
+  External.cpp)
 
 if(ENABLE_SHM)
   # Add shared memory tests

--- a/src/ddscxx/tests/CMakeLists.txt
+++ b/src/ddscxx/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ idlcxx_generate(TARGET ddscxx_test_types FILES
   data/EntityProperties_pragma.idl
   data/ExtendedTypesModels.idl
   data/RegressionModels.idl
+  data/ExternalModels.idl
   WARNINGS no-implicit-extensibility)
 
 configure_file(

--- a/src/ddscxx/tests/External.cpp
+++ b/src/ddscxx/tests/External.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright(c) 2022 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include "dds/dds.hpp"
+#include <dds/core/External.hpp>
+
+#include <gtest/gtest.h>
+
+using dds::core::external;
+
+TEST(External, constructing)
+{
+  external<int> ei1;
+  EXPECT_EQ(ei1.get(), nullptr);
+  EXPECT_FALSE(ei1);
+  EXPECT_FALSE(ei1.is_locked());
+
+  external<int> ei2(new int(123), true);
+  EXPECT_NE(ei2.get(), nullptr);
+  EXPECT_TRUE(ei2);
+  EXPECT_TRUE(ei2.is_locked());
+  EXPECT_EQ(*ei2, 123);
+
+  external<int> ei3(std::make_shared<int>(456));
+  EXPECT_NE(ei3.get(),nullptr);
+  EXPECT_TRUE(ei3);
+  EXPECT_FALSE(ei3.is_locked());
+  EXPECT_EQ(*ei3, 456);
+}
+
+TEST(External, assigning)
+{
+  external<int> ei1, ei2(new int(123), true), ei3;
+
+  ASSERT_NO_THROW(ei1 = ei2;);  //deep copy of ei2
+
+  EXPECT_NE(ei1.get(),nullptr);
+  EXPECT_FALSE(ei1.is_locked());
+  EXPECT_EQ(*ei1, *ei2);
+  EXPECT_NE(ei1, ei2);
+
+  ASSERT_NO_THROW(ei3 = ei1;);  //shallow copy of ei1
+  EXPECT_EQ(ei1, ei3);
+
+  EXPECT_THROW(ei2 = ei1;, dds::core::InvalidDataError);
+}
+
+TEST(External, accessing)
+{
+  external<int> ei1;
+
+  EXPECT_EQ(ei1.get(), nullptr);
+  EXPECT_EQ(ei1.get_shared_ptr(), nullptr);
+  EXPECT_EQ(ei1.operator->(), nullptr);
+  EXPECT_THROW(*ei1 = 123;, dds::core::NullReferenceError);
+
+  ei1 = new int(456);
+
+  EXPECT_NE(ei1.get(), nullptr);
+  EXPECT_NE(ei1.get_shared_ptr(), nullptr);
+  EXPECT_NE(ei1.operator->(), nullptr);
+  EXPECT_EQ(*ei1, 456);
+  EXPECT_NO_THROW(*ei1 = 567;);
+  EXPECT_EQ(*ei1, 567);
+}
+
+TEST(External, locking)
+{
+  external<int> ei1;
+
+  EXPECT_FALSE(ei1.is_locked());
+
+  EXPECT_THROW(ei1.lock();, dds::core::NullReferenceError);
+
+  ei1 = new int(123);
+
+  EXPECT_NO_THROW(ei1.lock(););
+
+  EXPECT_TRUE(ei1.is_locked());
+}

--- a/src/ddscxx/tests/data/ExternalModels.idl
+++ b/src/ddscxx/tests/data/ExternalModels.idl
@@ -1,0 +1,11 @@
+module external_testing {
+
+  @topic struct external_struct {
+
+    @external long external_long;
+    @external string external_string;
+    @external sequence<double> external_sequence_double;
+
+  };
+
+};

--- a/src/idlcxx/src/generator.h
+++ b/src/idlcxx/src/generator.h
@@ -29,6 +29,8 @@ struct generator {
   const char *bounded_string_include;
   char *optional_format;
   const char *optional_include;
+  char *external_format;
+  const char *external_include;
   char *union_format;
   char *union_getter_format;
   const char *union_include;
@@ -40,6 +42,7 @@ struct generator {
   bool uses_bounded_string;
   bool uses_union;
   bool uses_optional;
+  bool uses_external;
   struct {
     FILE *handle;
     char *path;
@@ -69,6 +72,9 @@ int get_cpp11_value(
   char *str, size_t size, const void *node, void *user_data);
 
 bool is_optional(
+  const void *node);
+
+bool is_external(
   const void *node);
 
 bool must_understand(


### PR DESCRIPTION
According to XTypes v1.3 7.5.1.2.3.3 added the dds::core::external
template class
Added unittests to test dds::core::external functionality
Added parsing of @external fields in generated C++ code

Signed-off-by: Martijn Reicher <martijn.reicher@zettascale.tech>