### PR TITLE
Update waitset to detach conditions on cleanup

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/ConditionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/ConditionDelegate.hpp
@@ -66,7 +66,7 @@ public:
 
     void init(ObjectDelegate::weak_ref_type weak_ref);
 
-    void close(const dds_entity_t entity_handle = DDS_HANDLE_NIL);
+    void close();
 
     virtual bool trigger_value() const = 0;
 
@@ -94,8 +94,8 @@ public:
     virtual bool remove_waitset(
         org::eclipse::cyclonedds::core::cond::WaitSetDelegate *waitset);
 
-    virtual void detach_from_waitset(
-        const dds_entity_t entity_handle);
+    virtual void detach_from_waitset(const dds_entity_t entity_handle);
+    virtual void detach_and_close(const dds_entity_t entity_handle);
 
     dds::core::cond::TCondition<ConditionDelegate> wrapper();
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/ConditionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/ConditionDelegate.hpp
@@ -48,13 +48,14 @@ namespace core
 namespace cond
 {
 
+DDSCXX_WARNING_MSVC_OFF(4251)
+
 class WaitSetDelegate;
 
 class OMG_DDS_API ConditionDelegate :
                       public virtual org::eclipse::cyclonedds::core::DDScObjectDelegate
 {
 public:
-    typedef std::set<WaitSetDelegate *> waitset_list_type;
     typedef ::dds::core::smart_ptr_traits< ConditionDelegate >::ref_type
                                                                       ref_type;
     typedef ::dds::core::smart_ptr_traits< ConditionDelegate >::weak_ref_type
@@ -100,10 +101,12 @@ public:
     dds::core::cond::TCondition<ConditionDelegate> wrapper();
 
 private:
-    waitset_list_type waitSetList;
+    std::set<WaitSetDelegate *> waitSetList;
     org::eclipse::cyclonedds::core::Mutex waitSetListUpdateMutex;
     org::eclipse::cyclonedds::core::cond::FunctorHolderBase *myFunctor;
 };
+
+DDSCXX_WARNING_MSVC_ON(4251)
 
 }
 }

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/ConditionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/ConditionDelegate.hpp
@@ -54,6 +54,7 @@ class OMG_DDS_API ConditionDelegate :
                       public virtual org::eclipse::cyclonedds::core::DDScObjectDelegate
 {
 public:
+    typedef std::set<WaitSetDelegate *> waitset_list_type;
     typedef ::dds::core::smart_ptr_traits< ConditionDelegate >::ref_type
                                                                       ref_type;
     typedef ::dds::core::smart_ptr_traits< ConditionDelegate >::weak_ref_type
@@ -65,7 +66,7 @@ public:
 
     void init(ObjectDelegate::weak_ref_type weak_ref);
 
-    void close();
+    void close(const dds_entity_t entity_handle = DDS_HANDLE_NIL);
 
     virtual bool trigger_value() const = 0;
 
@@ -86,9 +87,21 @@ public:
 
     virtual void dispatch();
 
+    virtual void add_waitset(
+        const dds::core::cond::TCondition<ConditionDelegate> & cond,
+        org::eclipse::cyclonedds::core::cond::WaitSetDelegate *waitset);
+
+    virtual bool remove_waitset(
+        org::eclipse::cyclonedds::core::cond::WaitSetDelegate *waitset);
+
+    virtual void detach_from_waitset(
+        const dds_entity_t entity_handle);
+
     dds::core::cond::TCondition<ConditionDelegate> wrapper();
 
 private:
+    waitset_list_type waitSetList;
+    org::eclipse::cyclonedds::core::Mutex waitSetListUpdateMutex;
     org::eclipse::cyclonedds::core::cond::FunctorHolderBase *myFunctor;
 };
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/WaitSetDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/WaitSetDelegate.hpp
@@ -81,6 +81,10 @@ DDSCXX_WARNING_MSVC_OFF(4251)
 
         void attach_condition (const dds::core::cond::Condition & cond);
         bool detach_condition (org::eclipse::cyclonedds::core::cond::ConditionDelegate * cond);
+        void add_condition_locked(const dds::core::cond::Condition& cond);
+        void remove_condition_locked(org::eclipse::cyclonedds::core::cond::ConditionDelegate *cond,
+                                     const dds_entity_t entity_handle = DDS_HANDLE_NIL);
+
         ConditionSeq & conditions (ConditionSeq & conds) const;
 
     private:

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/ConditionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/ConditionDelegate.cpp
@@ -39,17 +39,38 @@ org::eclipse::cyclonedds::core::cond::ConditionDelegate::~ConditionDelegate()
     // sure that functor is delete here
     if (this->myFunctor) {
         delete this->myFunctor;
+        this->myFunctor = nullptr;
     }
 }
 
 void
-org::eclipse::cyclonedds::core::cond::ConditionDelegate::close()
+org::eclipse::cyclonedds::core::cond::ConditionDelegate::detach_from_waitset(
+    const dds_entity_t entity_handle) {
+    std::vector<WaitSetDelegate *> waitset_list_tmp;
+    org::eclipse::cyclonedds::core::ScopedMutexLock scopedLock(this->waitSetListUpdateMutex);
+    waitset_list_tmp.assign(this->waitSetList.begin(), this->waitSetList.end());
+    scopedLock.unlock();
+
+    for (auto waitset : waitset_list_tmp) {
+        org::eclipse::cyclonedds::core::ScopedObjectLock scopedWaisetLock(*waitset);
+        if (this->waitSetList.erase(waitset)) {
+            waitset->remove_condition_locked(this, entity_handle);
+       }
+    }
+}
+
+void
+org::eclipse::cyclonedds::core::cond::ConditionDelegate::close(
+    const dds_entity_t entity_handle)
 {
+    // detach the condition from any waitsets
+    detach_from_waitset(entity_handle);
+    // close the condition
     DDScObjectDelegate::close();
 
     if (this->myFunctor) {
         delete this->myFunctor;
-        this->myFunctor = NULL;
+        this->myFunctor = nullptr;
     }
 }
 
@@ -84,6 +105,36 @@ org::eclipse::cyclonedds::core::cond::ConditionDelegate::dispatch()
                                                        cond = this->wrapper();
         this->myFunctor->dispatch(cond);
     }
+}
+
+void
+org::eclipse::cyclonedds::core::cond::ConditionDelegate::add_waitset(
+    const dds::core::cond::TCondition<ConditionDelegate> & cond,
+    org::eclipse::cyclonedds::core::cond::WaitSetDelegate *waitset)
+{
+    org::eclipse::cyclonedds::core::ScopedMutexLock scopedLock(this->waitSetListUpdateMutex);
+
+    // Insert waitset to the list and attach the condition
+    if (this->waitSetList.insert(waitset).second) {
+        waitset->add_condition_locked(cond);
+    }
+}
+
+bool
+org::eclipse::cyclonedds::core::cond::ConditionDelegate::remove_waitset(
+    org::eclipse::cyclonedds::core::cond::WaitSetDelegate *waitset)
+{
+    bool ret = false;
+    org::eclipse::cyclonedds::core::ScopedMutexLock scopedLock(this->waitSetListUpdateMutex);
+
+    // remove the waitset from the list and detach the condition
+    if (this->waitSetList.erase(waitset)) {
+        waitset->remove_condition_locked(this);
+        ret = true;
+    }
+    // since the API expects to return false even in cases when condition was not attached to
+    // waitset
+  return ret;
 }
 
 dds::core::cond::TCondition<org::eclipse::cyclonedds::core::cond::ConditionDelegate>

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/GuardConditionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/GuardConditionDelegate.cpp
@@ -38,7 +38,7 @@ org::eclipse::cyclonedds::core::cond::GuardConditionDelegate::close()
 {
     this->check();
     org::eclipse::cyclonedds::core::ScopedObjectLock scopedLock(*this);
-    ConditionDelegate::close(ddsc_entity);
+    ConditionDelegate::detach_and_close(ddsc_entity);
 }
 
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/GuardConditionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/GuardConditionDelegate.cpp
@@ -36,9 +36,9 @@ org::eclipse::cyclonedds::core::cond::GuardConditionDelegate::~GuardConditionDel
 void
 org::eclipse::cyclonedds::core::cond::GuardConditionDelegate::close()
 {
+    this->check();
     org::eclipse::cyclonedds::core::ScopedObjectLock scopedLock(*this);
-
-    ConditionDelegate::close();
+    ConditionDelegate::close(ddsc_entity);
 }
 
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/StatusConditionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/StatusConditionDelegate.cpp
@@ -53,7 +53,15 @@ org::eclipse::cyclonedds::core::cond::StatusConditionDelegate::close()
 {
     /* todo: cannot close this->ddsc_entity because this is the parent EntityDelegate;
         find better solution to get correct feedback when closed StatusCondition is used */
-    this->ddsc_entity = 0;
+
+    // detach the condition from any waitset
+    this->check();
+    org::eclipse::cyclonedds::core::ScopedObjectLock scopedLock(*this);
+    ConditionDelegate::detach_from_waitset(ddsc_entity);
+    // set the entity to 0
+    this->ddsc_entity = DDS_HANDLE_NIL;
+    // but don't close the entity as it is the parent entity (fix this above as per above todo)
+    // ConditionDelegate::close(ddsc_entity);
 }
 
 void

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/StatusConditionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/StatusConditionDelegate.cpp
@@ -61,7 +61,7 @@ org::eclipse::cyclonedds::core::cond::StatusConditionDelegate::close()
     // set the entity to 0
     this->ddsc_entity = DDS_HANDLE_NIL;
     // but don't close the entity as it is the parent entity (fix this above as per above todo)
-    // ConditionDelegate::close(ddsc_entity);
+    // ConditionDelegate::detach_and_close(ddsc_entity);
 }
 
 void

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/cond/ReadConditionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/cond/ReadConditionDelegate.cpp
@@ -72,11 +72,10 @@ org::eclipse::cyclonedds::sub::cond::ReadConditionDelegate::init(
 void
 org::eclipse::cyclonedds::sub::cond::ReadConditionDelegate::close()
 {
+    this->check();
     org::eclipse::cyclonedds::core::ScopedObjectLock scopedLock(*this);
-
     QueryDelegate::deinit();
-
-    ConditionDelegate::close();
+    ConditionDelegate::close(ddsc_entity);
 }
 
 bool

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/cond/ReadConditionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/cond/ReadConditionDelegate.cpp
@@ -75,7 +75,7 @@ org::eclipse::cyclonedds::sub::cond::ReadConditionDelegate::close()
     this->check();
     org::eclipse::cyclonedds::core::ScopedObjectLock scopedLock(*this);
     QueryDelegate::deinit();
-    ConditionDelegate::close(ddsc_entity);
+    ConditionDelegate::detach_and_close(ddsc_entity);
 }
 
 bool


### PR DESCRIPTION
This MR changes the behavior of waitset to detach the conditions automatically when the conditions are closed or cleaned up.

Fixes #306