### PR TITLE
Add skipping hashing of keyless topics

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -63,10 +63,12 @@ bool to_key(const T& tokey, ddsi_keyhash_t& hash)
   if (!move(str, tokey, true))
     return false;
   size_t sz = str.position();
-  size_t padding = 16 - sz % 16;
-  if (sz != 0 && padding == 16) padding = 0;
+  size_t padding = 0;
+  if (sz < 16)
+    padding = (16 - sz % 16)%16;
   std::vector<unsigned char> buffer(sz + padding);
-  memset(buffer.data() + sz, 0x0, padding);
+  if (padding)
+    memset(buffer.data() + sz, 0x0, padding);
   str.set_buffer(buffer.data(), sz);
   if (!write(str, tokey, true))
     return false;

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -49,7 +49,14 @@ using org::eclipse::cyclonedds::core::cdr::extensibility;
 using org::eclipse::cyclonedds::core::cdr::encoding_version;
 using org::eclipse::cyclonedds::topic::TopicTraits;
 
-template<typename T>
+template<typename T, std::enable_if_t<TopicTraits<T>::isKeyless(), bool> = true >
+bool to_key(const T&, ddsi_keyhash_t& hash)
+{
+  memset(&(hash.value), 0x0, sizeof(hash.value));
+  return true;  //return true here, as all instances have the same hash value, and hashing is pointless
+}
+
+template<typename T, std::enable_if_t<!TopicTraits<T>::isKeyless(), bool> = true >
 bool to_key(const T& tokey, ddsi_keyhash_t& hash)
 {
   basic_cdr_stream str(endianness::big_endian);

--- a/src/ddscxx/tests/data/Serialization.idl
+++ b/src/ddscxx/tests/data/Serialization.idl
@@ -73,3 +73,12 @@ module Endianness
     U u;
   };
 };
+
+module Keyhash
+{
+  struct NoKey      { unsigned long x; };
+  struct SmallKey   { @key unsigned long k; unsigned long x; };
+  struct LargeKey   { @key unsigned long a[5]; unsigned long x; };
+  struct StringKey  { @key string s; unsigned long x; };
+  struct BStringKey { @key string<11> s; unsigned long x; };
+};


### PR DESCRIPTION
As keyless topics have the same key value each time, "calculating"
it can be short-circuited significantly

Signed-off-by: Martijn Reicher <martijn.reicher@zettascale.tech>