### PR TITLE
Fix array include statement not being generated correctly (issue #233)

### DIFF
--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -734,6 +734,9 @@ register_types(
   (void)revisit;
   (void)path;
 
+  if (idl_is_array(node))
+    gen->uses_array = true;
+
   type_spec = idl_strip(idl_type_spec(node), IDL_STRIP_ALIASES | IDL_STRIP_FORWARD);
   loc = idl_location(type_spec);
   assert(type_spec && loc);
@@ -743,7 +746,7 @@ register_types(
   if (src && strcmp(loc->first.source->path->name, src) != 0)
     return IDL_VISIT_DONT_RECURSE;
 
-  if (idl_is_array(node) || idl_is_array(type_spec))
+  if (idl_is_array(type_spec))
     gen->uses_array = true;
 
   type_spec = idl_strip(idl_type_spec(node), IDL_STRIP_ALIASES | IDL_STRIP_ALIASES_ARRAY | IDL_STRIP_FORWARD);


### PR DESCRIPTION
The check on whether or not to include the array statement was not
being done, because this check was being skipped if the type the
array was on was from included from outside the current file
By doing the array check on the declarator before the type check
the array include is now being done correctly

Signed-off-by: Martijn Reicher <martijn.reicher@zettascale.tech>