### PR TITLE
Fix for issue #263

### DIFF
--- a/src/ddscxx/tests/CMakeLists.txt
+++ b/src/ddscxx/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ idlcxx_generate(TARGET ddscxx_test_types FILES
   data/EntityProperties_pragma.idl
   data/ExtendedTypesModels.idl
   data/RegressionModels.idl
+  data/RegressionModels_pragma.idl
   data/ExternalModels.idl
   data/TraitsModels.idl
   WARNINGS no-implicit-extensibility)

--- a/src/ddscxx/tests/Regression.cpp
+++ b/src/ddscxx/tests/Regression.cpp
@@ -12,6 +12,7 @@
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "RegressionModels.hpp"
+#include "RegressionModels_pragma.hpp"
 
 typedef std::vector<unsigned char> bytes;
 

--- a/src/ddscxx/tests/data/RegressionModels_pragma.idl
+++ b/src/ddscxx/tests/data/RegressionModels_pragma.idl
@@ -1,0 +1,16 @@
+module regression_models {
+
+struct Nested {
+short Member_Nested;
+};
+
+struct Base {
+Nested Member_Base;
+};
+
+struct Derived : Base {
+short Member_Derived;
+};
+#pragma keylist Derived Member_Derived
+
+};

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -1006,9 +1006,11 @@ process_keylist(
 {
   const idl_key_t *key = NULL;
 
-  IDL_FOREACH(key, _struct->keylist->keys) {
-    if (process_key(streams, _struct, key))
-      return IDL_RETCODE_NO_MEMORY;
+  if (_struct->keylist) {
+    IDL_FOREACH(key, _struct->keylist->keys) {
+      if (process_key(streams, _struct, key))
+        return IDL_RETCODE_NO_MEMORY;
+    }
   }
 
   return IDL_RETCODE_OK;
@@ -1158,7 +1160,7 @@ process_struct_contents(
   struct streams *streams)
 {
   idl_retcode_t ret = IDL_RETCODE_OK;
-  bool keylist = (pstate->config.flags & IDL_FLAG_KEYLIST) && _struct->keylist;
+  bool keylist_flag = (pstate->config.flags & IDL_FLAG_KEYLIST);
 
   size_t to_unroll = 1;
   const idl_struct_t *base = _struct;
@@ -1173,7 +1175,7 @@ process_struct_contents(
     while (depth_to_go--)
       base =  (const idl_struct_t *)(base->inherit_spec->base);
 
-    if (keylist
+    if (keylist_flag
      && (ret = process_keylist(streams, base)))
       return ret;
 


### PR DESCRIPTION
There was no check done on whether the keylist container for a struct
being parsed actually existed for baser structs when processing the
key entries for the derived structs
Added check on the existance of the keylist before attempting to
iterate over the (supposedly) contained key entries

Signed-off-by: Martijn Reicher <martijn.reicher@zettascale.tech>