### PR TITLE
Fix for issue #265

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -59,8 +59,10 @@ bool to_key(const T& tokey, ddsi_keyhash_t& hash)
   } else
   {
     basic_cdr_stream str(endianness::big_endian);
-    if (!move(str, tokey, true))
+    if (!move(str, tokey, true)) {
+      assert(false);
       return false;
+    }
     size_t sz = str.position();
     size_t padding = 0;
     if (sz < 16)
@@ -69,8 +71,10 @@ bool to_key(const T& tokey, ddsi_keyhash_t& hash)
     if (padding)
       memset(buffer.data() + sz, 0x0, padding);
     str.set_buffer(buffer.data(), sz);
-    if (!write(str, tokey, true))
+    if (!write(str, tokey, true)) {
+      assert(false);
       return false;
+    }
     static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t&) = NULL;
     if (fptr == NULL)
     {

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.cpp
@@ -29,7 +29,7 @@ entity_properties_t& basic_cdr_stream::next_entity(entity_properties_t &props, b
 
 bool basic_cdr_stream::start_struct(entity_properties_t &props)
 {
-  if (props.requires_xtypes() && status(unsupported_xtypes))
+  if (!is_key() && props.requires_xtypes() && status(unsupported_xtypes))
     return false;
 
   return cdr_stream::start_struct(props);

--- a/src/ddscxx/tests/CDRStreamer.cpp
+++ b/src/ddscxx/tests/CDRStreamer.cpp
@@ -122,9 +122,9 @@ void VerifyReadOneDeeper(const bytes &in, const T& out, S stream, bool as_key)
 VerifyRead(normal_bytes, test_struct, streamer, false);\
 VerifyRead(key_bytes, key_struct, streamer, true);
 
-#define read_test_fail(test_struct, key_struct, streamer)\
+#define read_test_fail(test_struct, key_struct, key_bytes, streamer)\
 VerifyRead(bytes(256, 0x0), test_struct, streamer, false, false);\
-VerifyRead(bytes(256, 0x0), key_struct, streamer, true, false);
+VerifyRead(key_bytes, key_struct, streamer, true);
 
 #define read_deeper_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
 VerifyRead(normal_bytes, test_struct, streamer, false);\
@@ -134,17 +134,17 @@ VerifyReadOneDeeper(key_bytes, key_struct, streamer, true);
 VerifyWrite(test_struct, normal_bytes, streamer, false);\
 VerifyWrite(key_struct, key_bytes, streamer, true);
 
-#define write_test_fail(test_struct, key_struct, streamer)\
+#define write_test_fail(test_struct, key_struct, key_bytes, streamer)\
 VerifyWrite(test_struct, bytes(256, 0x0), streamer, false, false);\
-VerifyWrite(test_struct, bytes(256, 0x0), streamer, true, false);
+VerifyWrite(test_struct, key_bytes, streamer, true);
 
 #define readwrite_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
 read_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
 write_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)
 
-#define readwrite_test_fail(test_struct, key_struct, streamer)\
-read_test_fail(test_struct, key_struct, streamer)\
-write_test_fail(test_struct, key_struct, streamer)
+#define readwrite_test_fail(test_struct, key_struct, key_bytes, streamer)\
+read_test_fail(test_struct, key_struct, key_bytes, streamer)\
+write_test_fail(test_struct, key_struct, key_bytes, streamer)
 
 #define readwrite_deeper_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
 read_deeper_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
@@ -161,7 +161,7 @@ readwrite_test(test_struct, key_struct, cdr_normal_bytes, key_bytes, xcdr_v1_str
 readwrite_test(test_struct, key_struct, cdr_normal_bytes, key_bytes, xcdr_v2_stream(endianness::big_endian))
 
 #define stream_test_fail_basic(test_struct, xcdr_v1_normal_bytes, xcdr_v2_normal_bytes, key_bytes)\
-readwrite_test_fail(test_struct, test_struct, basic_cdr_stream(endianness::big_endian))\
+readwrite_test_fail(test_struct, test_struct, key_bytes, basic_cdr_stream(endianness::big_endian))\
 readwrite_test(test_struct, test_struct, xcdr_v1_normal_bytes, key_bytes, xcdr_v1_stream(endianness::big_endian))\
 readwrite_test(test_struct, test_struct, xcdr_v2_normal_bytes, key_bytes, xcdr_v2_stream(endianness::big_endian))
 
@@ -650,7 +650,7 @@ TEST_F(CDRStreamer, cdr_optional)
   /* basic cdr does not support optional fields,
      therefore the streamer should enter error status
      when the streamer is asked to write them */
-  readwrite_test_fail(OFS, OFS, basic_cdr_stream(endianness::big_endian));
+  readwrite_test_fail(OFS, OFS, OFS_key, basic_cdr_stream(endianness::big_endian));
 
   readwrite_test(OFS, OFS, OFS_xcdr_v1_normal, OFS_key, xcdr_v1_stream(endianness::big_endian))
   readwrite_test(OAS, OAS, OFS_xcdr_v1_normal, OFS_key, xcdr_v1_stream(endianness::big_endian))

--- a/src/ddscxx/tests/Regression.cpp
+++ b/src/ddscxx/tests/Regression.cpp
@@ -322,3 +322,21 @@ TEST_F(Regression, typedef_of_sequence_of_enums)
     };
   readwrite_test(s, struct_seq_e1_bytes, xcdr_v2_stream(endianness::little_endian));
 }
+
+TEST_F(Regression, key_value_of_appendables)
+{
+  s_final s_f;
+  s_appendable s_a;
+
+  s_f.s() = "abcdef";
+  s_a.s() = "abcdef";
+
+  ddsi_keyhash_t kh_f, kh_a;
+
+  unsigned char k[] = {0xcd, 0x34, 0x4d, 0x59, 0xec, 0x90, 0xb9, 0x62, 0xca, 0xb1, 0x41, 0xcf, 0x2a, 0x5d, 0xa6, 0xcf};
+
+  ASSERT_TRUE(to_key<s_final>(s_f, kh_f));
+  EXPECT_EQ(0, memcmp(k, kh_f.value, 16));
+  ASSERT_TRUE(to_key<s_appendable>(s_a, kh_a));
+  EXPECT_EQ(0, memcmp(k, kh_a.value, 16));
+}

--- a/src/ddscxx/tests/data/RegressionModels.idl
+++ b/src/ddscxx/tests/data/RegressionModels.idl
@@ -166,4 +166,14 @@ union u_struct_arr switch (unsigned long) {
   u_struct_arr c;
 };
 
+@final
+struct s_final {
+  @key string s;
+};
+
+@appendable
+struct s_appendable {
+  @key string s;
+};
+
 };


### PR DESCRIPTION
This issue was caused by the to_key function to not stream the key
values correctly when encountering a type which had keys and required
xtypes functionality
The streaming operations (move/write) failed when they shouldnt and
the error was just being passed as a non-hashing of the key value
contents
Fixed the streaming of keys in this case, and the passing of failures
to stream in the to_key function
Added regression tests to check for the correct generation of keys in
this scenario

Signed-off-by: Martijn Reicher <martijn.reicher@zettascale.tech>