### PR TITLE
Disable inheritance for interface classes

### DIFF
--- a/src/ddscxx/include/dds/core/cond/TWaitSet.hpp
+++ b/src/ddscxx/include/dds/core/cond/TWaitSet.hpp
@@ -107,7 +107,7 @@ class TWaitSet;
  * @see for more information: @ref DCPS_Modules_Infrastructure_Waitset "WaitSet concept"
  */
 template <typename DELEGATE>
-class dds::core::cond::TWaitSet : public dds::core::Reference<DELEGATE>
+class dds::core::cond::TWaitSet final : public dds::core::Reference<DELEGATE>
 {
 public:
     typedef std::vector<dds::core::cond::Condition> ConditionSeq;

--- a/src/ddscxx/include/dds/domain/TDomainParticipant.hpp
+++ b/src/ddscxx/include/dds/domain/TDomainParticipant.hpp
@@ -63,7 +63,7 @@ class DomainParticipantListener;
  * @see for more information: @ref DCPS_Modules_DomainParticipant "Domain Participant"
  */
 template <typename DELEGATE>
-class dds::domain::TDomainParticipant : public ::dds::core::TEntity<DELEGATE>
+class dds::domain::TDomainParticipant final : public ::dds::core::TEntity<DELEGATE>
 {
 public:
     /**

--- a/src/ddscxx/include/dds/pub/DataWriter.hpp
+++ b/src/ddscxx/include/dds/pub/DataWriter.hpp
@@ -86,7 +86,7 @@ template <typename T> class DataWriterListener;
  * @see for more information: @ref DCPS_Modules_Publication_DataWriter "DataWriter concept"
  */
 template <typename T, template <typename Q> class DELEGATE>
-class dds::pub::DataWriter : public ::dds::pub::TAnyDataWriter< DELEGATE<T> >
+class dds::pub::DataWriter final : public ::dds::pub::TAnyDataWriter< DELEGATE<T> >
 {
 
 public:

--- a/src/ddscxx/include/dds/pub/TPublisher.hpp
+++ b/src/ddscxx/include/dds/pub/TPublisher.hpp
@@ -52,7 +52,7 @@ class PublisherListener;
  * @see for more information: @ref DCPS_Modules_Publisher "Publisher"
  */
 template <typename DELEGATE>
-class dds::pub::TPublisher : public dds::core::TEntity<DELEGATE>
+class dds::pub::TPublisher final : public dds::core::TEntity<DELEGATE>
 {
 public:
     /**

--- a/src/ddscxx/include/dds/sub/TDataReader.hpp
+++ b/src/ddscxx/include/dds/sub/TDataReader.hpp
@@ -102,7 +102,7 @@ class DataReaderListener;
  * @see for more information: @ref DCPS_Modules_Subscription_DataReader "DataReader concept"
  */
 template <typename T, template <typename Q> class DELEGATE>
-class dds::sub::DataReader : public dds::sub::TAnyDataReader< DELEGATE<T> >
+class dds::sub::DataReader final : public dds::sub::TAnyDataReader< DELEGATE<T> >
 {
 
 public:

--- a/src/ddscxx/include/dds/sub/TSubscriber.hpp
+++ b/src/ddscxx/include/dds/sub/TSubscriber.hpp
@@ -50,7 +50,7 @@ class SubscriberListener;
  * @see for more information: @ref DCPS_Modules_Subscriber "Subscriber"
  */
 template <typename DELEGATE>
-class dds::sub::TSubscriber : public dds::core::TEntity<DELEGATE>
+class dds::sub::TSubscriber final : public dds::core::TEntity<DELEGATE>
 {
 public:
     OMG_DDS_REF_TYPE_PROTECTED_DC(TSubscriber, dds::core::TEntity, DELEGATE)

--- a/src/ddscxx/include/dds/sub/cond/TQueryCondition.hpp
+++ b/src/ddscxx/include/dds/sub/cond/TQueryCondition.hpp
@@ -59,7 +59,7 @@ class TQueryCondition;
  * @see for more information: @ref anchor_dds_core_cond_waitset_examples "WaitSet examples"
  */
 template <typename DELEGATE>
-class dds::sub::cond::TQueryCondition :
+class dds::sub::cond::TQueryCondition final :
     public dds::sub::cond::TReadCondition<DELEGATE>,
     public dds::sub::TQuery<DELEGATE>
 {

--- a/src/ddscxx/include/dds/topic/TContentFilteredTopic.hpp
+++ b/src/ddscxx/include/dds/topic/TContentFilteredTopic.hpp
@@ -74,7 +74,7 @@ class ContentFilteredTopic;
  * @see for more information: @ref DCPS_Modules_TopicDefinition "Topic Definition"
  */
 template <typename T, template <typename Q> class DELEGATE>
-class dds::topic::ContentFilteredTopic : public dds::topic::TTopicDescription< DELEGATE<T> >
+class dds::topic::ContentFilteredTopic final : public dds::topic::TTopicDescription< DELEGATE<T> >
 {
 public:
     OMG_DDS_REF_TYPE_PROTECTED_DC_T(ContentFilteredTopic, dds::topic::TTopicDescription, T, DELEGATE)

--- a/src/ddscxx/include/dds/topic/TMultiTopic.hpp
+++ b/src/ddscxx/include/dds/topic/TMultiTopic.hpp
@@ -38,7 +38,7 @@ namespace topic
  * @see for more information: @ref DCPS_Modules_TopicDefinition "Topic Definition"
  */
 template <typename T, template <typename Q> class DELEGATE>
-class MultiTopic : public TTopicDescription< DELEGATE<T> >
+class MultiTopic final : public TTopicDescription< DELEGATE<T> >
 {
 public:
     OMG_DDS_REF_TYPE_PROTECTED_DC_T(MultiTopic, dds::topic::TTopicDescription, T, DELEGATE)

--- a/src/ddscxx/include/dds/topic/TTopic.hpp
+++ b/src/ddscxx/include/dds/topic/TTopic.hpp
@@ -72,7 +72,7 @@ class TopicListener;
  * @see for more information: @ref DCPS_Modules_TopicDefinition "Topic Definition"
  */
 template <typename T, template <typename Q> class DELEGATE>
-class dds::topic::Topic : public dds::topic::TAnyTopic< DELEGATE<T> >
+class dds::topic::Topic final : public dds::topic::TAnyTopic< DELEGATE<T> >
 {
 public:
     /**

--- a/src/ddscxx/include/dds/topic/detail/ContentFilteredTopic.hpp
+++ b/src/ddscxx/include/dds/topic/detail/ContentFilteredTopic.hpp
@@ -246,7 +246,7 @@ private:
 };
 
 template <typename T>
-class ContentFilteredTopic  :
+class ContentFilteredTopic final :
     public virtual org::eclipse::cyclonedds::topic::TopicDescriptionDelegate,
     public virtual org::eclipse::cyclonedds::core::DDScObjectDelegate
 {


### PR DESCRIPTION
As the interface classes (DataWriter, Topic, DataReader, etc.) in the
C++ binding make liberal use of virtual inheritance, they can not be
inherited from in the normal sense, as calling the inherited
constructor in the derived constructor will cause the Reference class
contained within to be initialized before the derived constructor is
called, producing an exception
To this end, these interface classes are made final, which disables
inheriting from them

Signed-off-by: Martijn Reicher <martijn.reicher@zettascale.tech>