### PR TITLE
Free type map/info only if successfully generated

### DIFF
--- a/src/idlcxx/src/traits.c
+++ b/src/idlcxx/src/traits.c
@@ -159,19 +159,18 @@ emit_traits(
   idl_retcode_t ret = IDL_RETCODE_OK;
   idl_typeinfo_typemap_t blobs;
   if (gen->config && gen->config->generate_typeinfo_typemap && gen->config->generate_type_info) {
-    if (gen->config->generate_typeinfo_typemap(pstate, (const idl_node_t*)node, &blobs) ||
-      idl_fprintf(gen->header.handle, type_info_decl1, name, blobs.typemap_size, blobs.typeinfo_size) < 0 ||
+    if (gen->config->generate_typeinfo_typemap(pstate, (const idl_node_t*)node, &blobs))
+      ret = IDL_RETCODE_NO_MEMORY;
+    else if (idl_fprintf(gen->header.handle, type_info_decl1, name, blobs.typemap_size, blobs.typeinfo_size) < 0 ||
       write_blob(gen->header.handle, blobs.typemap, blobs.typemap_size) ||
       idl_fprintf(gen->header.handle, type_info_decl2, name) < 0 ||
       write_blob(gen->header.handle, blobs.typeinfo, blobs.typeinfo_size) ||
       idl_fprintf(gen->header.handle, "%s", type_info_decl3) < 0)
-    ret = IDL_RETCODE_NO_MEMORY;
-
-    //cleanup typeinfo_typemap blobs
-    if (blobs.typemap)
+    {
+      ret = IDL_RETCODE_NO_MEMORY;
       free (blobs.typemap);
-    if (blobs.typeinfo)
       free (blobs.typeinfo);
+    }
   }
 
   return ret;

--- a/src/idlcxx/src/traits.c
+++ b/src/idlcxx/src/traits.c
@@ -161,13 +161,16 @@ emit_traits(
   if (gen->config && gen->config->generate_typeinfo_typemap && gen->config->generate_type_info) {
     if (gen->config->generate_typeinfo_typemap(pstate, (const idl_node_t*)node, &blobs))
       ret = IDL_RETCODE_NO_MEMORY;
-    else if (idl_fprintf(gen->header.handle, type_info_decl1, name, blobs.typemap_size, blobs.typeinfo_size) < 0 ||
-      write_blob(gen->header.handle, blobs.typemap, blobs.typemap_size) ||
-      idl_fprintf(gen->header.handle, type_info_decl2, name) < 0 ||
-      write_blob(gen->header.handle, blobs.typeinfo, blobs.typeinfo_size) ||
-      idl_fprintf(gen->header.handle, "%s", type_info_decl3) < 0)
+    else
     {
-      ret = IDL_RETCODE_NO_MEMORY;
+      if (idl_fprintf(gen->header.handle, type_info_decl1, name, blobs.typemap_size, blobs.typeinfo_size) < 0 ||
+        write_blob(gen->header.handle, blobs.typemap, blobs.typemap_size) ||
+        idl_fprintf(gen->header.handle, type_info_decl2, name) < 0 ||
+        write_blob(gen->header.handle, blobs.typeinfo, blobs.typeinfo_size) ||
+        idl_fprintf(gen->header.handle, "%s", type_info_decl3) < 0)
+      {
+        ret = IDL_RETCODE_NO_MEMORY;
+      }
       free (blobs.typemap);
       free (blobs.typeinfo);
     }


### PR DESCRIPTION
On failure generating the type info and type map, the code using these
blobs when writing out the traits would still free the typemap and
typeinfo blobs, even though the contents of the memory would be
undefined.  This changes the error handling so this is done only iff the
type info and type map were generated correctly.

Signed-off-by: Erik Boasson <eb@ilities.com>