### PR TITLE
Variant duplicate types fix

### DIFF
--- a/src/ddscxx/tests/Regression.cpp
+++ b/src/ddscxx/tests/Regression.cpp
@@ -201,3 +201,8 @@ TEST_F(Regression, propagate_xtypes_version_reqs)
   ASSERT_EQ(TopicTraits<td_3>::getExtensibility(), extensibility::ext_final);
   ASSERT_EQ(TopicTraits<td_3>::minXCDRVersion(), encoding_version::xcdr_v2);
 }
+
+TEST_F(Regression, union_duplicate_types)
+{
+  duplicate_types_union d_t;
+}

--- a/src/ddscxx/tests/data/RegressionModels.idl
+++ b/src/ddscxx/tests/data/RegressionModels.idl
@@ -51,4 +51,17 @@ typedef sequence<td_1> td_2;
   td_2 c;
 };
 
+typedef double td_d;
+
+union duplicate_types_union switch(long) {
+  case 1:
+    long l_1;
+  case 2:
+    td_l l_2;
+  case 3:
+    double d_1;
+  case 4:
+    td_d d_2;
+};
+
 };

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -333,7 +333,13 @@ int get_cpp11_name_typedef(
 int get_cpp11_type(
   char *str, size_t size, const void *node, void *user_data)
 {
-  if (idl_is_base_type(node))
+  if (idl_is_case(node)) {
+    const idl_case_t *_case = node;
+    if (idl_is_array(_case->declarator))
+      return get_cpp11_array_type(str, size, _case->declarator, user_data);
+    else
+      return get_cpp11_type(str, size, _case->type_spec, user_data);
+  } else if (idl_is_base_type(node))
     return get_cpp11_base_type(str, size, node, user_data);
   else if (idl_is_templ_type(node))
     return get_cpp11_templ_type(str, size, node, user_data);

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -961,7 +961,7 @@ process_case(
 
     char *accessor = NULL, *type = NULL, *value = NULL;
     if (IDL_PRINTA(&accessor, get_instance_accessor, _case->declarator, &loc) < 0 ||
-        IDL_PRINTA(&type, get_cpp11_type, _case->type_spec, streams->generator) < 0 ||
+        IDL_PRINTA(&type, get_cpp11_type, _case, streams->generator) < 0 ||
         (simple && IDL_PRINTA(&value, get_cpp11_default_value, _case->type_spec, streams->generator) < 0))
       return IDL_RETCODE_NO_MEMORY;
 

--- a/src/idlcxx/src/types.c
+++ b/src/idlcxx/src/types.c
@@ -630,7 +630,7 @@ emit_case_methods(
     "  }\n\n";
 
   name = get_cpp11_name(branch->declarator);
-  if (IDL_PRINTA(&type, get_cpp11_type, branch->type_spec, gen) < 0)
+  if (IDL_PRINTA(&type, get_cpp11_type, branch, gen) < 0)
     return IDL_RETCODE_NO_MEMORY;
   if (IDL_PRINTA(&discr_type, get_cpp11_type, _union->switch_type_spec->type_spec, gen) < 0)
     return IDL_RETCODE_NO_MEMORY;
@@ -849,7 +849,7 @@ emit_union(
 #pragma warning( push )
 #pragma warning( disable : 6263 )
 #endif
-    if (IDL_PRINTA(&variant_type, get_cpp11_type, cases[j]->type_spec, gen) < 0)
+    if (IDL_PRINTA(&variant_type, get_cpp11_type, cases[j], gen) < 0)
       ret = IDL_RETCODE_NO_MEMORY;
 #ifdef _WIN32
 #pragma warning ( pop )
@@ -900,7 +900,7 @@ cleanup:
     /* default case is present */
     const idl_case_t* default_case = idl_parent(_union->default_case);
     char *default_type = NULL;
-    if (IDL_PRINTA(&default_type, get_cpp11_type, default_case->type_spec, gen) < 0)
+    if (IDL_PRINTA(&default_type, get_cpp11_type, default_case, gen) < 0)
       return IDL_RETCODE_NO_MEMORY;
 
     /* add default constructor for type of default branch */


### PR DESCRIPTION
Added checking that the types supplied to the union container template class do not contain duplicates as std::variant can not handle this.

This fixes #127.