### PR TITLE
Add support for default parameters in constructors

### DIFF
--- a/src/ddscxx/tests/CMakeLists.txt
+++ b/src/ddscxx/tests/CMakeLists.txt
@@ -64,7 +64,8 @@ set(sources
   GeneratedEntities.cpp
   ExtendedTypes.cpp
   Regression.cpp
-  External.cpp)
+  External.cpp
+  DataModels.cpp)
 
 if(ENABLE_SHM)
   # Add shared memory tests

--- a/src/ddscxx/tests/DataModels.cpp
+++ b/src/ddscxx/tests/DataModels.cpp
@@ -29,8 +29,7 @@ public:
 /*testing implicit defaults of structs*/
 TEST_F(DataModels, implicit_defaults)
 {
-  using DataModels_testing::implicit_defaults_struct;
-  using DataModels_testing::test_enum;
+  using namespace DataModels_testing;
 
   implicit_defaults_struct ds;
 
@@ -39,12 +38,13 @@ TEST_F(DataModels, implicit_defaults)
   EXPECT_EQ(ds.c(), '\0');
   EXPECT_EQ(ds.s(), "");
   EXPECT_EQ(ds.e(), test_enum::e_0);
+  EXPECT_EQ(ds.b(), 0);
 }
 
 /*testing explicit defaults of structs*/
 TEST_F(DataModels, explicit_defaults)
 {
-  using DataModels_testing::explicit_defaults_struct;
+  using namespace DataModels_testing;
 
   explicit_defaults_struct ds;
 
@@ -56,4 +56,6 @@ TEST_F(DataModels, explicit_defaults)
   this test will fail until we support enum values as annotation parameters
   EXPECT_EQ(ds.e(), test_enum::e_1);
   */
+  EXPECT_EQ(ds.b(), 5);
+  EXPECT_EQ(ds.b(), f_0|f_2);
 }

--- a/src/ddscxx/tests/DataModels.cpp
+++ b/src/ddscxx/tests/DataModels.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright(c) 2022 ZettaScale Technologies
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include "dds/dds.hpp"
+#include <gtest/gtest.h>
+#include "CdrDataModels.hpp"
+
+/**
+ * Fixture for the DataModels tests
+ */
+class DataModels : public ::testing::Test
+{
+public:
+    DataModels() { }
+
+    void SetUp() { }
+
+    void TearDown() { }
+};
+
+/*testing implicit defaults of structs*/
+TEST_F(DataModels, implicit_defaults)
+{
+  using DataModels_testing::implicit_defaults_struct;
+  using DataModels_testing::test_enum;
+
+  implicit_defaults_struct ds;
+
+  EXPECT_EQ(ds.l(), 0);
+  EXPECT_EQ(ds.d(), 0);
+  EXPECT_EQ(ds.c(), '\0');
+  EXPECT_EQ(ds.s(), "");
+  EXPECT_EQ(ds.e(), test_enum::e_0);
+}
+
+/*testing explicit defaults of structs*/
+TEST_F(DataModels, explicit_defaults)
+{
+  using DataModels_testing::explicit_defaults_struct;
+
+  explicit_defaults_struct ds;
+
+  EXPECT_EQ(ds.l(), 123);
+  EXPECT_EQ(ds.d(), .456);
+  EXPECT_EQ(ds.c(), 'a');
+  EXPECT_EQ(ds.s(), "def");
+  /*
+  this test will fail until we support enum values as annotation parameters
+  EXPECT_EQ(ds.e(), test_enum::e_1);
+  */
+}

--- a/src/ddscxx/tests/data/CdrDataModels.idl
+++ b/src/ddscxx/tests/data/CdrDataModels.idl
@@ -217,6 +217,12 @@ module DataModels_testing {
     e_2
   };
 
+  bitmask test_bitmask {
+    f_0,
+    f_1,
+    f_2
+  };
+
   struct explicit_defaults_struct {
     @default(123) long l;
     @default(.456) double d;
@@ -226,6 +232,7 @@ module DataModels_testing {
     the idl parser does not yet support enumerator values as annotation parameters
     @default(e_0) test_enum e;
     */
+    @default(5) test_bitmask b; /*currently you need to set the bitmask defaults as integers*/
   };
 
   struct implicit_defaults_struct {
@@ -234,6 +241,7 @@ module DataModels_testing {
     char c;
     string s;
     test_enum e;
+    test_bitmask b;
   };
 
 };

--- a/src/ddscxx/tests/data/CdrDataModels.idl
+++ b/src/ddscxx/tests/data/CdrDataModels.idl
@@ -208,3 +208,32 @@ module CDR_testing {
   };
 
 };
+
+module DataModels_testing {
+
+  enum test_enum {
+    e_0,
+    e_1,
+    e_2
+  };
+
+  struct explicit_defaults_struct {
+    @default(123) long l;
+    @default(.456) double d;
+    @default('a') char c;
+    @default("def") string s;
+    /*
+    the idl parser does not yet support enumerator values as annotation parameters
+    @default(e_0) test_enum e;
+    */
+  };
+
+  struct implicit_defaults_struct {
+    long l;
+    double d;
+    char c;
+    string s;
+    test_enum e;
+  };
+
+};

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -434,6 +434,7 @@ int get_cpp11_base_type_const_value(
       return idl_snprintf(str, size, "%" PRId64, literal->value.int64);
     case IDL_UINT64:
     case IDL_ULLONG:
+    case IDL_BITMASK:
       return idl_snprintf(str, size, "%" PRIu64, literal->value.uint64);
     case IDL_FLOAT:
       return idl_snprintf(str, size, "%.6f", literal->value.flt);
@@ -469,7 +470,7 @@ static int get_cpp11_templ_type_const_value(
 int get_cpp11_value(
   char *str, size_t size, const void *node, void *user_data)
 {
-  if (idl_type(node) & IDL_BASE_TYPE)
+  if (idl_type(node) & (IDL_BASE_TYPE | IDL_BITMASK))
     return get_cpp11_base_type_const_value(str, size, node, user_data);
   if (idl_type(node) & IDL_TEMPL_TYPE)
     return get_cpp11_templ_type_const_value(str, size, node, user_data);

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -403,7 +403,7 @@ int get_cpp11_default_value(
   return idl_snprintf(str, size, "%s", value);
 }
 
-static int get_cpp11_base_type_const_value(
+int get_cpp11_base_type_const_value(
   char *str, size_t size, const void *node, void *user_data)
 {
   const idl_literal_t *literal = node;

--- a/src/idlcxx/src/generator.h
+++ b/src/idlcxx/src/generator.h
@@ -65,6 +65,9 @@ int get_cpp11_fully_scoped_name(
 int get_cpp11_name_typedef(
   char *str, size_t size, const void *node, void *user_data);
 
+int get_cpp11_base_type_const_value(
+  char *str, size_t size, const void *node, void *user_data);
+
 int get_cpp11_default_value(
   char *str, size_t size, const void *node, void *user_data);
 

--- a/src/idlcxx/src/types.c
+++ b/src/idlcxx/src/types.c
@@ -62,10 +62,10 @@ emit_member(
     value = "{ }";
   } else if (idl_is_enum(type_spec) || idl_is_base_type(type_spec) || idl_is_string(type_spec) || idl_is_bitmask(type_spec)) {
     if (mem->value.annotation) {
-      if ((idl_is_base_type(type_spec) || idl_is_string(type_spec)) && IDL_PRINTA(&value, get_cpp11_value, mem->value.value, gen) < 0)
+      if ((idl_is_base_type(type_spec) || idl_is_string(type_spec) || idl_is_bitmask(type_spec)) && IDL_PRINTA(&value, get_cpp11_value, mem->value.value, gen) < 0)
         return IDL_RETCODE_NO_MEMORY;
-      else if (idl_is_enum(type_spec) || idl_is_bitmask(type_spec))
-        return IDL_RETCODE_UNSUPPORTED;  //implement writing enum/bitmask value
+      else if (idl_is_enum(type_spec))
+        return IDL_RETCODE_UNSUPPORTED;  //implement writing enum value
     } else if (!idl_is_string(type_spec) && IDL_PRINTA(&value, get_cpp11_default_value, type_spec, gen) < 0) {
       return IDL_RETCODE_NO_MEMORY;
     }


### PR DESCRIPTION
Allows setting of default values in constructed types through the
@default annotation
At this point this only supports primitive non-enum types and strings
due to limitations in the idl parser
Add unittests to check whether this works as intended

Signed-off-by: Martijn Reicher <martijn.reicher@zettascale.tech>