### PR TITLE
Bump minimum CMake version to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 project(CycloneDDS-CXX VERSION 0.10.0 LANGUAGES C CXX)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
@@ -108,12 +108,6 @@ if(CMAKE_GENERATOR STREQUAL "Xcode")
   set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_UNUSED_VARIABLE YES)
   set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_DOCUMENTATION_COMMENTS YES)
   set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_ABOUT_MISSING_PROTOTYPES YES)
-endif()
-
-if(CMAKE_VERSION VERSION_LESS 3.13)
-  macro(add_link_options)
-    link_libraries(${ARGV})
-  endmacro()
 endif()
 
 if(CMAKE_CROSSCOMPILING)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ following installed on your host:
  * C and C++ compilers (most commonly GCC on Linux, Visual Studio on Windows,
    Xcode on macOS);
  * [Git](https://git-scm.com/) version control system;
- * [CMake](https://cmake.org/download/), version 3.10 or later;
+ * [CMake](https://cmake.org/download/), version 3.16 or later;
  * [Eclipse Cyclone DDS](https://github.com/eclipse-cyclonedds/cyclonedds/)
 
 *Eclipse Cyclone DDS* has dependencies of its own, most notably Bison. To

--- a/examples/helloworld/CMakeLists.txt
+++ b/examples/helloworld/CMakeLists.txt
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 project(helloworld LANGUAGES C CXX)
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 if(NOT TARGET CycloneDDS-CXX::ddscxx)
   find_package(CycloneDDS-CXX REQUIRED)


### PR DESCRIPTION
Support for EXPORT_PROPERTIES was added in CMake 3.12, so either the
minimum version required needs to be bumped, or this feature needs to be
emulated.  Ubuntu 22.04 ships with CMake 3.16, is over two years old now
and also the minimum required for ROS 2 Foxy, so that seems like a
reasonable new minimum version.

Closes #300 

Signed-off-by: Erik Boasson <eb@ilities.com>