### PR TITLE
Fix for issue #293

### DIFF
--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -737,6 +737,13 @@ register_types(
   (void)revisit;
   (void)path;
 
+  if (idl_is_typedef(node))
+  {
+    const idl_typedef_t *td = node;
+    if (idl_is_array(td->declarators))
+      gen->uses_array = true;
+  }
+
   if (idl_is_array(node))
     gen->uses_array = true;
 


### PR DESCRIPTION
This issue was caused by the register_types function not looking
at the declarator in a typedef to see whether the arrays include
is required. When the typedef was used, then the include was
put in correctly.
The fix was to look at the declarators of typedefs by themselves
too.

Signed-off-by: Martijn Reicher <martijn.reicher@zettascale.tech>