### PR TITLE
Fix for issue #308

### DIFF
--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/entity_properties.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/entity_properties.cpp
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <algorithm>
 #include <cassert>
+#include <string>
 
 namespace org {
 namespace eclipse {


### PR DESCRIPTION
The include for the C++ string library was missing, though this was not causing
issues in other compilation scenarioes, the order of compilation or parsing of
includes with Visual Studio 2017 caused this issue to be exposed

Signed-off-by: Martijn Reicher <martijn.reicher@zettascale.tech>