### PR TITLE
Properly propagate dependency to Boost if ENABLE_LEGACY is true

### DIFF
--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -144,7 +144,8 @@ steps:
       INSTALLPREFIX="$(pwd)/install"
       mkdir helloworld
       cd helloworld
-      cmake -DCMAKE_PREFIX_PATH="${BUILD_SOURCESDIRECTORY}/cyclonedds/build/install;${BUILD_SOURCESDIRECTORY}/iceoryx/build/install;${BUILD_SOURCESDIRECTORY}/build/install" \
+      conan install -b missing -s arch=${ARCH} -s build_type=${BUILD_TYPE} -g cmake_find_package_multi ../..
+      cmake -DCMAKE_PREFIX_PATH="${BUILD_SOURCESDIRECTORY}/cyclonedds/build/install;${BUILD_SOURCESDIRECTORY}/iceoryx/build/install;${BUILD_SOURCESDIRECTORY}/build/install;${BUILD_SOURCESDIRECTORY}/build/helloworld" \
             -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
             ${GENERATOR:+-G} "${GENERATOR}" "${INSTALLPREFIX}/share/CycloneDDS-CXX/examples/helloworld"
     name: test

--- a/PackageConfig.cmake.in
+++ b/PackageConfig.cmake.in
@@ -18,6 +18,12 @@ if(@ENABLE_SHM@)
   find_dependency(iceoryx_binding_c)
 endif()
 
+if(@ENABLE_LEGACY@)
+  include(CMakeFindDependencyMacro)
+  find_dependency(Boost)
+  set(CYCLONEDDS_CXX_ENABLE_LEGACY @ENABLE_LEGACY@)
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 
 if(TARGET CycloneDDS-CXX::idlcxx)

--- a/src/idlcxx/Generate.cmake
+++ b/src/idlcxx/Generate.cmake
@@ -42,4 +42,9 @@ function(IDLCXX_GENERATE)
     SUFFIXES .hpp .cpp
     DEPENDS ${_idlcxx_depends}
   )
+  if(CYCLONEDDS_CXX_ENABLE_LEGACY)
+      target_include_directories(${IDLCXX_TARGET}
+          INTERFACE ${Boost_INCLUDE_DIR}
+      )
+  endif()
 endfunction()


### PR DESCRIPTION
We got missing boost include errors when testing the latest master in legacy C++11 mode. This PR should fix the issue and correctly declare Boost as a transitive dependency of CycloneDDS-CXX.