### PR TITLE
Fix for issue #261

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp
@@ -41,15 +41,6 @@ public:
 
   /**
    * @brief
-   * Skips an entity, bypassing the stack.
-   *
-   * As the basic cdr stream does not have anything that requires delimiting between entities,
-   * this function is not supported.
-   */
-  void skip_entity(const entity_properties_t &) { status(serialization_status::unsupported_xtypes); }
-
-  /**
-   * @brief
    * Start a new struct.
    *
    * This function is called by the generated streaming functions, and will start a parameter list, if that is relevant for it.
@@ -59,19 +50,6 @@ public:
    * @return Whether the operation was completed succesfully.
    */
   bool start_struct(entity_properties_t &props);
-
-  /**
-   * @brief
-   * Returns the next entity to be processed.
-   *
-   * This implementation directly passes through to next_prop, since pops and pushes do nothing.
-   *
-   * @param[in, out] props The property tree to get the next entity from.
-   * @param[in, out] firstcall Whether it is the first time calling the function for props, will store first iterator if true, and then set to false.
-   *
-   * @return The next entity to be processed, or the final entity if the current tree level does not hold more entities.
-   */
-  entity_properties_t& next_entity(entity_properties_t &props, bool &firstcall);
 
 };
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp
@@ -411,7 +411,7 @@ public:
      *
      * @return Whether the operation was completed succesfully.
      */
-    virtual bool finish_member(entity_properties_t &, bool is_set = true) {(void) is_set; return !abort_status();}
+    virtual bool finish_member(entity_properties_t &, bool is_set = true);
 
     /**
      * @brief
@@ -494,16 +494,6 @@ protected:
 
     /**
      * @brief
-     * Records the start of a member entry.
-     *
-     * Will record the member start and set the member present flag to true.
-     *
-     * @param[in,out] prop The member whose start is recorded.
-     */
-    void record_member_start(entity_properties_t &prop);
-
-    /**
-     * @brief
      * Checks the struct for completeness.
      *
      * Checks whether all fields which must be understood are present.
@@ -537,6 +527,8 @@ protected:
 
     DDSCXX_WARNING_MSVC_OFF(4251)
     std::stack<size_t> m_buffer_end;              /**< the end of reading at the current level*/
+    std::stack<uint32_t> m_e_off,                 /**< the offset of the entity at the current level*/
+                         m_e_sz;                  /**< the size of the entity at the current level*/
     DDSCXX_WARNING_MSVC_ON(4251)
 };
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp
@@ -411,7 +411,7 @@ public:
      *
      * @return Whether the operation was completed succesfully.
      */
-    virtual bool finish_member(entity_properties_t &, bool is_set = true);
+    virtual bool finish_member(entity_properties_t &prop, bool is_set = true);
 
     /**
      * @brief
@@ -420,8 +420,7 @@ public:
      * This function is called by the instance implementation switchbox and will return the next entity to operate on by calling next_prop.
      * This will also call the implementation specific push/pop entity functions to write/finish headers where necessary.
      *
-     * @param[in, out] props The property tree to get the next entity from.
-     * @param[in, out] firstcall Whether it is the first time calling the function for props, will store first iterator if true, and then set to false.
+     * @param[in, out] prop The property tree to get the next entity from.
      *
      * @return The next entity to be processed, or the final entity if the current tree level does not hold more entities.
      */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
@@ -89,6 +89,7 @@ constexpr bit_bound get_bit_bound() {
       return bb_64_bits;
       break;
   }
+  return bb_unset;
 }
 
 /**
@@ -114,6 +115,7 @@ template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 constexpr bit_bound get_bit_bound();
 
 typedef struct entity_properties entity_properties_t;
+typedef std::vector<entity_properties_t> propvec;
 
 /**
  * @brief
@@ -205,24 +207,42 @@ struct OMG_DDS_API entity_properties
    * Used in the finish function to finish the entire entity_properties_t tree.
    */
   void erase_key_values();
+
+  /**
+   * @brief
+   * Finishes a tree representing an entire datamodel.
+   *
+   * This function will set the next_on_level and prev_on_level pointers to create a sub linked list
+   * of the members of the entity at that level. Also it will set the parent pointer of member entities
+   * and the first_member pointer of entities which have sub entities (members).
+   * When all this is done, it will take the key information in the key_endpoint map to (un)set the is_key
+   * flags on all members.
+   *
+   * @param[in, out] props The list of entities representing the datamodel.
+   * @param[in] keys The map of key indices.
+   */
+  static void finish(propvec &props, const key_endpoint &keys);
+
+  /**
+   * @brief
+   * Appends a sub tree to the current tree as a member.
+   *
+   * This function will take the contents of toappend, insert them at the end of appendto and increase the
+   * depth of all entities added. It is used to add a constructed type as a member of another constructed type.
+   *
+   * @param[in, out] appendto The tree to append to.
+   * @param[in] toappend The sub tree to append.
+   */
+  static void append_struct_contents(propvec &appendto, const propvec &toappend);
+
+  /**
+   * @brief
+   * Prints the contents of a tree representing a datatype to the screen.
+   *
+   * @param[in] in The tree to print.
+   */
+  static void print(const propvec &in);
 };
-
-typedef std::vector<entity_properties_t> propvec;
-
-/**
- * @brief
- * Finishes a tree representing an entire datamodel.
- *
- * This function will set the next_on_level and prev_on_level pointers to create a sub linked list
- * of the members of the entity at that level. Also it will set the parent pointer of member entities
- * and the first_member pointer of entities which have sub entities (members).
- * When all this is done, it will take the key information in the key_endpoint map to (un)set the is_key
- * flags on all members.
- *
- * @param[in, out] props The list of entities representing the datamodel.
- * @param[in] keys The map of key indices.
- */
-void finish(propvec &props, const key_endpoint &keys);
 
 /**
  * @brief
@@ -236,26 +256,6 @@ void finish(propvec &props, const key_endpoint &keys);
  */
 template<typename T>
 propvec& get_type_props();
-
-/**
- * @brief
- * Appends a sub tree to the current tree as a member.
- *
- * This function will take the contents of toappend, insert them at the end of appendto and increase the
- * depth of all entities added. It is used to add a constructed type as a member of another constructed type.
- *
- * @param[in, out] appendto The tree to append to.
- * @param[in] toappend The sub tree to append.
- */
-void append_struct_contents(propvec &appendto, const propvec &toappend);
-
-/**
- * @brief
- * Prints the contents of a tree representing a datatype to the screen.
- *
- * @param[in] in The tree to print.
- */
-void print(const propvec &in);
 
 }
 }

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
@@ -143,8 +143,6 @@ struct OMG_DDS_API entity_properties
 
   extensibility e_ext = extensibility::ext_final; /**< The extensibility of the entity itself. */
   extensibility p_ext = extensibility::ext_final; /**< The extensibility of the entity's parent. */
-  size_t e_off = 0;                               /**< The current offset in the stream at which the member field starts, does not include header. */
-  uint32_t e_sz = 0;                              /**< The size of the current entity as member field (only used in reading from streams).*/
   uint32_t m_id = 0;                              /**< The member id of the entity, it is the global field by which the entity is identified. */
   uint32_t depth = 0;                             /**< The depth of this entity.*/
   bool must_understand = false;                   /**< If the reading end cannot parse a field with this header, it must discard the entire object.*/
@@ -165,7 +163,7 @@ struct OMG_DDS_API entity_properties
    * @brief
    * Reset function.
    *
-   * This function will reset the fields that may have been set through streaming (e_off, e_sz, is_present).
+   * This function will reset the fields that may have been set through streaming (is_present).
    */
   void reset();
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
@@ -15,6 +15,7 @@
 #include <dds/core/macros.hpp>
 #include <cstdint>
 #include <list>
+#include <vector>
 #include <map>
 #include <atomic>
 #include <mutex>
@@ -52,9 +53,6 @@ enum bit_bound {
   bb_64_bits = 8
 };
 
-typedef struct entity_properties entity_properties_t;
-typedef std::list<entity_properties_t> proplist;
-
 /**
  * @brief
  * Helper struct to keep track of key endpoints of the a struct
@@ -69,6 +67,56 @@ DDSCXX_WARNING_MSVC_ON(4251)
 
 /**
  * @brief
+ * Primitive type get_bit_bound function.
+ *
+ * Returns a bb_unset for all primitive types.
+ *
+ * @return The bit bound for the primitive type.
+ */
+template<typename T, std::enable_if_t<std::is_arithmetic<T>::value, bool> = true >
+constexpr bit_bound get_bit_bound() {
+  switch (sizeof(T)) {
+    case 1:
+      return bb_8_bits;
+      break;
+    case 2:
+      return bb_16_bits;
+      break;
+    case 4:
+      return bb_32_bits;
+      break;
+    case 8:
+      return bb_64_bits;
+      break;
+  }
+}
+
+/**
+ * @brief
+ * Generic get_bit_bound fallback function.
+ *
+ * Returns a bb_unset for all non-primitive, non-enum types.
+ *
+ * @return bb_unset always.
+ */
+template<typename T, std::enable_if_t<!std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
+constexpr bit_bound get_bit_bound() { return bb_unset;}
+
+/**
+ * @brief
+ * Forward declaration for get_bit_bound function for enum classes.
+ *
+ * This function will be implemented for all enums defined in the implementation files.
+ *
+ * @return The bit_bound for the custom enum.
+ */
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
+constexpr bit_bound get_bit_bound();
+
+typedef struct entity_properties entity_properties_t;
+
+/**
+ * @brief
  * Entity properties struct.
  *
  * This is a container for data fields inside message classes, both as a representation passed for writing
@@ -79,184 +127,104 @@ DDSCXX_WARNING_MSVC_ON(4251)
 struct OMG_DDS_API entity_properties
 {
   entity_properties(
+    uint32_t _depth = 0,
     uint32_t _m_id = 0,
-    bool _is_optional = false):
+    bool _is_optional = false,
+    bit_bound _bb = bb_unset,
+    extensibility _ext = extensibility::ext_final,
+    bool _must_understand = true):
+      e_ext(_ext),
       m_id(_m_id),
-      is_optional(_is_optional) {;}
+      depth(_depth),
+      must_understand(_must_understand),
+      xtypes_necessary(_ext != extensibility::ext_final || _is_optional),
+      is_optional(_is_optional),
+      e_bb(_bb) {;}
 
   extensibility e_ext = extensibility::ext_final; /**< The extensibility of the entity itself. */
   extensibility p_ext = extensibility::ext_final; /**< The extensibility of the entity's parent. */
   size_t e_off = 0;                               /**< The current offset in the stream at which the member field starts, does not include header. */
   uint32_t e_sz = 0;                              /**< The size of the current entity as member field (only used in reading from streams).*/
   uint32_t m_id = 0;                              /**< The member id of the entity, it is the global field by which the entity is identified. */
-  bool must_understand_local = false;             /**< If the reading end cannot parse a field with this header, it must discard the entire object.*/
-  bool must_understand_remote = false;            /**< If the reading end cannot parse a field with this header, it must discard the entire object.*/
+  uint32_t depth = 0;                             /**< The depth of this entity.*/
+  bool must_understand = false;                   /**< If the reading end cannot parse a field with this header, it must discard the entire object.*/
   bool xtypes_necessary = false;                  /**< Is set if any of the members of this entity require xtypes support.*/
   bool implementation_extension = false;          /**< Can be set in XCDR_v1 stream parameter list headers.*/
-  bool is_last = false;                           /**< Indicates terminating entry for reading/writing entities, will cause the current subroutine to end and decrement the stack.*/
   bool ignore = false;                            /**< Indicates that this field must be ignored.*/
   bool is_optional = false;                       /**< Indicates that this field can be empty (length 0) for reading/writing purposes.*/
   bool is_key = false;                            /**< Indicates that this field is a key field.*/
   bool is_present = false;                        /**< Indicates that this entity is present in the read stream.*/
   bit_bound e_bb = bb_unset;                      /**< The minimum number of bytes necessary to represent this entity/bitmask.*/
 
-  DDSCXX_WARNING_MSVC_OFF(4251)
-  proplist m_members_by_seq;                      /**< Fields in normal streaming mode, ordered by their declaration.*/
-  proplist m_members_by_id;                       /**< Fields in normal streaming mode, ordered by their member id.*/
-  proplist m_keys;                                /**< Fields in key streaming mode, ordered by their member id.*/
-  DDSCXX_WARNING_MSVC_ON(4251)
+  entity_properties_t  *next_on_level = nullptr,  /**< Pointer to the next entity on the same level.*/
+                       *prev_on_level = nullptr,  /**< Pointer to the previous entity on the same level.*/
+                       *parent        = nullptr,  /**< Pointer to the parent of this entity.*/
+                       *first_member  = nullptr;  /**< Pointer to the first entity which is a member of this entity.*/
 
   /**
    * @brief
-   * Conversion to boolean operator.
+   * Reset function.
    *
-   * Checks whether the is_last flag is NOT set.
-   * Exists to make iterating over lists of entity properties easier, as the last entry of a list should be
-   * the one that converts to 'false', and the rest are all 'true'.
+   * This function will reset the fields that may have been set through streaming (e_off, e_sz, is_present).
    */
-  operator bool() const {return !is_last;}
+  void reset();
 
   /**
    * @brief
-   * Comparison operator.
+   * Print function.
    *
-   * @param[in] other The other entity to compare to.
-   *
-   * @return True when member and sequence ids are the same.
+   * This function write the contents (id, is_key, is_optional, must_understand, xtypes_necessary) of this entity to std::cout.
    */
-  bool operator==(const entity_properties_t &other) const {return m_id == other.m_id;}
+  void print() const;
 
   /**
    * @brief
-   * Comparison function.
+   * Checks whether this entity is not keyless.
    *
-   * Sorts by is_final and m_id, in that precedence.
-   * Used in sorting lists of entity_properties by member id, which makes lookup of the entity
-   * when receiving member id fields much quicker.
+   * This function will check all members (if any) and if any of them has the is_key flag set, this will return true.
+   * If none have this flag set, it will return false.
+   * Used in the finish function to finish the entire entity_properties_t tree.
    *
-   * @param[in] lhs First entity to be compared.
-   * @param[in] rhs Second entity to be compared.
-   *
-   * @return Whether lhs should be sorted before rhs.
+   * @return true if any of the members have a key, false otherwise.
    */
-  static bool member_id_comp(const entity_properties_t &lhs, const entity_properties_t &rhs);
+  bool has_keys() const;
 
   /**
    * @brief
-   * Finishing function.
+   * Sets is_key flags on members.
    *
-   * Generates the m_members_by_id and m_keys from m_members_by_seq and the supplied indices.
-   *
-   * @param[in] keys The indices of members which are keys.
+   * This function will set is_key flags on all members if the entity is keyless
+   * and will recursively call this on all members with the is_key flag set.
+   * Used in the finish function to finish the entire entity_properties_t tree.
    */
-  void finish(const key_endpoint &keys);
+  void set_key_values();
 
   /**
    * @brief
-   * Member property setting function.
+   * Removes all is_key flags from members.
    *
-   * Sets the m_id and is_optional values.
-   * Created to not have to have a constructor with a prohibitively large number of parameters.
-   *
-   * @param[in] member_id Sets the m_id field.
-   * @param[in] optional Sets the is_optional field.
+   * This function will set all is_key flags of members of this entity to false.
+   * Used in the finish function to finish the entire entity_properties_t tree.
    */
-  void set_member_props(uint32_t member_id, bool optional);
-
-  /**
-   * @brief
-   * Entity printing function.
-   *
-   * Prints the following information of the entity:
-   * - m_id, s_id, (key)member status, which ordering is followed: sequence(declaration)/id
-   * - whether it is a list terminating entry
-   * - the extensibility of the parent and the entity itself
-   *
-   * @param[in] recurse Whether to print its own children.
-   * @param[in] depth At which depth we are printing, determining the indentation at which is printed.
-   * @param[in] prefix Which prefix preceeds the printed entity information.
-   */
-  void print(bool recurse = true, size_t depth = 0, const char *prefix = "") const;
-
-  /**
-   * @brief
-   * Xtypes requirement function.
-   *
-   * @return Whether this contains features that cannot be sent through basic cdr serialization.
-   */
-  bool requires_xtypes() const;
-
-  /**
-   * @brief
-   * Empties the instance.
-   */
-  void clear();
-private:
-
-  /**
-   * @brief
-   * Non-key member trimming function.
-   *
-   * Removes entries from the list of key members which do not have the is_key flag set.
-   * This is called recursively on all members of the key list m_keys.
-   */
-  void trim_non_key_members();
-
-  /**
-   * @brief
-   * must_understand and is_key flag propagation function.
-   *
-   * Will set the is_key and must_understand flag on all members of entities which are themselves
-   * keys but themselves have no key members, indicating that the key stream for a this member is
-   * all members of this entity.
-   * This is called recursively on all members.
-   */
-  void propagate_flags();
-
-  /**
-   * @brief
-   * Other representations population function.
-   *
-   * Generates the m_members_by_id and m_keys representations from m_members_by_seq.
-   * Will discard unnecessary representations as indicated by to_keep.
-   * Is called recursively on all representations which are kept.
-   */
-  void populate_from_seq();
-
-  /**
-   * @brief
-   * Overwrites the existing key values.
-   *
-   * @param[in] endpoints A tree of indices indicating the which (sub)members are keys.
-   */
-  void set_key_values(const key_endpoint &endpoints);
+  void erase_key_values();
 };
+
+typedef std::vector<entity_properties_t> propvec;
 
 /**
  * @brief
- * Shortcut for creating a property list final entry.
+ * Finishes a tree representing an entire datamodel.
  *
- * Sets the is_last field to true.
- */
-struct OMG_DDS_API final_entry: public entity_properties_t {
-  final_entry(): entity_properties_t() {
-    is_last = true;
-  }
-};
-
-/**
- * @brief
- * Type properties getter function for basic types.
+ * This function will set the next_on_level and prev_on_level pointers to create a sub linked list
+ * of the members of the entity at that level. Also it will set the parent pointer of member entities
+ * and the first_member pointer of entities which have sub entities (members).
+ * When all this is done, it will take the key information in the key_endpoint map to (un)set the is_key
+ * flags on all members.
  *
- * @return entity_properties_t "Tree" representing the type.
+ * @param[in, out] props The list of entities representing the datamodel.
+ * @param[in] keys The map of key indices.
  */
-template<typename T, std::enable_if_t<std::is_arithmetic<T>::value, bool> = true >
-entity_properties_t get_type_props() {
-  entity_properties_t props;
-  static_assert(sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8);
-  props.e_bb = bit_bound(sizeof(T));
-  return props;
-}
+void finish(propvec &props, const key_endpoint &keys);
 
 /**
  * @brief
@@ -266,21 +234,30 @@ entity_properties_t get_type_props() {
  * It generates a static container which is initialized the first time the function is called,
  * this is then returned.
  *
- * @return entity_properties_t "Tree" representing the type.
+ * @return propvec "Tree" representing the type.
  */
-template<typename T, std::enable_if_t<!std::is_arithmetic<T>::value, bool> = true >
-entity_properties_t get_type_props();
+template<typename T>
+propvec& get_type_props();
 
 /**
  * @brief
- * Forward declaration for bit bound property of enum classes.
+ * Appends a sub tree to the current tree as a member.
  *
- * This function is implementated by each enum class that is encountered.
+ * This function will take the contents of toappend, insert them at the end of appendto and increase the
+ * depth of all entities added. It is used to add a constructed type as a member of another constructed type.
  *
- * @return bit_bound The bit bound for the indicated enum.
+ * @param[in, out] appendto The tree to append to.
+ * @param[in] toappend The sub tree to append.
  */
-template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
-constexpr bit_bound get_enum_bit_bound();
+void append_struct_contents(propvec &appendto, const propvec &toappend);
+
+/**
+ * @brief
+ * Prints the contents of a tree representing a datatype to the screen.
+ *
+ * @param[in] in The tree to print.
+ */
+void print(const propvec &in);
 
 }
 }

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.hpp
@@ -89,7 +89,7 @@ public:
    *
    * @return The first entity to be processed, or a nullptr if the current tree level does not hold any entities that match this tree.
    */
-  entity_properties_t *first_entity(entity_properties_t *props);
+  entity_properties_t *first_entity(entity_properties_t *prop);
 
   /**
    * @brief

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
@@ -261,11 +261,9 @@ private:
    * @brief
    * Finishes the write operation of the EM-header.
    *
-   * @param[in, out] props The entity whose EM-header to finish.
-   *
    * @return Whether the header was read succesfully.
    */
-  bool finish_em_header(entity_properties_t &props);
+  bool finish_em_header();
 
   /**
    * @brief

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
@@ -163,8 +163,8 @@ private:
   static const uint32_t must_understand;  /**< must understand member field flag*/
 
   DDSCXX_WARNING_MSVC_OFF(4251)
-  std::stack<consecutives_t> m_consecutives; /**< stack of consecutive entries, uses to determine whether or not to finish a d_header*/
-  std::stack<size_t> m_delimiters;        /**< locations of sequence delimiters */
+  custom_stack<consecutives_t, m_maximum_depth> m_consecutives; /**< stack of consecutive entries, uses to determine whether or not to finish a d_header*/
+  custom_stack<size_t, m_maximum_depth> m_delimiters; /**< locations of sequence delimiters */
   DDSCXX_WARNING_MSVC_ON(4251)
 
   /**

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
@@ -53,7 +53,7 @@ public:
    *
    * Determines whether a header is necessary for this entity through em_header_necessary, and if it is, handles the header.
    *
-   * @param[in] prop Properties of the member to start.
+   * @param[in, out] prop Properties of the member to start.
    * @param[in] is_set Whether the entity represented by prop is present, if it is an optional entity.
    */
   bool start_member(entity_properties_t &prop, bool is_set = true);
@@ -64,7 +64,7 @@ public:
    *
    * Determines whether a header is necessary for this entity through em_header_necessary, and if it is, completes the previous header.
    *
-   * @param[in] prop Properties of the member to finish.
+   * @param[in, out] prop Properties of the member to finish.
    * @param[in] is_set Whether the entity represented by prop is present, if it is an optional entity.
    *
    * @return Whether the operation was completed succesfully.
@@ -73,17 +73,29 @@ public:
 
   /**
    * @brief
-   * Returns the next entity to be processed.
+   * Returns the next entity to be processed at this level.
    *
    * Depending on the data structure and the streaming mode, either a header is read from the stream, or a
    * properties entry is pulled from the tree.
    *
-   * @param[in, out] props The property tree to get the next entity from.
-   * @param[in, out] firstcall Whether it is the first time calling the function for props, will store first iterator if true, and then set to false.
+   * @param[in, out] prop The property tree to get the next entity from.
    *
-   * @return The next entity to be processed, or the final entity if the current tree level does not hold more entities.
+   * @return The next entity to be processed, or a nullptr if the current tree level does not hold more entities that match this tree.
    */
-  entity_properties_t& next_entity(entity_properties_t &props, bool &firstcall);
+  entity_properties_t* next_entity(entity_properties_t *prop);
+
+  /**
+   * @brief
+   * Returns the first entity to be processed at this level.
+   *
+   * Depending on the data structure and the streaming mode, either a header is read from the stream, or a
+   * properties entry is pulled from the tree.
+   *
+   * @param[in, out] prop The property tree to get the next entity from.
+   *
+   * @return The first entity to be processed, or a nullptr if the current tree level does not hold any entities that match this tree.
+   */
+  entity_properties_t *first_entity(entity_properties_t *props);
 
   /**
    * @brief
@@ -213,11 +225,11 @@ private:
    * @brief
    * Writes an EM-header to the stream.
    *
-   * @param[in, out] props The entity to write the EM-header for.
+   * @param[in, out] prop The entity to write the EM-header for.
    *
    * @return Whether the header was read succesfully.
    */
-  bool write_em_header(entity_properties_t &props);
+  bool write_em_header(entity_properties_t &prop);
 
   /**
    * @brief
@@ -301,7 +313,7 @@ private:
  */
 template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
 bool read(xcdr_v2_stream& str, T& toread, size_t N = 1) {
-  switch (str.is_key() ? bb_32_bits : get_enum_bit_bound<T>())
+  switch (str.is_key() ? bb_32_bits : get_bit_bound<T>())
   {
     case bb_8_bits:
       return read_enum_impl<xcdr_v2_stream,T,uint8_t>(str, toread, N);
@@ -330,7 +342,7 @@ bool read(xcdr_v2_stream& str, T& toread, size_t N = 1) {
  */
 template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
 bool write(xcdr_v2_stream& str, const T& towrite, size_t N = 1) {
-  switch (str.is_key() ? bb_32_bits : get_enum_bit_bound<T>())
+  switch (str.is_key() ? bb_32_bits : get_bit_bound<T>())
   {
     case bb_8_bits:
       return write_enum_impl<xcdr_v2_stream,T,uint8_t>(str, towrite, N);
@@ -358,7 +370,7 @@ bool write(xcdr_v2_stream& str, const T& towrite, size_t N = 1) {
  */
 template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
 bool move(xcdr_v2_stream& str, const T&, size_t N = 1) {
-  switch (str.is_key() ? bb_32_bits : get_enum_bit_bound<T>())
+  switch (str.is_key() ? bb_32_bits : get_bit_bound<T>())
   {
     case bb_8_bits:
       return move(str, int8_t(0), N);

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
@@ -95,7 +95,7 @@ public:
    *
    * @return The first entity to be processed, or a nullptr if the current tree level does not hold any entities that match this tree.
    */
-  entity_properties_t *first_entity(entity_properties_t *props);
+  entity_properties_t *first_entity(entity_properties_t *prop);
 
   /**
    * @brief

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -49,6 +49,9 @@ using org::eclipse::cyclonedds::core::cdr::extensibility;
 using org::eclipse::cyclonedds::core::cdr::encoding_version;
 using org::eclipse::cyclonedds::topic::TopicTraits;
 
+template<typename T, class S>
+bool get_serialized_size(const T& sample, bool as_key, size_t &sz);
+
 template<typename T>
 bool to_key(const T& tokey, ddsi_keyhash_t& hash)
 {
@@ -59,11 +62,11 @@ bool to_key(const T& tokey, ddsi_keyhash_t& hash)
   } else
   {
     basic_cdr_stream str(endianness::big_endian);
-    if (!move(str, tokey, true)) {
+    size_t sz = 0;
+    if (!get_serialized_size<T, basic_cdr_stream>(tokey, true, sz)) {
       assert(false);
       return false;
     }
-    size_t sz = str.position();
     size_t padding = 0;
     if (sz < 16)
       padding = (16 - sz % 16)%16;
@@ -75,7 +78,7 @@ bool to_key(const T& tokey, ddsi_keyhash_t& hash)
       assert(false);
       return false;
     }
-    static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t&) = NULL;
+    static thread_local bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t&) = NULL;
     if (fptr == NULL)
     {
       max(str, tokey, true);
@@ -243,11 +246,37 @@ bool read_header(const void *buffer, encoding_version &ver, endianness &end)
   return true;
 }
 
+template<typename T, class S, bool K>
+bool get_serialized_fixed_size(const T& sample, size_t &sz)
+{
+  static thread_local size_t serialized_size = 0;
+  static thread_local std::mutex mtx;
+  static thread_local std::atomic_bool initialized {false};
+  if (initialized.load(std::memory_order_relaxed)) {
+    sz = serialized_size;
+    return true;
+  }
+  std::lock_guard<std::mutex> lock(mtx);
+  if (initialized.load(std::memory_order_relaxed)) {
+    sz = serialized_size;
+    return true;
+  }
+  S str;
+  if (!move(str, sample, K))
+    return false;
+  serialized_size = str.position();
+  initialized.store(true, std::memory_order::memory_order_release);
+  sz = serialized_size;
+  return true;
+}
+
 template<typename T, class S>
 bool get_serialized_size(const T& sample, bool as_key, size_t &sz)
 {
   if (TopicTraits<T>::isSelfContained()) {
-    sz = TopicTraits<T>::getSampleSize();
+    if ((as_key && !get_serialized_fixed_size<T,S,true>(sample, sz)) ||
+        (!as_key && !get_serialized_fixed_size<T,S,false>(sample, sz)))
+      return false;
   } else {
     S str;
     if (!move(str, sample, as_key))

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -246,10 +246,14 @@ bool read_header(const void *buffer, encoding_version &ver, endianness &end)
 template<typename T, class S>
 bool get_serialized_size(const T& sample, bool as_key, size_t &sz)
 {
-  S str;
-  if (!move(str, sample, as_key))
-    return false;
-  sz = str.position();
+  if (TopicTraits<T>::isSelfContained()) {
+    sz = TopicTraits<T>::getSampleSize();
+  } else {
+    S str;
+    if (!move(str, sample, as_key))
+      return false;
+    sz = str.position();
+  }
 
   return true;
 }

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.cpp
@@ -18,18 +18,9 @@ namespace cyclonedds {
 namespace core {
 namespace cdr {
 
-entity_properties_t& basic_cdr_stream::next_entity(entity_properties_t &props, bool &firstcall)
-{
-  if (abort_status())
-    return m_final;
-
-  auto &prop = next_prop(props, m_key ? member_list_type::key : member_list_type::member_by_seq, firstcall);
-  return prop;
-}
-
 bool basic_cdr_stream::start_struct(entity_properties_t &props)
 {
-  if (!is_key() && props.requires_xtypes() && status(unsupported_xtypes))
+  if (!is_key() && props.xtypes_necessary && status(unsupported_xtypes))
     return false;
 
   return cdr_stream::start_struct(props);

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/cdr_stream.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/cdr_stream.cpp
@@ -57,14 +57,11 @@ bool cdr_stream::finish_struct(entity_properties_t &props)
 {
   check_struct_completeness(props);
 
-  return !abort_status() && props.is_present;
+  return props.is_present;
 }
 
 entity_properties_t *cdr_stream::first_entity(entity_properties_t *props)
 {
-  if (abort_status())
-    return nullptr;
-
   auto ptr = props->first_member;
   while (m_key && ptr && !ptr->is_key)
     ptr = next_entity(ptr);
@@ -74,9 +71,6 @@ entity_properties_t *cdr_stream::first_entity(entity_properties_t *props)
 
 entity_properties_t* cdr_stream::next_entity(entity_properties_t *prop)
 {
-  if (abort_status())
-    return nullptr;
-
   prop = prop->next_on_level;
   if (m_key) {
     while (prop && !prop->is_key)
@@ -87,9 +81,6 @@ entity_properties_t* cdr_stream::next_entity(entity_properties_t *prop)
 
 entity_properties_t* cdr_stream::previous_entity(entity_properties_t *prop)
 {
-  if (abort_status())
-    return nullptr;
-
   prop = prop->prev_on_level;
   if (m_key) {
     while (prop && !prop->is_key)
@@ -113,7 +104,7 @@ bool cdr_stream::bytes_available(size_t N, bool peek)
         break;
     }
   }
-  return !abort_status();
+  return true;
 }
 
 void cdr_stream::reset()

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/entity_properties.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/entity_properties.cpp
@@ -60,7 +60,7 @@ static void add_key(const key_endpoint &key, entity_properties_t &props)
   }
 }
 
-void finish(propvec &props, const key_endpoint &keys)
+void entity_properties_t::finish(propvec &props, const key_endpoint &keys)
 {
   assert(props.size());
 
@@ -149,7 +149,7 @@ void entity_properties_t::erase_key_values()
   }
 }
 
-void append_struct_contents(propvec &appendto, const propvec &toappend)
+void entity_properties_t::append_struct_contents(propvec &appendto, const propvec &toappend)
 {
   auto oldsize = appendto.size();
 
@@ -157,14 +157,14 @@ void append_struct_contents(propvec &appendto, const propvec &toappend)
 
   for (size_t i = oldsize; i < appendto.size(); i++) {
     appendto[i].depth++;
-    appendto[i].next_on_level = nullptr,
-    appendto[i].prev_on_level = nullptr,
-    appendto[i].parent        = nullptr,
+    appendto[i].next_on_level = nullptr;
+    appendto[i].prev_on_level = nullptr;
+    appendto[i].parent        = nullptr;
     appendto[i].first_member  = nullptr;
   }
 }
 
-void print(const propvec &in)
+void entity_properties_t::print(const propvec &in)
 {
   for (const auto & e:in)
     e.print();

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/entity_properties.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/entity_properties.cpp
@@ -104,8 +104,6 @@ void finish(propvec &props, const key_endpoint &keys)
 
 void entity_properties_t::reset()
 {
-  e_off = 0;
-  e_sz = 0;
   is_present = false;
 }
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.cpp
@@ -51,6 +51,7 @@ bool xcdr_v1_stream::start_member(entity_properties_t &prop, bool is_set)
     }
   }
 
+  push_member_start();
   return cdr_stream::start_member(prop, is_set);
 }
 
@@ -70,6 +71,7 @@ bool xcdr_v1_stream::finish_member(entity_properties_t &prop, bool is_set)
     }
   }
 
+  pop_member_start();
   return cdr_stream::finish_member(prop, is_set);
 }
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.cpp
@@ -303,7 +303,7 @@ bool xcdr_v1_stream::finish_struct(entity_properties_t &props)
       break;
   }
 
-  return !abort_status() && props.is_present;
+  return props.is_present;
 }
 
 bool xcdr_v1_stream::list_necessary(const entity_properties_t &props)

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.cpp
@@ -51,8 +51,7 @@ bool xcdr_v1_stream::start_member(entity_properties_t &prop, bool is_set)
     }
   }
 
-  record_member_start(prop);
-  return true;
+  return cdr_stream::start_member(prop, is_set);
 }
 
 bool xcdr_v1_stream::finish_member(entity_properties_t &prop, bool is_set)
@@ -77,60 +76,136 @@ bool xcdr_v1_stream::finish_member(entity_properties_t &prop, bool is_set)
   return true;
 }
 
-entity_properties_t& xcdr_v1_stream::next_entity(entity_properties_t &props, bool &firstcall)
+entity_properties_t* xcdr_v1_stream::next_entity(entity_properties_t *prop)
 {
-  if (abort_status())
-    return m_final;
-
-  member_list_type ml = member_list_type::member_by_seq;
-  if (m_key)
-    ml = member_list_type::key;
-
   if (m_mode != stream_mode::read)
-    return next_prop(props, ml, firstcall);
+    return cdr_stream::next_entity(prop);
 
-  if (!list_necessary(props)) {
-    while (1) {  //using while loop to prevent recursive calling, which could lead to stack overflow
-      auto &prop = next_prop(props, ml, firstcall);
-
-      if (prop.is_optional) {
+  if (!list_necessary(*(prop->parent))) {
+    while ((prop = cdr_stream::next_entity(prop))) {
+      if (prop->is_optional) {
         entity_properties_t temp;
-        if (!read_header(temp))
+        bool is_final = false;
+        if (!read_header(temp, is_final)) {
+          return nullptr;  //read failure
+        } else if (is_final) {
+          return nullptr;  //final field
+        }
+
+        if (temp.e_sz) {
+          prop->e_sz = temp.e_sz;
           break;
-
-        prop.e_sz = temp.e_sz;
-        if (prop.e_sz)
-          return prop;
+        }
       } else {
-        return prop;
+        break;
       }
-
     }
   } else {
-    proplist *ptr = NULL;
-    if (m_key)
-      ptr = &props.m_keys;
-    else
-      ptr = &props.m_members_by_id;
-
     while (1) {  //using while loop to prevent recursive calling, which could lead to stack overflow
-
-      if (!read_header(m_current_header) || !m_current_header)
-        break;
-      else if (0 == m_current_header.e_sz)
+      entity_properties_t temp;
+      bool is_final = false;
+      if (!read_header(temp, is_final)) {
+        return nullptr;  //read failure
+      } else if (is_final) {
+        return nullptr;  //final field
+      } else if (0 == temp.e_sz) {
+        continue;  //empty field
+      } else if (temp.ignore) {
+        //ignore this field
+        incr_position(temp.e_sz);
+        alignment(0);
         continue;
+      }
 
-      auto p = std::equal_range(ptr->begin(), ptr->end(), m_current_header, entity_properties_t::member_id_comp);
-      if (p.first != ptr->end() && (p.first->m_id == m_current_header.m_id || (!(*p.first) && !m_current_header))) {
-        p.first->must_understand_remote = m_current_header.must_understand_remote;
-        p.first->e_sz = m_current_header.e_sz;
-        return *(p.first);
+      //search forward
+      auto p = prop;
+      while (p && p->m_id != temp.m_id)
+        p = cdr_stream::next_entity(p);
+
+      //search backward
+      if (!p) {
+        p = prop;
+        while (p && p->m_id != temp.m_id)
+          p = cdr_stream::previous_entity(p);
+      }
+
+      if (!p) {  //could not find this entry in the list of parameters
+        if (temp.must_understand &&
+            status(must_understand_fail))
+          return nullptr;
+        incr_position(temp.e_sz);
+        alignment(0);
       } else {
-        return m_current_header;
+        prop = p;
+        prop->e_sz = temp.e_sz;
+        break;
       }
     }
   }
-  return m_final;
+  return prop;
+}
+
+entity_properties_t* xcdr_v1_stream::first_entity(entity_properties_t *props)
+{
+  if (m_mode != stream_mode::read)
+    return cdr_stream::first_entity(props);
+
+  auto prop = cdr_stream::first_entity(props);
+  if (!list_necessary(*props)) {
+    do {
+      if (prop->is_optional) {
+        entity_properties_t temp;
+        bool is_final = false;
+        if (!read_header(temp, is_final)) {
+          return nullptr;  //read failure
+        } else if (is_final) {
+          return nullptr;  //final field
+        }
+
+        if (temp.e_sz) {
+          prop->e_sz = temp.e_sz;
+          break;
+        }
+      } else {
+        break;
+      }
+    } while  ((prop = cdr_stream::next_entity(prop)));
+  } else {
+    while (1) {  //using while loop to prevent recursive calling, which could lead to stack overflow
+      entity_properties_t temp;
+      bool is_final = false;
+      if (!read_header(temp, is_final)) {
+        return nullptr;  //read failure
+      } else if (is_final) {
+        return nullptr;  //final field
+      } else if (0 == temp.e_sz) {
+        continue;  //empty field
+      } else if (temp.ignore) {
+        //ignore this field
+        incr_position(temp.e_sz);
+        alignment(0);
+        continue;
+      }
+
+      //search forward
+      auto p = prop;
+      while (p && p->m_id != temp.m_id)
+        p = cdr_stream::next_entity(p);
+
+      if (!p) {  //could not find this entry in the list of parameters
+        if (temp.must_understand &&
+            status(must_understand_fail))
+          return nullptr;
+        incr_position(temp.e_sz);
+        alignment(0);
+      } else {
+        prop = p;
+        prop->e_sz = temp.e_sz;
+        break;
+      }
+    }
+  }
+  return prop;
 }
 
 bool xcdr_v1_stream::header_necessary(const entity_properties_t &props)
@@ -138,9 +213,8 @@ bool xcdr_v1_stream::header_necessary(const entity_properties_t &props)
   return (props.p_ext == extensibility::ext_mutable || props.is_optional) && !m_key;
 }
 
-bool xcdr_v1_stream::read_header(entity_properties_t &out)
+bool xcdr_v1_stream::read_header(entity_properties_t &out, bool &is_final)
 {
-  out = entity_properties_t();
   uint16_t smallid = 0, smalllength = 0;
 
   if (!align(4, false)
@@ -151,11 +225,11 @@ bool xcdr_v1_stream::read_header(entity_properties_t &out)
 
   out.m_id = smallid & pid_mask;
   out.e_sz = smalllength;
-  out.must_understand_remote = pid_flag_must_understand & smallid;
+  out.must_understand = pid_flag_must_understand & smallid;
   out.implementation_extension = pid_flag_impl_extension & smallid;
   switch (out.m_id) {
     case pid_list_end:
-      out.is_last = true;
+      is_final = true;
       break;
     case pid_ignore:
       out.ignore = true;
@@ -169,7 +243,7 @@ bool xcdr_v1_stream::read_header(entity_properties_t &out)
         return false;
 
       out.e_sz = largelength;
-      out.must_understand_remote = pl_extended_flag_must_understand & memberheader;
+      out.must_understand = pl_extended_flag_must_understand & memberheader;
       out.implementation_extension = pl_extended_flag_impl_extension & memberheader;
       out.m_id = pl_extended_mask & memberheader;
     }
@@ -188,11 +262,11 @@ bool xcdr_v1_stream::write_header(entity_properties_t &props)
     return false;
   } else if (extended_header(props)) {
     uint16_t smallid = pid_extended + pid_flag_must_understand;
-    uint32_t largeid = (props.m_id & pl_extended_mask) + (props.must_understand_local ? pl_extended_flag_must_understand : 0);
+    uint32_t largeid = (props.m_id & pl_extended_mask) + (props.must_understand || props.is_key ? pl_extended_flag_must_understand : 0);
     return write(*this, smallid) && write(*this, uint16_t(8))
         && write(*this, largeid) && write(*this, uint32_t(0));  /* length field placeholder, to be completed by finish_write_header */
   } else {
-    uint16_t smallid = static_cast<uint16_t>(props.m_id + (props.must_understand_local ? pid_flag_must_understand : 0));
+    uint16_t smallid = static_cast<uint16_t>(props.m_id + (props.must_understand || props.is_key ? pid_flag_must_understand : 0));
     return write(*this, smallid) && write(*this, uint16_t(0));  /* length field placeholder, to be completed by finish_write_header */
   }
 }
@@ -234,8 +308,7 @@ bool xcdr_v1_stream::finish_struct(entity_properties_t &props)
         return move_final_list_entry();
       break;
     case stream_mode::read:
-      check_struct_completeness(props, m_key ? member_list_type::key :
-          (list_necessary(props) ? member_list_type::member_by_id : member_list_type::member_by_seq));
+      check_struct_completeness(props);
       break;
     default:
       break;
@@ -275,7 +348,7 @@ bool xcdr_v1_stream::move_header(const entity_properties_t &props)
 
 bool xcdr_v1_stream::extended_header(const entity_properties_t &props)
 {
-  return !props.e_bb || props.m_id >= pid_extended;
+  return props.e_bb == bb_unset || props.m_id >= pid_extended;
 }
 
 }

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.cpp
@@ -60,7 +60,7 @@ bool xcdr_v2_stream::start_member(entity_properties_t &prop, bool is_set)
   }
 
   m_consecutives.push({false, false});
-
+  push_member_start();
   return cdr_stream::start_member(prop, is_set);
 }
 
@@ -82,7 +82,7 @@ bool xcdr_v2_stream::finish_member(entity_properties_t &prop, bool is_set)
   }
 
   m_consecutives.pop();
-
+  pop_member_start();
   return cdr_stream::finish_member(prop, is_set);
 }
 
@@ -434,7 +434,8 @@ bool xcdr_v2_stream::finish_d_header()
 void xcdr_v2_stream::reset()
 {
   cdr_stream::reset();
-  m_delimiters = std::stack<size_t>();
+  m_delimiters.reset();
+  m_consecutives.reset();
 }
 
 bool xcdr_v2_stream::finish_em_header()

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.cpp
@@ -325,7 +325,7 @@ bool xcdr_v2_stream::finish_struct(entity_properties_t &props)
       break;
   }
 
-  return !abort_status() && props.is_present;
+  return props.is_present;
 }
 
 bool xcdr_v2_stream::start_consecutive(bool is_array, bool primitive)

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.cpp
@@ -53,7 +53,7 @@ bool xcdr_v2_stream::start_member(entity_properties_t &prop, bool is_set)
       break;
     case stream_mode::read:
       if (em_header_necessary(prop))
-        m_buffer_end.push(position() + prop.e_sz);
+        m_buffer_end.push(position() + m_e_sz.top());
       break;
     default:
       break;
@@ -68,9 +68,8 @@ bool xcdr_v2_stream::finish_member(entity_properties_t &prop, bool is_set)
 {
   switch (m_mode) {
     case stream_mode::write:
-      prop.e_sz = static_cast<uint32_t>(position()-prop.e_off);
       if (em_header_necessary(prop)) {
-        if (is_set && !finish_em_header(prop))
+        if (is_set && !finish_em_header())
           return false;
       }
       break;
@@ -84,7 +83,7 @@ bool xcdr_v2_stream::finish_member(entity_properties_t &prop, bool is_set)
 
   m_consecutives.pop();
 
-  return true;
+  return cdr_stream::finish_member(prop, is_set);
 }
 
 bool xcdr_v2_stream::write_d_header()
@@ -125,11 +124,11 @@ entity_properties_t* xcdr_v2_stream::next_entity(entity_properties_t *prop)
       if (!bytes_available(4, true) ||
           !read_em_header(temp)) {
         return nullptr;  //no more fields to read
-      } else if (0 == temp.e_sz) {
+      } else if (0 == m_e_sz.top()) {
         continue; //this field is empty
       } else if (temp.ignore) {
         //ignore this field
-        incr_position(temp.e_sz);
+        incr_position(m_e_sz.top());
         alignment(0);
         continue;
       }
@@ -150,11 +149,10 @@ entity_properties_t* xcdr_v2_stream::next_entity(entity_properties_t *prop)
         if (temp.must_understand &&
             status(must_understand_fail))
           return nullptr;
-        incr_position(temp.e_sz);
+        incr_position(m_e_sz.top());
         alignment(0);
       } else {
         prop = p;
-        prop->e_sz = temp.e_sz;
         break;
       }
     }
@@ -186,11 +184,11 @@ entity_properties_t* xcdr_v2_stream::first_entity(entity_properties_t *props)
       if (!bytes_available(4, true) ||
           !read_em_header(temp)) {
         return nullptr;  //no more fields to read
-      } else if (0 == temp.e_sz) {
+      } else if (0 == m_e_sz.top()) {
         continue; //this field is empty
       } else if (temp.ignore) {
         //ignore this field
-        incr_position(temp.e_sz);
+        incr_position(m_e_sz.top());
         alignment(0);
         continue;
       }
@@ -204,11 +202,10 @@ entity_properties_t* xcdr_v2_stream::first_entity(entity_properties_t *props)
         if (temp.must_understand &&
             status(must_understand_fail))
           return nullptr;
-        incr_position(temp.e_sz);
+        incr_position(m_e_sz.top());
         alignment(0);
       } else {
         prop = p;
-        prop->e_sz = temp.e_sz;
         break;
       }
     }
@@ -228,19 +225,19 @@ bool xcdr_v2_stream::read_em_header(entity_properties_t &props)
   props.m_id = emheader & id_mask;
   switch (emheader & lc_mask) {
     case bytes_1:
-      props.e_sz = 1;
+      m_e_sz.top() = 1;
       break;
     case bytes_2:
-      props.e_sz = 2;
+      m_e_sz.top() = 2;
       break;
     case bytes_4:
-      props.e_sz = 4;
+      m_e_sz.top() = 4;
       break;
     case bytes_8:
-      props.e_sz = 8;
+      m_e_sz.top() = 8;
       break;
     case nextint:
-      if (!read(*this, props.e_sz))
+      if (!read(*this, m_e_sz.top()))
         return false;
       break;
     case nextint_times_1:
@@ -255,10 +252,10 @@ bool xcdr_v2_stream::read_em_header(entity_properties_t &props)
   }
 
   if (factor) {
-    if (!read(*this, props.e_sz))
+    if (!read(*this, m_e_sz.top()))
       return false;
-    props.e_sz *= factor;
-    props.e_sz += 4;
+    m_e_sz.top() *= factor;
+    m_e_sz.top() += 4;
     //move cursor back 4 bytes, due to overlap of nextint and entity
     if ((emheader & lc_mask) > nextint)
       position(position()-4);
@@ -440,17 +437,18 @@ void xcdr_v2_stream::reset()
   m_delimiters = std::stack<size_t>();
 }
 
-bool xcdr_v2_stream::finish_em_header(entity_properties_t &props)
+bool xcdr_v2_stream::finish_em_header()
 {
-  if (props.e_sz == 0)
+  uint32_t e_sz = static_cast<uint32_t>(position()-m_e_off.top());
+  if (e_sz == 0)
     return true;
 
   auto current_position = position();
   auto current_alignment = alignment();
 
-  position(props.e_off - 4);
+  position(m_e_off.top() - 4);
   alignment(4);
-  if (!write(*this, props.e_sz))
+  if (!write(*this, e_sz))
     return false;
 
   position(current_position);

--- a/src/ddscxx/tests/Regression.cpp
+++ b/src/ddscxx/tests/Regression.cpp
@@ -227,17 +227,7 @@ TEST_F(Regression, delimiters_bitmask)
 
 TEST_F(Regression, emumerators_properties)
 {
-  auto props = org::eclipse::cyclonedds::core::cdr::get_type_props<e1>();
-
-  EXPECT_EQ(props.e_ext, extensibility::ext_appendable);
-  EXPECT_EQ(props.e_bb, bb_8_bits);
-  EXPECT_TRUE(props.xtypes_necessary);
-  ASSERT_EQ(props.m_members_by_seq.size(), 1);
-  EXPECT_FALSE(bool(props.m_members_by_seq.front()));
-  ASSERT_EQ(props.m_members_by_id.size(), 1);
-  EXPECT_FALSE(bool(props.m_members_by_id.front()));
-  ASSERT_EQ(props.m_keys.size(), 1);
-  EXPECT_FALSE(bool(props.m_keys.front()));
+  EXPECT_EQ(org::eclipse::cyclonedds::core::cdr::get_bit_bound<e1>(), bb_8_bits);
 }
 
 TEST_F(Regression, delimiters_emumerators)

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -561,7 +561,8 @@ static bool sc_struct(const idl_struct_t *str)
 bool is_selfcontained(const void *node)
 {
   if (idl_is_sequence(node)
-   || idl_is_string(node)) {
+   || idl_is_string(node)
+   || idl_is_optional(node)) {
     return false;
   } else if (idl_is_typedef(node)) {
     return is_selfcontained(((const idl_typedef_t*)node)->type_spec);

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -724,7 +724,7 @@ generate_member_properties(
   }
 
   if (idl_is_struct(type_spec) &&
-      putf(&streams->props, "  append_struct_contents(props, get_type_props<%1$s>());  //internal contents of ::%2$s\n", type, idl_identifier(decl)))
+      putf(&streams->props, "  entity_properties_t::append_struct_contents(props, get_type_props<%1$s>());  //internal contents of ::%2$s\n", type, idl_identifier(decl)))
     return IDL_RETCODE_NO_MEMORY;
 
   return IDL_RETCODE_OK;
@@ -1130,7 +1130,7 @@ print_constructed_type_close(
     "  return streamer.finish_struct(*props);\n"
     "}\n\n";
   static const char *pfmt =
-    "\n  finish(props, keylist);\n"
+    "\n  entity_properties_t::finish(props, keylist);\n"
     "  initialized.store(true, std::memory_order::memory_order_release);\n"
     "  return props;\n"
     "}\n\n";


### PR DESCRIPTION
This fixes issue #261

Improved the performance of (de)serialization through the following changes:
- flattened the entity_properties tree as the std::list approach was not that quick
- created a custom stack which is faster than std::stack
- moved adminstration of the streaming status of entity offset (e_off) and entity size (e_sz) out the entity_properties and into the streamer class
- added skipping of size determination through streaming functions when serialized type has constant size
- removed member start/stop checking for basic cdr streams
- simpified a number of frequently used streaming functions
- changed from a range based for-loop to just running over the bare pointers in get_type_props as this vector will not change in size
- removed a number of unnecessary checks for abort_status, the streaming function will exit with a false status before
- only calculate whether byte swapping is necessary once, as the endiannesses will not change during the lifetime of the stream
- optimized reading/writing of single entry basic types, no longer an unaligned memcpy