### PR TITLE
Fix issue 260

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/Missing.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/Missing.hpp
@@ -20,7 +20,7 @@
 
 //since these helpers are only introduced from c++14 onwards
 
-#if __cplusplus == 201103L
+#if __cplusplus < 201402L
 namespace std {
   template< bool B, class T, class F >
   using conditional_t = typename std::conditional<B, T, F>::type;

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/cdr_stream.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/cdr_stream.cpp
@@ -11,6 +11,7 @@
  */
 #include <cstring>
 #include <assert.h>
+#include <algorithm>
 
 #include <org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp>
 


### PR DESCRIPTION
Fixes problems with compiling under MSVC15 (2017)

- Changed check for TopicTraits::isKeyless in tokey function to inside function block, as this is a constexpr this will result in the same optimized bytecode, as MSVC15 seems to resolve the template classes (TopicTraits and datatopic in the wrong order)
- Added include for <algorithm> which MSVC15 could not find