### PR TITLE
Fix issue 276 and type/topic discovery issues

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicTraits.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicTraits.hpp
@@ -166,11 +166,15 @@ public:
      */
     static ddsi_typeid_t* getTypeId(const struct ddsi_sertype *, ddsi_typeid_kind_t kind)
     {
-        auto ptr = TopicTraits<TOPIC>::getTypeInfo(NULL);
-        auto id = ddsi_typeinfo_typeid(ptr, kind);
-        ddsi_typeinfo_fini(ptr);
-        ddsrt_free(ptr);
-        return id;
+        auto ti = getTypeInfo(NULL);
+        if (ti) {
+            auto id = ddsi_typeinfo_typeid(ti, kind);
+            ddsi_typeinfo_fini(ti);
+            ddsrt_free(ti);
+            return id;
+        } else {
+            return nullptr;
+        }
     }
 
     /**
@@ -183,32 +187,73 @@ public:
      */
     static ddsi_typemap_t* getTypeMap(const struct ddsi_sertype *)
     {
-        ddsi_sertype_cdr_data cdr{TopicTraits<TOPIC>::type_map_blob_sz, const_cast<uint8_t*>(TopicTraits<TOPIC>::type_map_blob)};
+        ddsi_sertype_cdr_data_t cdr{type_map_blob_sz(), const_cast<uint8_t*>(type_map_blob())};
         return ddsi_typemap_deser(&cdr);
     }
 
     /**
      * @brief Returns the type info for TOPIC.
      *
-     * Takes the type info blob for this topic which is part of thegenerated type traits, and deserializes
+     * Takes the type info blob for this topic which is part of the generated type traits, and deserializes
      * the type info from this blob.
      *
      * @return A pointer to the typeinfo for this topic.
      */
     static ddsi_typeinfo_t* getTypeInfo(const struct ddsi_sertype *)
     {
-        ddsi_sertype_cdr_data cdr{TopicTraits<TOPIC>::type_info_blob_sz, const_cast<uint8_t*>(TopicTraits<TOPIC>::type_info_blob)};
+        ddsi_sertype_cdr_data_t cdr{type_info_blob_sz(), const_cast<uint8_t*>(type_info_blob())};
         return ddsi_typeinfo_deser(&cdr);
     }
 
-private:
-    static const unsigned int type_map_blob_sz; /**< Size of blob of the cdr serialized type map, needs to be instantiated for all declared types.*/
-    static const unsigned int type_info_blob_sz; /**< Size of blob of the cdr serialized type info, needs to be instantiated for all declared types.*/
-    static const unsigned char type_map_blob[]; /**< Blob of the cdr serialized type map, needs to be instantiated for all declared types.*/
-    static const unsigned char type_info_blob[]; /**< Blob of the cdr serialized type info, needs to be instantiated for all declared types.*/
+    /**
+     * @brief Returns size of the blob of the cdr serialized type map.
+     *
+     * This function is a placeholder, it will be instantiated for all valid topics.
+     *
+     * @return The size of the serialized type map blob.
+     */
+    static constexpr unsigned int type_map_blob_sz()
+    {
+        return static_cast<unsigned int>(-1);
+    }
+
+    /**
+     * @brief Returns size of the blob of the cdr serialized type info.
+     *
+     * This function is a placeholder, it will be instantiated for all valid topics.
+     *
+     * @return The size of the serialized type info blob.
+     */
+    static constexpr unsigned int type_info_blob_sz()
+    {
+        return static_cast<unsigned int>(-1);
+    }
+
+    /**
+     * @brief Returns pointer to the blob of the cdr serialized type map.
+     *
+     * This function is a placeholder, it will be instantiated for all valid topics.
+     *
+     * @return Pointer to the serialized type map blob.
+     */
+    static inline const uint8_t * type_map_blob()
+    {
+        return nullptr;
+    }
+
+    /**
+     * @brief Returns pointer to the blob of the cdr serialized type info.
+     *
+     * This function is a placeholder, it will be instantiated for all valid topics.
+     *
+     * @return Pointer to the serialized type info blob.
+     */
+    static inline const uint8_t * type_info_blob()
+    {
+        return nullptr;
+    }
 #endif  //DDSCXX_HAS_TYPE_DISCOVERY
 
-public:
     /**
      * @brief Returns a pointer to the derived sertype.
      *

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -264,7 +264,7 @@ bool get_serialized_fixed_size(const T& sample, size_t &sz)
   if (!move(str, sample, K))
     return false;
   serialized_size = str.position();
-  initialized.store(true, std::memory_order::memory_order_release);
+  initialized.store(true, std::memory_order_release);
   sz = serialized_size;
   return true;
 }

--- a/src/ddscxx/tests/CMakeLists.txt
+++ b/src/ddscxx/tests/CMakeLists.txt
@@ -68,6 +68,11 @@ set(sources
   External.cpp
   DataModels.cpp)
 
+if (ENABLE_TYPE_DISCOVERY AND ENABLE_TOPIC_DISCOVERY)
+  # Add topic/type discovery tests
+  list(APPEND sources TopicTypeDiscovery.cpp)
+endif()
+
 if(ENABLE_SHM)
   # Add shared memory tests
   list(APPEND sources SharedMemory.cpp)

--- a/src/ddscxx/tests/TopicTypeDiscovery.cpp
+++ b/src/ddscxx/tests/TopicTypeDiscovery.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright(c) 2006 to 2022 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include "dds/dds.hpp"
+#include <gtest/gtest.h>
+#include "Space.hpp"
+
+using org::eclipse::cyclonedds::topic::TopicTraits;
+using TraitTest::StructDefault;
+using TraitTest::StructNested;
+using TraitTest::StructTopic;
+using TraitTest::UnionDefault;
+using TraitTest::UnionNested;
+using TraitTest::UnionTopic;
+
+template<class T>
+void test_traits(unsigned int map_sz, unsigned int info_sz, bool map_blob_present, bool info_blob_present)
+{
+  EXPECT_EQ(TopicTraits<T>::type_map_blob_sz(), map_sz);
+  EXPECT_EQ(TopicTraits<T>::type_info_blob_sz(), info_sz);
+  if (map_blob_present)
+    EXPECT_NE(TopicTraits<T>::type_map_blob(), nullptr);
+  else
+    EXPECT_EQ(TopicTraits<T>::type_map_blob(), nullptr);
+  if (info_blob_present)
+    EXPECT_NE(TopicTraits<T>::type_info_blob(), nullptr);
+  else
+    EXPECT_EQ(TopicTraits<T>::type_info_blob(), nullptr);
+}
+
+template<class T>
+void test_typemap(bool typemap_present)
+{
+  auto *tm = TopicTraits<T>::getTypeMap(nullptr);
+
+  if (typemap_present)
+    EXPECT_NE(tm, nullptr);
+  else
+    EXPECT_EQ(tm, nullptr);
+
+  if (tm) {
+    ddsi_typemap_fini(tm);
+    dds_free(tm);
+  }
+}
+
+template<class T>
+void test_typeinfo(bool typeinfo_present)
+{
+  auto *ti = TopicTraits<T>::getTypeInfo(nullptr);
+  if (typeinfo_present)
+    EXPECT_NE(ti, nullptr);
+  else
+    EXPECT_EQ(ti, nullptr);
+
+  if (ti) {
+    ddsi_typeinfo_fini(ti);
+    dds_free(ti);
+  }
+}
+
+template<class T, ddsi_typeid_kind_t kind>
+void test_typeid(bool typeid_present)
+{
+  auto *ti = TopicTraits<T>::getTypeId(nullptr, kind);
+  if (typeid_present)
+    EXPECT_NE(ti, nullptr);
+  else
+    EXPECT_EQ(ti, nullptr);
+
+  if (ti) {
+    ddsi_typeid_fini(ti);
+    dds_free(ti);
+  }
+}
+
+template<class T>
+void test_typeids(bool minimal_present,
+                  bool complete_present,
+                  bool fully_descriptive_present)
+{
+  test_typeid<T, DDSI_TYPEID_KIND_MINIMAL>(minimal_present);
+  test_typeid<T, DDSI_TYPEID_KIND_COMPLETE>(complete_present);
+  test_typeid<T, DDSI_TYPEID_KIND_FULLY_DESCRIPTIVE>(fully_descriptive_present);
+}
+
+TEST(TopicTypeDiscovery, blobs)
+{
+  test_traits<StructDefault>(202,100,true,true);
+  test_traits<StructNested>(static_cast<unsigned int>(-1),static_cast<unsigned int>(-1),false,false);
+  test_traits<StructTopic>(198,100,true,true);
+
+  test_traits<UnionDefault>(282,100,true,true);
+  test_traits<UnionNested>(static_cast<unsigned int>(-1),static_cast<unsigned int>(-1),false,false);
+  test_traits<UnionTopic>(282,100,true,true);
+}
+
+TEST(TopicTypeDiscovery, typemap)
+{
+  test_typemap<StructDefault>(true);
+  test_typemap<StructNested>(false);
+  test_typemap<StructTopic>(true);
+
+  test_typemap<UnionDefault>(true);
+  test_typemap<UnionNested>(false);
+  test_typemap<UnionTopic>(true);
+}
+
+TEST(TopicTypeDiscovery, typeinfo)
+{
+  test_typeinfo<StructDefault>(true);
+  test_typeinfo<StructNested>(false);
+  test_typeinfo<StructTopic>(true);
+
+  test_typeinfo<UnionDefault>(true);
+  test_typeinfo<UnionNested>(false);
+  test_typeinfo<UnionTopic>(true);
+}
+
+TEST(TopicTypeDiscovery, typeID)
+{
+  test_typeids<StructDefault>(true, true, true);
+  test_typeids<StructNested>(false, false, false);
+  test_typeids<StructTopic>(true, true, true);
+
+  test_typeids<UnionDefault>(true, true, true);
+  test_typeids<UnionNested>(false, false, false);
+  test_typeids<UnionTopic>(true, true, true);
+}

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -1137,7 +1137,7 @@ print_constructed_type_close(
   static const char *pfmt =
     "\n  entity_properties_t::finish(props, keylist);\n"
     "  props_end = props.data() + props.size();\n"
-    "  initialized.store(true, std::memory_order::memory_order_release);\n"
+    "  initialized.store(true, std::memory_order_release);\n"
     "  return props;\n"
     "}\n\n";
 

--- a/src/idlcxx/src/traits.c
+++ b/src/idlcxx/src/traits.c
@@ -113,14 +113,23 @@ emit_traits(
     "{\n"
     "  return extensibility::ext_%2$s;\n"
     "}\n\n";
-  static const char *type_info_hdr1 =
+  static const char *type_info_decl1 =
     "#ifdef DDSCXX_HAS_TYPE_DISCOVERY\n"
-    "template<> const unsigned int TopicTraits<%1$s>::type_map_blob_sz = %2$u;\n"
-    "template<> const unsigned int TopicTraits<%1$s>::type_info_blob_sz = %3$u;\n"
-    "template<> const unsigned char TopicTraits<%1$s>::type_map_blob[] = {\n";
-  static const char *type_info_hdr2 =
-    " };\n"
-    "template<> const unsigned char TopicTraits<%1$s>::type_info_blob[] = {\n";
+    "template<> constexpr unsigned int TopicTraits<%1$s>::type_map_blob_sz() { return %2$u; }\n"
+    "template<> constexpr unsigned int TopicTraits<%1$s>::type_info_blob_sz() { return %3$u; }\n"
+    "template<> inline const uint8_t * TopicTraits<%1$s>::type_map_blob() {\n"
+    "  static const uint8_t blob[] = {\n";
+  static const char *type_info_decl2 =
+    "};\n"
+    "  return blob;\n"
+    "}\n"
+    "template<> inline const uint8_t * TopicTraits<%1$s>::type_info_blob() {\n"
+    "  static const uint8_t blob[] = {\n";
+  static const char *type_info_decl3 =
+    "};\n"
+    "  return blob;\n"
+    "}\n"
+    "#endif //DDSCXX_HAS_TYPE_DISCOVERY\n\n";
 
   if (IDL_PRINTA(&name, get_cpp11_fully_scoped_name, node, gen) < 0 ||
       idl_fprintf(gen->header.handle, fmt, name, name+2) < 0)
@@ -151,11 +160,11 @@ emit_traits(
   idl_typeinfo_typemap_t blobs;
   if (gen->config && gen->config->generate_typeinfo_typemap && gen->config->generate_type_info) {
     if (gen->config->generate_typeinfo_typemap(pstate, (const idl_node_t*)node, &blobs) ||
-      idl_fprintf(gen->impl.handle, type_info_hdr1, name, blobs.typemap_size, blobs.typeinfo_size) < 0 ||
-      write_blob(gen->impl.handle, blobs.typemap, blobs.typemap_size) ||
-      idl_fprintf(gen->impl.handle, type_info_hdr2, name) < 0 ||
-      write_blob(gen->impl.handle, blobs.typeinfo, blobs.typeinfo_size) ||
-      idl_fprintf(gen->impl.handle, " };\n#endif //DDSCXX_HAS_TYPE_DISCOVERY\n\n") < 0)
+      idl_fprintf(gen->header.handle, type_info_decl1, name, blobs.typemap_size, blobs.typeinfo_size) < 0 ||
+      write_blob(gen->header.handle, blobs.typemap, blobs.typemap_size) ||
+      idl_fprintf(gen->header.handle, type_info_decl2, name) < 0 ||
+      write_blob(gen->header.handle, blobs.typeinfo, blobs.typeinfo_size) ||
+      idl_fprintf(gen->header.handle, "%s", type_info_decl3) < 0)
     ret = IDL_RETCODE_NO_MEMORY;
 
     //cleanup typeinfo_typemap blobs


### PR DESCRIPTION
This PR fixes:
- issue #276 by replacing the scoped enumerator `std::memory_order::memory_order_release`  with its non-scoped alias `std::memory_order_release`
- issues uncovered by the newer builds of CycloneDDS which now supports topic/type discovery by default
  - defining static members in template classes to contain the type/topic discovery information was not accepted by compilers other than GCC
  - to work around this this data is now accessed by static accessor functions
  - added unittests to check the correct generation of topic/type discovery information
  
@nate800 could you give this a try (and a review)?
