### PR TITLE
PackageConfig: remove unconditional Generate.cmake include

### DIFF
--- a/PackageConfig.cmake.in
+++ b/PackageConfig.cmake.in
@@ -31,4 +31,3 @@ if(TARGET CycloneDDS-CXX::idlcxx)
 endif()
 
 check_required_components("@PROJECT_NAME@")
-include("${CMAKE_CURRENT_LIST_DIR}/idlcxx/Generate.cmake")


### PR DESCRIPTION
The line has to be removed in order for projects to correctly
use CycloneDDS-CXX::ddscxx library when CycloneDDS-CXX was
built without idlcxx using the -DBUILD_IDLLIB=OFF option or
when crosscompiling (see commit 2050fc451555b8309d4ed5c02b948d8d1cfd4d8e).
Without idlcxx the Generate.cmake never gets installed in the
first place, so the usage of the PackageConfig file gives an error:

/usr/local/lib/cmake/CycloneDDS-CXX/CycloneDDS-CXXConfig.cmake:52 (include):
  include could not find requested file:

    /usr/local/lib/cmake/CycloneDDS-CXX/idlcxx/Generate.cmake

If idlcxx is being used, the include a few lines above with

    if(TARGET CycloneDDS-CXX::idlcxx)

will bring in the necessary idlcxx_generate definition.