### PR TITLE
Remove unused include ddsi_sertopic.h

### DIFF
--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
@@ -24,7 +24,6 @@
 #include <dds/dds.h>
 #include <dds/ddsc/dds_loan_api.h>
 
-#include "dds/ddsi/ddsi_sertopic.h"
 #include "dds/ddsi/q_protocol.h"
 #include "dds/features.hpp"
 


### PR DESCRIPTION
The deprecated sertopic implementation is removed, see https://github.com/eclipse-cyclonedds/cyclonedds/pull/1397