### PR TITLE
Update to 0.9.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 cmake_minimum_required(VERSION 3.10)
-project(CycloneDDS-CXX VERSION 0.9.0 LANGUAGES C CXX)
+project(CycloneDDS-CXX VERSION 0.9.1 LANGUAGES C CXX)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
 

--- a/examples/helloworld/readme.rst
+++ b/examples/helloworld/readme.rst
@@ -41,5 +41,5 @@ Running the example
 It is recommended that you run the subscriber and publisher in separate terminals to avoid mixing the output.
 
 - Open 2 terminals.
-- In the first terminal start the subscriber by running ddscxxHelloWorldSubscriber
-- In the second terminal start the publisher by running ddscxxHelloWorldPublisher
+- In the first terminal start the subscriber by running ddscxxHelloworldSubscriber
+- In the second terminal start the publisher by running ddscxxHelloworldPublisher

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/Missing.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/Missing.hpp
@@ -20,7 +20,7 @@
 
 //since these helpers are only introduced from c++14 onwards
 
-#if __cplusplus == 201103L
+#if __cplusplus < 201402L
 namespace std {
   template< bool B, class T, class F >
   using conditional_t = typename std::conditional<B, T, F>::type;

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -59,8 +59,10 @@ bool to_key(const T& tokey, ddsi_keyhash_t& hash)
   } else
   {
     basic_cdr_stream str(endianness::big_endian);
-    if (!move(str, tokey, true))
+    if (!move(str, tokey, true)) {
+      assert(false);
       return false;
+    }
     size_t sz = str.position();
     size_t padding = 0;
     if (sz < 16)
@@ -69,8 +71,10 @@ bool to_key(const T& tokey, ddsi_keyhash_t& hash)
     if (padding)
       memset(buffer.data() + sz, 0x0, padding);
     str.set_buffer(buffer.data(), sz);
-    if (!write(str, tokey, true))
+    if (!write(str, tokey, true)) {
+      assert(false);
       return false;
+    }
     static bool (*fptr)(const std::vector<unsigned char>&, ddsi_keyhash_t&) = NULL;
     if (fptr == NULL)
     {

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.cpp
@@ -29,7 +29,7 @@ entity_properties_t& basic_cdr_stream::next_entity(entity_properties_t &props, b
 
 bool basic_cdr_stream::start_struct(entity_properties_t &props)
 {
-  if (props.requires_xtypes() && status(unsupported_xtypes))
+  if (!is_key() && props.requires_xtypes() && status(unsupported_xtypes))
     return false;
 
   return cdr_stream::start_struct(props);

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/cdr_stream.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/cdr_stream.cpp
@@ -11,6 +11,7 @@
  */
 #include <cstring>
 #include <assert.h>
+#include <algorithm>
 
 #include <org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp>
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/cdr_stream.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/cdr_stream.cpp
@@ -194,7 +194,7 @@ void cdr_stream::check_struct_completeness(entity_properties_t &props, member_li
 
   while (*it) {
     if (it->must_understand_local && !it->is_present) {
-      status(must_understand_fail);
+      (void)status(must_understand_fail);
       props.is_present = false;
       break;
     }

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.cpp
@@ -254,9 +254,7 @@ bool xcdr_v2_stream::start_struct(entity_properties_t &props)
     }
   }
 
-  cdr_stream::start_struct(props);
-
-  return true;
+  return cdr_stream::start_struct(props);
 }
 
 bool xcdr_v2_stream::finish_struct(entity_properties_t &props)

--- a/src/ddscxx/tests/CDRStreamer.cpp
+++ b/src/ddscxx/tests/CDRStreamer.cpp
@@ -122,9 +122,9 @@ void VerifyReadOneDeeper(const bytes &in, const T& out, S stream, bool as_key)
 VerifyRead(normal_bytes, test_struct, streamer, false);\
 VerifyRead(key_bytes, key_struct, streamer, true);
 
-#define read_test_fail(test_struct, key_struct, streamer)\
+#define read_test_fail(test_struct, key_struct, key_bytes, streamer)\
 VerifyRead(bytes(256, 0x0), test_struct, streamer, false, false);\
-VerifyRead(bytes(256, 0x0), key_struct, streamer, true, false);
+VerifyRead(key_bytes, key_struct, streamer, true);
 
 #define read_deeper_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
 VerifyRead(normal_bytes, test_struct, streamer, false);\
@@ -134,17 +134,17 @@ VerifyReadOneDeeper(key_bytes, key_struct, streamer, true);
 VerifyWrite(test_struct, normal_bytes, streamer, false);\
 VerifyWrite(key_struct, key_bytes, streamer, true);
 
-#define write_test_fail(test_struct, key_struct, streamer)\
+#define write_test_fail(test_struct, key_struct, key_bytes, streamer)\
 VerifyWrite(test_struct, bytes(256, 0x0), streamer, false, false);\
-VerifyWrite(test_struct, bytes(256, 0x0), streamer, true, false);
+VerifyWrite(test_struct, key_bytes, streamer, true);
 
 #define readwrite_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
 read_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
 write_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)
 
-#define readwrite_test_fail(test_struct, key_struct, streamer)\
-read_test_fail(test_struct, key_struct, streamer)\
-write_test_fail(test_struct, key_struct, streamer)
+#define readwrite_test_fail(test_struct, key_struct, key_bytes, streamer)\
+read_test_fail(test_struct, key_struct, key_bytes, streamer)\
+write_test_fail(test_struct, key_struct, key_bytes, streamer)
 
 #define readwrite_deeper_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
 read_deeper_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
@@ -161,7 +161,7 @@ readwrite_test(test_struct, key_struct, cdr_normal_bytes, key_bytes, xcdr_v1_str
 readwrite_test(test_struct, key_struct, cdr_normal_bytes, key_bytes, xcdr_v2_stream(endianness::big_endian))
 
 #define stream_test_fail_basic(test_struct, xcdr_v1_normal_bytes, xcdr_v2_normal_bytes, key_bytes)\
-readwrite_test_fail(test_struct, test_struct, basic_cdr_stream(endianness::big_endian))\
+readwrite_test_fail(test_struct, test_struct, key_bytes, basic_cdr_stream(endianness::big_endian))\
 readwrite_test(test_struct, test_struct, xcdr_v1_normal_bytes, key_bytes, xcdr_v1_stream(endianness::big_endian))\
 readwrite_test(test_struct, test_struct, xcdr_v2_normal_bytes, key_bytes, xcdr_v2_stream(endianness::big_endian))
 
@@ -650,7 +650,7 @@ TEST_F(CDRStreamer, cdr_optional)
   /* basic cdr does not support optional fields,
      therefore the streamer should enter error status
      when the streamer is asked to write them */
-  readwrite_test_fail(OFS, OFS, basic_cdr_stream(endianness::big_endian));
+  readwrite_test_fail(OFS, OFS, OFS_key, basic_cdr_stream(endianness::big_endian));
 
   readwrite_test(OFS, OFS, OFS_xcdr_v1_normal, OFS_key, xcdr_v1_stream(endianness::big_endian))
   readwrite_test(OAS, OAS, OFS_xcdr_v1_normal, OFS_key, xcdr_v1_stream(endianness::big_endian))

--- a/src/ddscxx/tests/CMakeLists.txt
+++ b/src/ddscxx/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ idlcxx_generate(TARGET ddscxx_test_types FILES
   data/EntityProperties_pragma.idl
   data/ExtendedTypesModels.idl
   data/RegressionModels.idl
+  data/RegressionModels_pragma.idl
   data/ExternalModels.idl
   data/TraitsModels.idl
   WARNINGS no-implicit-extensibility)

--- a/src/ddscxx/tests/Regression.cpp
+++ b/src/ddscxx/tests/Regression.cpp
@@ -322,3 +322,21 @@ TEST_F(Regression, typedef_of_sequence_of_enums)
     };
   readwrite_test(s, struct_seq_e1_bytes, xcdr_v2_stream(endianness::little_endian));
 }
+
+TEST_F(Regression, key_value_of_appendables)
+{
+  s_final s_f;
+  s_appendable s_a;
+
+  s_f.s() = "abcdef";
+  s_a.s() = "abcdef";
+
+  ddsi_keyhash_t kh_f, kh_a;
+
+  unsigned char k[] = {0xcd, 0x34, 0x4d, 0x59, 0xec, 0x90, 0xb9, 0x62, 0xca, 0xb1, 0x41, 0xcf, 0x2a, 0x5d, 0xa6, 0xcf};
+
+  ASSERT_TRUE(to_key<s_final>(s_f, kh_f));
+  EXPECT_EQ(0, memcmp(k, kh_f.value, 16));
+  ASSERT_TRUE(to_key<s_appendable>(s_a, kh_a));
+  EXPECT_EQ(0, memcmp(k, kh_a.value, 16));
+}

--- a/src/ddscxx/tests/Regression.cpp
+++ b/src/ddscxx/tests/Regression.cpp
@@ -12,6 +12,7 @@
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "RegressionModels.hpp"
+#include "RegressionModels_pragma.hpp"
 
 typedef std::vector<unsigned char> bytes;
 

--- a/src/ddscxx/tests/data/RegressionModels.idl
+++ b/src/ddscxx/tests/data/RegressionModels.idl
@@ -166,4 +166,14 @@ union u_struct_arr switch (unsigned long) {
   u_struct_arr c;
 };
 
+@final
+struct s_final {
+  @key string s;
+};
+
+@appendable
+struct s_appendable {
+  @key string s;
+};
+
 };

--- a/src/ddscxx/tests/data/RegressionModels_pragma.idl
+++ b/src/ddscxx/tests/data/RegressionModels_pragma.idl
@@ -1,0 +1,16 @@
+module regression_models {
+
+struct Nested {
+short Member_Nested;
+};
+
+struct Base {
+Nested Member_Base;
+};
+
+struct Derived : Base {
+short Member_Derived;
+};
+#pragma keylist Derived Member_Derived
+
+};

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -1006,9 +1006,11 @@ process_keylist(
 {
   const idl_key_t *key = NULL;
 
-  IDL_FOREACH(key, _struct->keylist->keys) {
-    if (process_key(streams, _struct, key))
-      return IDL_RETCODE_NO_MEMORY;
+  if (_struct->keylist) {
+    IDL_FOREACH(key, _struct->keylist->keys) {
+      if (process_key(streams, _struct, key))
+        return IDL_RETCODE_NO_MEMORY;
+    }
   }
 
   return IDL_RETCODE_OK;
@@ -1158,7 +1160,7 @@ process_struct_contents(
   struct streams *streams)
 {
   idl_retcode_t ret = IDL_RETCODE_OK;
-  bool keylist = (pstate->config.flags & IDL_FLAG_KEYLIST) && _struct->keylist;
+  bool keylist_flag = (pstate->config.flags & IDL_FLAG_KEYLIST);
 
   size_t to_unroll = 1;
   const idl_struct_t *base = _struct;
@@ -1173,7 +1175,7 @@ process_struct_contents(
     while (depth_to_go--)
       base =  (const idl_struct_t *)(base->inherit_spec->base);
 
-    if (keylist
+    if (keylist_flag
      && (ret = process_keylist(streams, base)))
       return ret;
 

--- a/src/idlcxx/src/traits.c
+++ b/src/idlcxx/src/traits.c
@@ -115,12 +115,12 @@ emit_traits(
     "}\n\n";
   static const char *type_info_hdr1 =
     "#ifdef DDSCXX_HAS_TYPE_DISCOVERY\n"
-    "template<> constexpr const unsigned int TopicTraits<%1$s>::type_map_blob_sz = %2$u;\n"
-    "template<> constexpr const unsigned int TopicTraits<%1$s>::type_info_blob_sz = %3$u;\n"
-    "template<> constexpr const unsigned char TopicTraits<%1$s>::type_map_blob[] = {\n";
+    "template<> const unsigned int TopicTraits<%1$s>::type_map_blob_sz = %2$u;\n"
+    "template<> const unsigned int TopicTraits<%1$s>::type_info_blob_sz = %3$u;\n"
+    "template<> const unsigned char TopicTraits<%1$s>::type_map_blob[] = {\n";
   static const char *type_info_hdr2 =
     " };\n"
-    "template<> constexpr const unsigned char TopicTraits<%1$s>::type_info_blob[] = {\n";
+    "template<> const unsigned char TopicTraits<%1$s>::type_info_blob[] = {\n";
 
   if (IDL_PRINTA(&name, get_cpp11_fully_scoped_name, node, gen) < 0 ||
       idl_fprintf(gen->header.handle, fmt, name, name+2) < 0)
@@ -151,11 +151,11 @@ emit_traits(
   idl_typeinfo_typemap_t blobs;
   if (gen->config && gen->config->generate_typeinfo_typemap && gen->config->generate_type_info) {
     if (gen->config->generate_typeinfo_typemap(pstate, (const idl_node_t*)node, &blobs) ||
-      idl_fprintf(gen->header.handle, type_info_hdr1, name, blobs.typemap_size, blobs.typeinfo_size) < 0 ||
-      write_blob(gen->header.handle, blobs.typemap, blobs.typemap_size) ||
-      idl_fprintf(gen->header.handle, type_info_hdr2, name) < 0 ||
-      write_blob(gen->header.handle, blobs.typeinfo, blobs.typeinfo_size) ||
-      idl_fprintf(gen->header.handle, " };\n#endif //DDSCXX_HAS_TYPE_DISCOVERY\n\n") < 0)
+      idl_fprintf(gen->impl.handle, type_info_hdr1, name, blobs.typemap_size, blobs.typeinfo_size) < 0 ||
+      write_blob(gen->impl.handle, blobs.typemap, blobs.typemap_size) ||
+      idl_fprintf(gen->impl.handle, type_info_hdr2, name) < 0 ||
+      write_blob(gen->impl.handle, blobs.typeinfo, blobs.typeinfo_size) ||
+      idl_fprintf(gen->impl.handle, " };\n#endif //DDSCXX_HAS_TYPE_DISCOVERY\n\n") < 0)
     ret = IDL_RETCODE_NO_MEMORY;
 
     //cleanup typeinfo_typemap blobs


### PR DESCRIPTION
This fixes:

* linker problems caused by the type object being defined in the header file
* a build issue with Visual Studio 2017
* issues compiling IDL: nested structures 
* key serialization for types requiring XCDR2
* some issues noted by Coverity (likely not affecting behaviour)
* a typo in the README