### PR TITLE
Add enumerator defaults to struct constructors

### DIFF
--- a/src/ddscxx/tests/DataModels.cpp
+++ b/src/ddscxx/tests/DataModels.cpp
@@ -37,7 +37,7 @@ TEST_F(DataModels, implicit_defaults)
   EXPECT_EQ(ds.d(), 0);
   EXPECT_EQ(ds.c(), '\0');
   EXPECT_EQ(ds.s(), "");
-  EXPECT_EQ(ds.e(), test_enum::e_0);
+  EXPECT_EQ(ds.e(), test_enum::e_2);
   EXPECT_EQ(ds.b(), 0);
 }
 

--- a/src/ddscxx/tests/data/CdrDataModels.idl
+++ b/src/ddscxx/tests/data/CdrDataModels.idl
@@ -214,7 +214,7 @@ module DataModels_testing {
   enum test_enum {
     e_0,
     e_1,
-    e_2
+    @default_literal e_2
   };
 
   bitmask test_bitmask {
@@ -230,7 +230,7 @@ module DataModels_testing {
     @default("def") string s;
     /*
     the idl parser does not yet support enumerator values as annotation parameters
-    @default(e_0) test_enum e;
+    @default(e_1) test_enum e;
     */
     @default(5) test_bitmask b; /*currently you need to set the bitmask defaults as integers*/
   };

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -354,6 +354,7 @@ int get_cpp11_default_value(
 {
   struct generator *gen = user_data;
   const idl_enumerator_t *enumerator;
+  const idl_enum_t *e;
   const idl_type_spec_t *unaliased = idl_strip(node, IDL_STRIP_ALIASES | IDL_STRIP_FORWARD);
   const char *value = NULL;
 
@@ -362,7 +363,8 @@ int get_cpp11_default_value(
 
   switch (idl_type(unaliased)) {
     case IDL_ENUM:
-      enumerator = ((const idl_enum_t *)unaliased)->enumerators;
+      e = ((const idl_enum_t *)unaliased);
+      enumerator = e->default_enumerator ? e->default_enumerator : e->enumerators;
       return get_cpp11_fully_scoped_name(str, size, enumerator, gen);
     case IDL_BOOL:
       value = "false";

--- a/src/idlcxx/src/types.c
+++ b/src/idlcxx/src/types.c
@@ -366,9 +366,6 @@ emit_enum(
   (void)revisit;
   (void)path;
 
-  if (_enum->default_enumerator && idl_mask(_enum->default_enumerator) == IDL_DEFAULT_ENUMERATOR)
-    idl_warning(pstate, IDL_WARN_UNSUPPORTED_ANNOTATIONS, idl_location(node), "The @default_literal annotation is not fully supported yet in the C++ generator and will not modify default construction behaviour");
-
   name = get_cpp11_name(node);
   if (idl_fprintf(gen->header.handle, "enum class %s\n{\n", name) < 0)
     return IDL_RETCODE_NO_MEMORY;


### PR DESCRIPTION
The default value of enumerators will now also take the
@default_literal annotation into account when these enumerators are
used as members of structs
As, in C++, enum classes do not have default constructors, this
annotation does not have any effect here

Signed-off-by: Martijn Reicher <martijn.reicher@zettascale.tech>