### PR TITLE
Fix for arrays of unions/structs in union cases

### DIFF
--- a/src/ddscxx/tests/Regression.cpp
+++ b/src/ddscxx/tests/Regression.cpp
@@ -287,6 +287,11 @@ TEST_F(Regression, direct_typedef_of_primitive)
   readwrite_test(s, s_td_bool_seq_arr_bytes, basic_cdr_stream(endianness::little_endian));
 }
 
+TEST_F(Regression, union_array_case)
+{
+  s_u_struct_arr z;
+}
+
 TEST_F(Regression, direct_typedef_of_struct)
 {
   u_s_inner u;

--- a/src/ddscxx/tests/data/RegressionModels.idl
+++ b/src/ddscxx/tests/data/RegressionModels.idl
@@ -159,4 +159,11 @@ typedef sequence<e1, 3> seq_e1;
   @optional seq_e1 c;
 };
 
+union u_struct_arr switch (unsigned long) {
+  case 0: s_inner c_1[1];
+};
+@appendable @topic struct s_u_struct_arr {
+  u_struct_arr c;
+};
+
 };

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -860,7 +860,7 @@ process_case(
 
   bool single = (idl_degree(_case->labels) == 1) && !(idl_mask(_case->labels) == IDL_DEFAULT_CASE_LABEL),
        simple = (idl_is_base_type(_case->type_spec) || idl_is_bitmask(_case->type_spec)) && !idl_is_array(_case->declarator),
-       constructed_type = idl_is_constr_type(_case->type_spec) && !idl_is_enum(_case->type_spec) && !idl_is_array(_case->declarator) && !idl_is_bitmask(_case->type_spec);
+       constructed_type = idl_is_constr_type(_case->type_spec) && !idl_is_enum(_case->type_spec) && !idl_is_bitmask(_case->type_spec);
   instance_location_t loc = { .parent = "instance", .type = UNION_BRANCH };
 
   static const char *max_start =
@@ -915,7 +915,7 @@ process_case(
     if (multi_putf(streams, READ, check_props))
       return IDL_RETCODE_NO_MEMORY;
 
-    if (multi_putf(streams, (WRITE | MOVE), "      break; }\n")
+    if (multi_putf(streams, (WRITE | MOVE), "      }\n      break;\n")
      || putf(&streams->read, read_end, name)
      || putf(&streams->max, max_end))
       return IDL_RETCODE_NO_MEMORY;


### PR DESCRIPTION
Arrays of unions/structs in union cases, did not retrieve the entity
properties for the streaming function, resulting in a failure to
compile

Signed-off-by: Martijn Reicher <martijn.reicher@zettascale.tech>