### PR TITLE
ADLINK Technology Ltd became ZettaScale Technology

### DIFF
--- a/.azure/codecov.yml
+++ b/.azure/codecov.yml
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2021 ADLINK Technology Limited and others
+# Copyright(c) 2021 ZettaScale Technology and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/.azure/coverity-scan.yml
+++ b/.azure/coverity-scan.yml
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2021 ADLINK Technology Limited and others
+# Copyright(c) 2021 ZettaScale Technology and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2021 ADLINK Technology Limited and others
+# Copyright(c) 2021 ZettaScale Technology and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/CMakeCPack.cmake
+++ b/CMakeCPack.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020 ADLINK Technology Limited and others
+# Copyright(c) 2020 to 2021 ZettaScale Technology and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020 ADLINK Technology Limited and others
+# Copyright(c) 2020 to 2022 ZettaScale Technology and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/PackageConfig.cmake.in
+++ b/PackageConfig.cmake.in
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020 ADLINK Technology Limited and others
+# Copyright(c) 2020 to 2021 ZettaScale Technology and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2021 ADLINK Technology Limited and others
+# Copyright(c) 2021 ZettaScale Technology and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/cmake/Modules/Codecov.cmake
+++ b/cmake/Modules/Codecov.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020 ADLINK Technology Limited and others
+# Copyright(c) 2020 to 2021 ZettaScale Technology and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/cmake/Modules/Codecov/codecov.cmake
+++ b/cmake/Modules/Codecov/codecov.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020 ADLINK Technology Limited and others
+# Copyright(c) 2020 to 2021 ZettaScale Technology and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
-# Copyright(c) 2020 ADLINK Technology Limited and others
-# Copyright(c) 2021 Apex.AI Inc. All rights reserved.
+# Copyright(c) 2020 to 2021 ZettaScale Technology and others
+# Copyright(c) 2021 Apex.AI, Inc
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/docs/manual/ddscxx.rst
+++ b/docs/manual/ddscxx.rst
@@ -1,5 +1,5 @@
 ..
-   Copyright(c) 2020 ADLINK Technology Limited and others
+   Copyright(c) 2020 ZettaScale Technology and others
 
    This program and the accompanying materials are made available under the
    terms of the Eclipse Public License v. 2.0 which is available at

--- a/docs/manual/idlcxx.rst
+++ b/docs/manual/idlcxx.rst
@@ -1,5 +1,5 @@
 ..
-   Copyright(c) 2021 ADLINK Technology Limited and others
+   Copyright(c) 2021 ZettaScale Technology and others
 
    This program and the accompanying materials are made available under the
    terms of the Eclipse Public License v. 2.0 which is available at

--- a/docs/manual/index.rst
+++ b/docs/manual/index.rst
@@ -1,5 +1,5 @@
 ..
-   Copyright(c) 2020 ADLINK Technology Limited and others
+   Copyright(c) 2020 to 2021 ZettaScale Technology and others
 
    This program and the accompanying materials are made available under the
    terms of the Eclipse Public License v. 2.0 which is available at

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020 ADLINK Technology Limited and others
+# Copyright(c) 2020 to 2022 ZettaScale Technology and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/examples/ddscxx_examples.rst
+++ b/examples/ddscxx_examples.rst
@@ -1,5 +1,5 @@
 ..
-   Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+   Copyright(c) 2006 to 2020 ZettaScale Technology and others
 
    This program and the accompanying materials are made available under the
    terms of the Eclipse Public License v. 2.0 which is available at

--- a/examples/helloworld/CMakeLists.txt
+++ b/examples/helloworld/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020 ADLINK Technology Limited and others
+# Copyright(c) 2020 to 2022 ZettaScale Technology and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/examples/helloworld/HelloWorldData.idl
+++ b/examples/helloworld/HelloWorldData.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/examples/helloworld/publisher.cpp
+++ b/examples/helloworld/publisher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/examples/helloworld/readme.rst
+++ b/examples/helloworld/readme.rst
@@ -1,5 +1,5 @@
 ..
-   Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+   Copyright(c) 2006 to 2022 ZettaScale Technology and others
 
    This program and the accompanying materials are made available under the
    terms of the Eclipse Public License v. 2.0 which is available at

--- a/examples/helloworld/subscriber.cpp
+++ b/examples/helloworld/subscriber.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020 ADLINK Technology Limited and others
+# Copyright(c) 2020 to 2021 ZettaScale Technology and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/CMakeLists.txt
+++ b/src/ddscxx/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2020 ADLINK Technology Limited and others
+# Copyright(c) 2020 to 2022 ZettaScale Technology and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/documentation.cmake
+++ b/src/ddscxx/documentation.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2022 ADLINK Technology Limited and others
+# Copyright(c) 2022 ZettaScale Technology and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/cond/detail/Condition.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/Condition.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/cond/detail/GuardCondition.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/GuardCondition.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/cond/detail/StatusCondition.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/StatusCondition.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/cond/detail/TConditionImpl.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/TConditionImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/cond/detail/TGuardConditionImpl.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/TGuardConditionImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/cond/detail/TStatusConditionImpl.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/TStatusConditionImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/cond/detail/TWaitSetImpl.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/TWaitSetImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/cond/detail/WaitSet.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/WaitSet.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/detail/BuiltinTopicTypes.hpp
+++ b/src/ddscxx/include/dds/core/detail/BuiltinTopicTypes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/detail/ReferenceImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/ReferenceImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/detail/TEntityImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/TEntityImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/detail/TEntityQosImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/TEntityQosImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/detail/TInstanceHandleImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/TInstanceHandleImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/detail/TQosProviderImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/TQosProviderImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/detail/Value.hpp
+++ b/src/ddscxx/include/dds/core/detail/Value.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/detail/WeakReferenceImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/WeakReferenceImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/detail/array.hpp
+++ b/src/ddscxx/include/dds/core/detail/array.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/detail/conformance.hpp
+++ b/src/ddscxx/include/dds/core/detail/conformance.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/detail/ddscore.hpp
+++ b/src/ddscxx/include/dds/core/detail/ddscore.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/detail/inttypes.hpp
+++ b/src/ddscxx/include/dds/core/detail/inttypes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/detail/macros.hpp
+++ b/src/ddscxx/include/dds/core/detail/macros.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/detail/module_docs.hpp
+++ b/src/ddscxx/include/dds/core/detail/module_docs.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/detail/ref_traits.hpp
+++ b/src/ddscxx/include/dds/core/detail/ref_traits.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/policy/detail/TCorePolicyImpl.hpp
+++ b/src/ddscxx/include/dds/core/policy/detail/TCorePolicyImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/policy/detail/TQosPolicyCountImpl.hpp
+++ b/src/ddscxx/include/dds/core/policy/detail/TQosPolicyCountImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/status/detail/TStatusImpl.hpp
+++ b/src/ddscxx/include/dds/core/status/detail/TStatusImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/xtypes/detail/Annotation.hpp
+++ b/src/ddscxx/include/dds/core/xtypes/detail/Annotation.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/xtypes/detail/CollectionTypes.hpp
+++ b/src/ddscxx/include/dds/core/xtypes/detail/CollectionTypes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/xtypes/detail/DynamicData.hpp
+++ b/src/ddscxx/include/dds/core/xtypes/detail/DynamicData.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/xtypes/detail/DynamicType.hpp
+++ b/src/ddscxx/include/dds/core/xtypes/detail/DynamicType.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/xtypes/detail/MemberType.hpp
+++ b/src/ddscxx/include/dds/core/xtypes/detail/MemberType.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/xtypes/detail/PrimitiveTypes.hpp
+++ b/src/ddscxx/include/dds/core/xtypes/detail/PrimitiveTypes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/xtypes/detail/StructType.hpp
+++ b/src/ddscxx/include/dds/core/xtypes/detail/StructType.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/xtypes/detail/TypeProvider.hpp
+++ b/src/ddscxx/include/dds/core/xtypes/detail/TypeProvider.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/xtypes/detail/UnionCase.hpp
+++ b/src/ddscxx/include/dds/core/xtypes/detail/UnionCase.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/core/xtypes/detail/UnionType.hpp
+++ b/src/ddscxx/include/dds/core/xtypes/detail/UnionType.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/domain/detail/TDomainParticipantImpl.hpp
+++ b/src/ddscxx/include/dds/domain/detail/TDomainParticipantImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/domain/detail/ddsdomain.hpp
+++ b/src/ddscxx/include/dds/domain/detail/ddsdomain.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/pub/detail/AnyDataWriter.hpp
+++ b/src/ddscxx/include/dds/pub/detail/AnyDataWriter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/pub/detail/CoherentSet.hpp
+++ b/src/ddscxx/include/dds/pub/detail/CoherentSet.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/pub/detail/SuspendedPublication.hpp
+++ b/src/ddscxx/include/dds/pub/detail/SuspendedPublication.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/pub/detail/TAnyDataWriterImpl.hpp
+++ b/src/ddscxx/include/dds/pub/detail/TAnyDataWriterImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/pub/detail/TCoherentSetImpl.hpp
+++ b/src/ddscxx/include/dds/pub/detail/TCoherentSetImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/pub/detail/TPublisherImpl.hpp
+++ b/src/ddscxx/include/dds/pub/detail/TPublisherImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/pub/detail/TSuspendedPublicationImpl.hpp
+++ b/src/ddscxx/include/dds/pub/detail/TSuspendedPublicationImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/pub/detail/ddspub.hpp
+++ b/src/ddscxx/include/dds/pub/detail/ddspub.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/pub/detail/discovery.hpp
+++ b/src/ddscxx/include/dds/pub/detail/discovery.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/pub/detail/find.hpp
+++ b/src/ddscxx/include/dds/pub/detail/find.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/cond/detail/ReadCondition.hpp
+++ b/src/ddscxx/include/dds/sub/cond/detail/ReadCondition.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/cond/detail/TQueryConditionImpl.hpp
+++ b/src/ddscxx/include/dds/sub/cond/detail/TQueryConditionImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/cond/detail/TReadConditionImpl.hpp
+++ b/src/ddscxx/include/dds/sub/cond/detail/TReadConditionImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/AnyDataReader.hpp
+++ b/src/ddscxx/include/dds/sub/detail/AnyDataReader.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/CoherentAccess.hpp
+++ b/src/ddscxx/include/dds/sub/detail/CoherentAccess.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/DataReader.hpp
+++ b/src/ddscxx/include/dds/sub/detail/DataReader.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/GenerationCount.hpp
+++ b/src/ddscxx/include/dds/sub/detail/GenerationCount.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/LoanedSamples.hpp
+++ b/src/ddscxx/include/dds/sub/detail/LoanedSamples.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/LoanedSamplesImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/LoanedSamplesImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/Manipulators.hpp
+++ b/src/ddscxx/include/dds/sub/detail/Manipulators.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/Query.hpp
+++ b/src/ddscxx/include/dds/sub/detail/Query.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/Rank.hpp
+++ b/src/ddscxx/include/dds/sub/detail/Rank.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/SampleInfo.hpp
+++ b/src/ddscxx/include/dds/sub/detail/SampleInfo.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/SamplesHolder.hpp
+++ b/src/ddscxx/include/dds/sub/detail/SamplesHolder.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/SharedSamples.hpp
+++ b/src/ddscxx/include/dds/sub/detail/SharedSamples.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/SharedSamplesImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/SharedSamplesImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/TAnyDataReaderImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TAnyDataReaderImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/TCoherentAccessImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TCoherentAccessImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/TGenerationCountImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TGenerationCountImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/TQueryImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TQueryImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/TRankImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TRankImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/TSampleImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TSampleImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/TSampleInfoImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TSampleInfoImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/TSampleRefImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TSampleRefImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/TSubscriberImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TSubscriberImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/ddssub.hpp
+++ b/src/ddscxx/include/dds/sub/detail/ddssub.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/discovery.hpp
+++ b/src/ddscxx/include/dds/sub/detail/discovery.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/detail/find.hpp
+++ b/src/ddscxx/include/dds/sub/detail/find.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/sub/status/detail/DataStateImpl.hpp
+++ b/src/ddscxx/include/dds/sub/status/detail/DataStateImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/topic/detail/AnyTopic.hpp
+++ b/src/ddscxx/include/dds/topic/detail/AnyTopic.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/topic/detail/Filter.hpp
+++ b/src/ddscxx/include/dds/topic/detail/Filter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/topic/detail/TAnyTopicImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TAnyTopicImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/topic/detail/TBuiltinTopicImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TBuiltinTopicImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/topic/detail/TBuiltinTopicKeyImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TBuiltinTopicKeyImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/topic/detail/TContentFilteredTopicImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TContentFilteredTopicImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/topic/detail/TFilterImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TFilterImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/topic/detail/TTopicDescriptionImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TTopicDescriptionImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/topic/detail/Topic.hpp
+++ b/src/ddscxx/include/dds/topic/detail/Topic.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/topic/detail/TopicDescription.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TopicDescription.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/topic/detail/TopicInstanceImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TopicInstanceImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/topic/detail/ddstopic.hpp
+++ b/src/ddscxx/include/dds/topic/detail/ddstopic.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/topic/detail/discovery.hpp
+++ b/src/ddscxx/include/dds/topic/detail/discovery.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/dds/topic/detail/find.hpp
+++ b/src/ddscxx/include/dds/topic/detail/find.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/ForwardDeclarations.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/ForwardDeclarations.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/DDScObjectDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/DDScObjectDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/EntityDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/EntityDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/EntityRegistry.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/EntityRegistry.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/EntitySet.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/EntitySet.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/InstanceHandleDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/InstanceHandleDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/ListenerDispatcher.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/ListenerDispatcher.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/MiscUtils.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/MiscUtils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/Missing.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/Missing.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/Mutex.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/Mutex.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/ObjectDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/ObjectDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/ObjectSet.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/ObjectSet.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/QosProviderDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/QosProviderDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/ReportUtils.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/ReportUtils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/ScopedLock.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/ScopedLock.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/TimeHelper.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/TimeHelper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/WeakReferenceSet.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/WeakReferenceSet.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2021 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_enums.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_enums.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2021 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2021 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2021 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2021 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2021 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/ConditionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/ConditionDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/FunctorHolder.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/FunctorHolder.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/GuardConditionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/GuardConditionDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/ShadowParticipant.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/ShadowParticipant.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/StatusConditionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/StatusConditionDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/WaitSetDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/WaitSetDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/config.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/config.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/Policy.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/Policy.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/PolicyDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/PolicyDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/ProprietaryPolicyKind.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/ProprietaryPolicyKind.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/QosPolicyCountDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/QosPolicyCountDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/TPolicy.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/TPolicy.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/status/StatusDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/status/StatusDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/type_helpers.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/type_helpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/domain/Domain.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/domain/Domain.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainParticipantListener.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainParticipantListener.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainParticipantRegistry.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainParticipantRegistry.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainWrap.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainWrap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/domain/qos/DomainParticipantQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/domain/qos/DomainParticipantQosDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/CoherentSetDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/CoherentSetDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/PublisherDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/PublisherDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/SuspendedPublicationDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/SuspendedPublicationDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/qos/PublisherQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/qos/PublisherQosDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/BuiltinSubscriberDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/BuiltinSubscriberDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/CoherentAccessDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/CoherentAccessDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/GenerationCountImpl.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/GenerationCountImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/QueryDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/QueryDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/RankImpl.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/RankImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/SampleInfoImpl.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/SampleInfoImpl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/SubscriberDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/SubscriberDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/cond/QueryConditionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/cond/QueryConditionDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/cond/ReadConditionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/cond/ReadConditionDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/qos/SubscriberQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/qos/SubscriberQosDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/AnyTopicDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/AnyTopicDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/AnyTopicListener.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/AnyTopicListener.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopic.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicCopy.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicCopy.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicKeyDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicKeyDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicTraits.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicTraits.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/CDRBlob.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/CDRBlob.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/FilterDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/FilterDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/TBuiltinTopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/TBuiltinTopic.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicListener.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicListener.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicTraits.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicTraits.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -1,6 +1,5 @@
 /*
- * Copyright(c) 2022 ZettaScale Technology and others
- * Copyright(c) 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2020 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/discovery.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/discovery.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/find.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/find.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/hash.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/hash.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/qos/TopicQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/qos/TopicQosDelegate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/dds/core/Duration.cpp
+++ b/src/ddscxx/src/dds/core/Duration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/dds/core/Exception.cpp
+++ b/src/ddscxx/src/dds/core/Exception.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/dds/core/Reference.cpp
+++ b/src/ddscxx/src/dds/core/Reference.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/dds/core/Time.cpp
+++ b/src/ddscxx/src/dds/core/Time.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/dds/core/policy/CorePolicy.cpp
+++ b/src/ddscxx/src/dds/core/policy/CorePolicy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/dds/core/status/State.cpp
+++ b/src/ddscxx/src/dds/core/status/State.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/dds/domain/discovery.cpp
+++ b/src/ddscxx/src/dds/domain/discovery.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/dds/domain/find.cpp
+++ b/src/ddscxx/src/dds/domain/find.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/dds/pub/pubdiscovery.cpp
+++ b/src/ddscxx/src/dds/pub/pubdiscovery.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/dds/sub/status/DataState.cpp
+++ b/src/ddscxx/src/dds/sub/status/DataState.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/dds/sub/subdiscovery.cpp
+++ b/src/ddscxx/src/dds/sub/subdiscovery.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/dds/sub/subfind.cpp
+++ b/src/ddscxx/src/dds/sub/subfind.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/DDScObjectDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/DDScObjectDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/EntityDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/EntityDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/EntitySet.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/EntitySet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/InstanceHandleDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/InstanceHandleDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/ListenerDispatcher.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/ListenerDispatcher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/MiscUtils.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/MiscUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/Mutex.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/Mutex.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/ObjectDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/ObjectDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/ObjectSet.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/ObjectSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/ReportUtils.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/ReportUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2021 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/cdr_stream.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/cdr_stream.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2020 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/entity_properties.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/entity_properties.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2021 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2020 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2020 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/ConditionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/ConditionDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/GuardConditionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/GuardConditionDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/ShadowParticipant.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/ShadowParticipant.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/StatusConditionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/StatusConditionDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/WaitSetDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/WaitSetDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/policy/PolicyDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/policy/PolicyDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/Domain.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/Domain.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantRegistry.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantRegistry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainWrap.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainWrap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/qos/DomainParticipantQosDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/qos/DomainParticipantQosDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/PublisherDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/PublisherDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/qos/PublisherQosDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/qos/PublisherQosDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/BuiltinSubscriberDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/BuiltinSubscriberDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/QueryDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/QueryDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/SubscriberDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/SubscriberDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/cond/QueryConditionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/cond/QueryConditionDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/cond/ReadConditionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/cond/ReadConditionDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/qos/SubscriberQosDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/qos/SubscriberQosDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/AnyTopicDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/AnyTopicDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/FilterDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/FilterDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/find.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/find.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/hash.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/hash.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2020 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/qos/TopicQosDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/qos/TopicQosDelegate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/Bounded.cpp
+++ b/src/ddscxx/tests/Bounded.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/CDRStreamer.cpp
+++ b/src/ddscxx/tests/CDRStreamer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/CMakeLists.txt
+++ b/src/ddscxx/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+# Copyright(c) 2006 to 2022 ZettaScale Technology and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/Condition.cpp
+++ b/src/ddscxx/tests/Condition.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/Conversions.cpp
+++ b/src/ddscxx/tests/Conversions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/DataReader.cpp
+++ b/src/ddscxx/tests/DataReader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/DataReaderManipulatorSelector.cpp
+++ b/src/ddscxx/tests/DataReaderManipulatorSelector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/DataReaderSelector.cpp
+++ b/src/ddscxx/tests/DataReaderSelector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/DataWriter.cpp
+++ b/src/ddscxx/tests/DataWriter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/DomainParticipant.cpp
+++ b/src/ddscxx/tests/DomainParticipant.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/Duration.cpp
+++ b/src/ddscxx/tests/Duration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/Exception.cpp
+++ b/src/ddscxx/tests/Exception.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/ExtendedTypes.cpp
+++ b/src/ddscxx/tests/ExtendedTypes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/FindDataReader.cpp
+++ b/src/ddscxx/tests/FindDataReader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/FindDataWriter.cpp
+++ b/src/ddscxx/tests/FindDataWriter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/FindTopic.cpp
+++ b/src/ddscxx/tests/FindTopic.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/GeneratedEntities.cpp
+++ b/src/ddscxx/tests/GeneratedEntities.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/Listener.cpp
+++ b/src/ddscxx/tests/Listener.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/ListenerStress.cpp
+++ b/src/ddscxx/tests/ListenerStress.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/Publisher.cpp
+++ b/src/ddscxx/tests/Publisher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/Qos.cpp
+++ b/src/ddscxx/tests/Qos.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/Query.cpp
+++ b/src/ddscxx/tests/Query.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/Regression.cpp
+++ b/src/ddscxx/tests/Regression.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/Serdata.cpp
+++ b/src/ddscxx/tests/Serdata.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/SharedMemory.cpp
+++ b/src/ddscxx/tests/SharedMemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/Subscriber.cpp
+++ b/src/ddscxx/tests/Subscriber.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/Time.cpp
+++ b/src/ddscxx/tests/Time.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/Topic.cpp
+++ b/src/ddscxx/tests/Topic.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/Util.cpp
+++ b/src/ddscxx/tests/Util.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/Util.hpp
+++ b/src/ddscxx/tests/Util.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/WaitSet.cpp
+++ b/src/ddscxx/tests/WaitSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2006 to 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2006 to 2021 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/ddscxx/tests/config_simple.xml.in
+++ b/src/ddscxx/tests/config_simple.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-  Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+  Copyright(c) 2006 to 2022 ZettaScale Technology and others
 
   This program and the accompanying materials are made available under the
   terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/idlcxx/CMakeLists.txt
+++ b/src/idlcxx/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2021 ADLINK Technology Limited and others
+# Copyright(c) 2020 to 2021 ZettaScale Technology and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/idlcxx/Generate.cmake
+++ b/src/idlcxx/Generate.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright(c) 2021 ADLINK Technology Limited and others
+# Copyright(c) 2020 to 2022 ZettaScale Technology and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2020 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/idlcxx/src/generator.h
+++ b/src/idlcxx/src/generator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2021 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2021 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/idlcxx/src/traits.c
+++ b/src/idlcxx/src/traits.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020 ADLINK Technology Limited and others
+ * Copyright(c) 2020 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/idlcxx/src/types.c
+++ b/src/idlcxx/src/types.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 ADLINK Technology Limited and others
+ * Copyright(c) 2021 to 2022 ZettaScale Technology and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at


### PR DESCRIPTION
This updates the copyright comments at the beginning of the files to reflect this change.

Companion to https://github.com/eclipse-cyclonedds/cyclonedds/pull/1254: I confess to completely forgetting to update them also in the C++ and Python repositories ...