### PR TITLE
Fix compilation for clang on debian

### DIFF
--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -1095,7 +1095,7 @@ print_constructed_type_close(
   static const char *pfmt =
     "\n  props.m_members_by_seq.push_back(final_entry());\n\n"
     "  props.finish(keylist);\n"
-    "  initialized.store(true, std::memory_order::memory_order_release);\n"
+    "  initialized.store(true, std::memory_order_release);\n"
     "  return props;\n"
     "}\n\n";
 


### PR DESCRIPTION
This fix was needed for compilation to succeed on my machine. There are more references to std::memory_order_* in the repo, but this was the only reference to std::memory_order::memory_order_release. See also https://en.cppreference.com/w/cpp/atomic/memory_order