### PR TITLE
Instance handles are well behaved in cyclone and discovery always takes place

### DIFF
--- a/src/ddscxx/include/dds/pub/discovery.hpp
+++ b/src/ddscxx/include/dds/pub/discovery.hpp
@@ -72,13 +72,6 @@ void ignore(const dds::domain::DomainParticipant& dp, FwdIterator begin, FwdIter
  * dds::pub::matched_subscription_data operation or to the read with instance
  * operation on the built-in reader for the “DCPSSubscription” topic.
  *
- * The operation may fail if the infrastructure does not locally maintain the
- * connectivity information. This is the case when OpenSplice is configured not to
- * maintain discovery information in the Networking Service. (See the description for
- * the NetworkingService/Discovery/enabled property in the Deployment
- * Manual for more information about this subject.) In such cases the operation will
- * throw UnsupportedError.
- *
  * See @ref DCPS_Builtin_Topics "Builtin Topics" for more information.
  *
  * @param dw        the DataWriter
@@ -114,13 +107,6 @@ matched_subscriptions(const dds::pub::DataWriter<T>& dw);
  * subscription by passing its subscription_handle to either the
  * dds::pub::matched_subscription_data operation or to the read with instance
  * operation on the built-in reader for the “DCPSSubscription” topic.
- *
- * The operation may fail if the infrastructure does not locally maintain the
- * connectivity information. This is the case when OpenSplice is configured not to
- * maintain discovery information in the Networking Service. (See the description for
- * the NetworkingService/Discovery/enabled property in the Deployment
- * Manual for more information about this subject.) In such cases the operation will
- * throw UnsupportedError.
  *
  * See @ref DCPS_Builtin_Topics "Builtin Topics" for more information.
  *

--- a/src/ddscxx/include/dds/pub/discovery.hpp
+++ b/src/ddscxx/include/dds/pub/discovery.hpp
@@ -72,17 +72,6 @@ void ignore(const dds::domain::DomainParticipant& dp, FwdIterator begin, FwdIter
  * dds::pub::matched_subscription_data operation or to the read with instance
  * operation on the built-in reader for the “DCPSSubscription” topic.
  *
- * @note Be aware that since InstanceHandle is an opaque datatype, it does not
- * necessarily mean that the handles obtained from the
- * matched_subscriptions operation have the same value as the ones that
- * appear in the instance_handle field of the SampleInfo when retrieving the
- * subscription info through corresponding "DCPSSubscriptions" built-in reader. You
- * can’t just compare two handles to determine whether they represent the same
- * subscription. If you want to know whether two handles actually do represent the
- * same subscription, use both handles to retrieve their corresponding
- * SubscriptionBuiltinTopicData samples and then compare the key field of
- * both samples.
- *
  * The operation may fail if the infrastructure does not locally maintain the
  * connectivity information. This is the case when OpenSplice is configured not to
  * maintain discovery information in the Networking Service. (See the description for
@@ -125,17 +114,6 @@ matched_subscriptions(const dds::pub::DataWriter<T>& dw);
  * subscription by passing its subscription_handle to either the
  * dds::pub::matched_subscription_data operation or to the read with instance
  * operation on the built-in reader for the “DCPSSubscription” topic.
- *
- * @note Be aware that since InstanceHandle is an opaque datatype, it does not
- * necessarily mean that the handles obtained from the
- * matched_subscriptions operation have the same value as the ones that
- * appear in the instance_handle field of the SampleInfo when retrieving the
- * subscription info through corresponding "DCPSSubscriptions" built-in reader. You
- * can’t just compare two handles to determine whether they represent the same
- * subscription. If you want to know whether two handles actually do represent the
- * same subscription, use both handles to retrieve their corresponding
- * SubscriptionBuiltinTopicData samples and then compare the key field of
- * both samples.
  *
  * The operation may fail if the infrastructure does not locally maintain the
  * connectivity information. This is the case when OpenSplice is configured not to

--- a/src/ddscxx/include/dds/sub/discovery.hpp
+++ b/src/ddscxx/include/dds/sub/discovery.hpp
@@ -74,13 +74,6 @@ void ignore(const dds::domain::DomainParticipant& dp, FwdIterator begin, FwdIter
  * dds::sub::matched_publication_data operation or to the read with instance
  * operation on the built-in reader for the “DCPSPublication” topic.
  *
- * The operation may fail if the infrastructure does not locally maintain the
- * connectivity information. This is the case when OpenSplice is configured not to
- * maintain discovery information in the Networking Service. (See the description for
- * the NetworkingService/Discovery/enabled property in the Deployment
- * Manual for more information about this subject.) In such cases the operation will
- * throw UnsupportedError.
- *
  * See @ref DCPS_Builtin_Topics "Builtin Topics" for more information.
  *
  * @param dr        the DataReader
@@ -116,13 +109,6 @@ matched_publications(const dds::sub::DataReader<T>& dr);
  * publication by passing its publication_handle to either the
  * dds::sub::matched_publication_data operation or to the read with instance
  * operation on the built-in reader for the “DCPSPublication” topic.
- *
- * The operation may fail if the infrastructure does not locally maintain the
- * connectivity information. This is the case when OpenSplice is configured not to
- * maintain discovery information in the Networking Service. (See the description for
- * the NetworkingService/Discovery/enabled property in the Deployment
- * Manual for more information about this subject.) In such cases the operation will
- * throw UnsupportedError.
  *
  * See @ref DCPS_Builtin_Topics "Builtin Topics" for more information.
  *

--- a/src/ddscxx/include/dds/sub/discovery.hpp
+++ b/src/ddscxx/include/dds/sub/discovery.hpp
@@ -74,17 +74,6 @@ void ignore(const dds::domain::DomainParticipant& dp, FwdIterator begin, FwdIter
  * dds::sub::matched_publication_data operation or to the read with instance
  * operation on the built-in reader for the “DCPSPublication” topic.
  *
- * @note Be aware that since InstanceHandle_t is an opaque datatype, it does not
- * necessarily mean that the handles obtained from the
- * get_matched_publications operation have the same value as the ones that
- * appear in the instance_handle field of the SampleInfo when retrieving the
- * publication info through corresponding "DCPSPublications" built-in reader. You
- * can’t just compare two handles to determine whether they represent the same
- * publication. If you want to know whether two handles actually do represent the
- * same publication, use both handles to retrieve their corresponding
- * PublicationBuiltinTopicData samples and then compare the key field of
- * both samples.
- *
  * The operation may fail if the infrastructure does not locally maintain the
  * connectivity information. This is the case when OpenSplice is configured not to
  * maintain discovery information in the Networking Service. (See the description for
@@ -127,17 +116,6 @@ matched_publications(const dds::sub::DataReader<T>& dr);
  * publication by passing its publication_handle to either the
  * dds::sub::matched_publication_data operation or to the read with instance
  * operation on the built-in reader for the “DCPSPublication” topic.
- *
- * @note Be aware that since InstanceHandle_t is an opaque datatype, it does not
- * necessarily mean that the handles obtained from the
- * get_matched_publications operation have the same value as the ones that
- * appear in the instance_handle field of the SampleInfo when retrieving the
- * publication info through corresponding "DCPSPublications" built-in reader. You
- * can’t just compare two handles to determine whether they represent the same
- * publication. If you want to know whether two handles actually do represent the
- * same publication, use both handles to retrieve their corresponding
- * PublicationBuiltinTopicData samples and then compare the key field of
- * both samples.
  *
  * The operation may fail if the infrastructure does not locally maintain the
  * connectivity information. This is the case when OpenSplice is configured not to


### PR DESCRIPTION
This PR removes some scary wording from the C++ documentation that doesn't apply to Cyclone. Part of it is definitely OpenSplice-specific and overlooked until @thijsmie's improved formatting of the documentation. The bit about the `InstanceHandle` of discovery data may or may not coming from the OMG, but it just doesn't apply for us and so needs to be removed as well.