### PR TITLE
Update api for changed dds_find_topic

### DIFF
--- a/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
@@ -307,7 +307,8 @@ dds::topic::detail::Topic<T>::discover_topic(
         const dds::core::Duration& timeout)
 {
     dds::topic::Topic<T> found = dds::core::null;
-    dds_entity_t ddsc_topic = dp.delegate()->lookup_topic(name, timeout);
+    const dds_typeinfo_t *type_info = org::eclipse::cyclonedds::topic::TopicTraits<T>::getTypeInfo(nullptr);
+    dds_entity_t ddsc_topic = dp.delegate()->lookup_topic(name, type_info, timeout);
 
     if (ddsc_topic <= 0) {
         return dds::core::null;

--- a/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.hpp
@@ -117,6 +117,7 @@ public:
 
     dds_entity_t
     lookup_topic(const std::string& topic_name,
+                 const dds_typeinfo_t *type_info,
                  const dds::core::Duration& timeout);
 
     void

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
@@ -449,26 +449,11 @@ org::eclipse::cyclonedds::domain::DomainParticipantDelegate::remove_cfTopic(
 dds_entity_t
 org::eclipse::cyclonedds::domain::DomainParticipantDelegate::lookup_topic(
         const std::string& topic_name,
+        const dds_typeinfo_t *type_info,
         const dds::core::Duration& timeout)
 {
-    dds_entity_t ddsc_topic;
-    dds_duration_t ddsc_timeout = 0;
-    (void)timeout;
-
     this->check();
-
-    dds_time_t starttime = dds_time();
-    while (true)
-    {
-        ddsc_topic = dds_find_topic_scoped(DDS_FIND_SCOPE_LOCAL_DOMAIN, this->ddsc_entity, topic_name.c_str(), 0);
-        if (ddsc_topic <= 0 || (ddsc_timeout != DDS_INFINITY &&
-            dds_time () >= starttime + ddsc_timeout)) {
-            break;
-        }
-        dds_sleepfor (DDS_MSECS(100));
-    }
-
-    return ddsc_topic;
+    return dds_find_topic(DDS_FIND_SCOPE_LOCAL_DOMAIN, this->ddsc_entity, topic_name.c_str(), type_info,  org::eclipse::cyclonedds::core::convertDuration (timeout));
 }
 
 void

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/AnyTopicDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/AnyTopicDelegate.cpp
@@ -152,7 +152,7 @@ AnyTopicDelegate::discover_topic(
 {
     char nameBuf[MAX_TOPIC_NAME_LENGTH];
 
-    dds_entity_t ddsc_topic = dp.delegate()->lookup_topic(name, timeout);
+    dds_entity_t ddsc_topic = dp.delegate()->lookup_topic(name, NULL, timeout);
 
     if (ddsc_topic <= 0) {
         return dds::core::null;

--- a/src/ddscxx/tests/DataWriter.cpp
+++ b/src/ddscxx/tests/DataWriter.cpp
@@ -126,8 +126,6 @@ public:
 
             this->lifespan_qos = this->publisher.default_datawriter_qos();
             this->lifespan_qos.policy(dds::core::policy::Lifespan(dds::core::Duration(10, 0)));
-            //this policy is implicitly set when no datarepresentation is selected
-            this->lifespan_qos.policy(dds::core::policy::DataRepresentation({dds::core::policy::DataRepresentationId::XCDR1}));
         }
     }
 

--- a/src/ddscxx/tests/FindTopic.cpp
+++ b/src/ddscxx/tests/FindTopic.cpp
@@ -190,7 +190,7 @@ TEST_F(FindTopic, discover_with_null)
 TEST_F(FindTopic, discover_with_empty)
 {
     dds::topic::Topic<Space::Type1> found = dds::core::null;
-    found = dds::topic::discover<dds::topic::Topic<Space::Type1> >(this->dp, std::string(TOPIC1_NAME_1));
+    found = dds::topic::discover<dds::topic::Topic<Space::Type1> >(this->dp, std::string(TOPIC1_NAME_1), dds::core::Duration::from_millisecs(10));
     ASSERT_EQ(found, dds::core::null);
 }
 

--- a/src/ddscxx/tests/Topic.cpp
+++ b/src/ddscxx/tests/Topic.cpp
@@ -131,7 +131,7 @@ TEST_F(Topic, create_same)
     ASSERT_STREQ(ttopic1A.type_name().c_str(), ttopic1B.type_name().c_str());
 }
 
-TEST_F(Topic, create_conflict)
+TEST_F(Topic, create_same_type)
 {
     dds::topic::Topic<Space::Type1> ttopic1 = dds::core::null;
     dds::topic::Topic<Space::Type2> ttopic2 = dds::core::null;
@@ -139,9 +139,8 @@ TEST_F(Topic, create_conflict)
     ttopic1 = dds::topic::Topic<Space::Type1>(this->participant, "ttopic");
     ASSERT_NE(ttopic1, dds::core::null);
 
-    ASSERT_THROW({
-        ttopic2 = dds::topic::Topic<Space::Type2>(this->participant, "ttopic");
-    }, dds::core::PreconditionNotMetError);
+    ttopic2 = dds::topic::Topic<Space::Type2>(this->participant, "ttopic");
+    ASSERT_NE(ttopic2, dds::core::null);
 }
 
 TEST_F(Topic, name)


### PR DESCRIPTION
This updates the c++ binding for the changes in the dds_find_topic function from [Cyclone PR 1308](https://github.com/eclipse-cyclonedds/cyclonedds/pull/1308): find_topic expects a type_info, which is retrieved from the topic traits.

Note: this PR is in draft, because I have to find out why the test `DataWriter.qos_nondefault_set` failed unexpectedly, and was fixed removing the data representation from the `lifespan` QoS that is used for this test.  