### PR TITLE
Array fixes

### DIFF
--- a/src/ddscxx/tests/Regression.cpp
+++ b/src/ddscxx/tests/Regression.cpp
@@ -204,6 +204,8 @@ TEST_F(Regression, union_duplicate_types)
 {
   duplicate_types_union d_t;
   d_t.l_1(456789);
+  duplicate_types_union_2 d_t_2;
+  d_t_2.b_1({1,2,3,4,5});
   duplicate_sequences_union d_s;
   d_s.c_1({1,2,3,4,5,6});
 }
@@ -220,4 +222,25 @@ TEST_F(Regression, delimiters_bitmask)
   s.c({b_0 | b_1, b_1 | b_2, b_2 | b_0});
 
   readwrite_test(s, s_bm1_bytes, xcdr_v2_stream(endianness::little_endian));
+}
+
+TEST_F(Regression, arrays_in_union_case)
+{
+  W w_a, w_b;
+
+  w_a.c({'c', 'd'});
+  std::array<std::array<char,3>,2> arr = {std::array<char,3>({'j', 'i', 'h'}),std::array<char,3>({'g', 'f', 'e'})};
+  w_b.d(arr);
+
+  bytes w_a_bytes =
+    {'a',           /*W::discriminator*/
+     'c','d'},      /*W::c*/
+        w_b_bytes =
+    {'b',           /*W::discriminator*/
+     'j', 'i', 'h', /*W::d[0]*/
+     'g', 'f', 'e'  /*W::d[1]*/
+    };
+
+  readwrite_test(w_a, w_a_bytes, xcdr_v2_stream(endianness::little_endian));
+  readwrite_test(w_b, w_b_bytes, xcdr_v2_stream(endianness::little_endian));
 }

--- a/src/ddscxx/tests/data/RegressionModels.idl
+++ b/src/ddscxx/tests/data/RegressionModels.idl
@@ -70,6 +70,33 @@ union duplicate_types_union switch(long) {
     td_d d_2;  //should be the same as d_1;
 };
 
+union W switch(char) {
+  case 'a':
+    char c[2];
+  case 'b':
+    char d[2][3];
+};
+
+typedef long long_array_5[5];
+typedef long long_array_7[7];
+typedef long long_array_2[2];
+typedef long_array_2 long_array_6[3];
+
+union duplicate_types_union_2 switch(long) {
+  case 1:
+    long b_1[5];
+  case 2:
+    long_array_5 b_2;  //should be the same type as branch b_1
+  case 3:
+    long_array_7 b_3;  //should be different type than b_2
+  case 4:
+    long b_4[2][3];
+  case 5:
+    long_array_2 b_5[3];  //should be the same type as branch b_4
+  case 6:
+    long_array_6 b_6;  //should be the same type as branch b_5
+};
+
 /*this model is to check whether is_same_type sees "through" sequences correctly*/
 typedef unsigned long ulong_arr[4];
 typedef sequence<ulong_arr> seq_ulong_arr;

--- a/src/ddscxx/tests/data/RegressionModels.idl
+++ b/src/ddscxx/tests/data/RegressionModels.idl
@@ -95,6 +95,8 @@ union duplicate_types_union_2 switch(long) {
     long_array_2 b_5[3];  //should be the same type as branch b_4
   case 6:
     long_array_6 b_6;  //should be the same type as branch b_5
+  case 7:
+    long b_7;  //should be different from all above types
 };
 
 /*this model is to check whether is_same_type sees "through" sequences correctly*/

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -336,7 +336,7 @@ int get_cpp11_type(
   if (idl_is_case(node)) {
     const idl_case_t *_case = node;
     if (idl_is_array(_case->declarator))
-      return get_cpp11_array_type(str, size, _case->declarator, user_data);
+      return get_cpp11_type(str, size, _case->declarator, user_data);
     else
       return get_cpp11_type(str, size, _case->type_spec, user_data);
   } else if (idl_is_base_type(node))

--- a/src/idlcxx/src/types.c
+++ b/src/idlcxx/src/types.c
@@ -781,9 +781,6 @@ static idl_retcode_t is_same_type(
       if (j >= i || a_sz[j++] != ((const idl_literal_t*)ce)->value.uint32)
         return IDL_RETCODE_OK;
     }
-  } else {
-    if (i)
-      return IDL_RETCODE_OK;
   }
 
   while (idl_is_alias(type_b) || idl_is_forward(type_b)) {
@@ -799,6 +796,10 @@ static idl_retcode_t is_same_type(
       }
     }
   }
+
+  /* check that we compared the same number of array sizes */
+  if (i != j)
+    return IDL_RETCODE_OK;
 
   /* unalias bitmasks to underlying integer types */
   idl_type_t t_a = idl_is_bitmask(type_a) ? unalias_bitmask(type_a) : idl_type(type_a),


### PR DESCRIPTION
A number of fixes related to array handling:
- added batch copying of primitive types in arrays which should improve performance
- fixed union cases not taking array declarators into account
- added unittests to check these additions