### PR TITLE
Feature/optional ddscxx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,8 @@ endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
 
+option(BUILD_DDSLIB "Build DDS lib" ON)
+
 option(BUILD_IDLLIB "Build IDL preprocessor lib" ${not_crosscompiling})
 
 # Make it easy to enable MSVC, Clang's/gcc's analyzers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,10 @@ option(BUILD_DDSLIB "Build DDS lib" ON)
 
 option(BUILD_IDLLIB "Build IDL preprocessor lib" ${not_crosscompiling})
 
+if(NOT BUILD_DDSLIB AND NOT BUILD_IDLLIB)
+  message(FATAL_ERROR "Nothing to build. At least one of the options BUILD_DDSLIB and/or BUILD_IDLLIB must be ON.")
+endif()
+
 # Make it easy to enable MSVC, Clang's/gcc's analyzers
 set(ANALYZER "" CACHE STRING "Analyzer to enable on the build.")
 if(ANALYZER)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ for Cyclone DDS or contribute to it you can follow different procedures.
 ### Build configuration
 
 There are some configuration options specified using CMake defines in addition to the standard options like `CMAKE_BUILD_TYPE`:
-* `-DBUILD_DDSLIB=OFF`: to disable DDS lib build, useful in crosscompiling scenarios where you need the generator be executable on the machine and the DDS LIB in another architecture build.
+* `-DBUILD_DDSLIB=OFF`: to disable DDS lib build, useful in crosscompiling scenarios where you only need the generator and use the DDS lib from another build.
 * `-DBUILD_IDLLIB=OFF`: to disable IDL preprocessor lib build
 * `-DBUILD_DOCS=ON`: to build the documentation
 * `-DBUILD_TESTING=ON`: to build the testing tree

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ for Cyclone DDS or contribute to it you can follow different procedures.
 ### Build configuration
 
 There are some configuration options specified using CMake defines in addition to the standard options like `CMAKE_BUILD_TYPE`:
+* `-DBUILD_DDSLIB=OFF`: to disable DDS lib build, useful in crosscompiling scenarios where you need the generator be executable on the machine and the DDS LIB in another architecture build.
 * `-DBUILD_IDLLIB=OFF`: to disable IDL preprocessor lib build
 * `-DBUILD_DOCS=ON`: to build the documentation
 * `-DBUILD_TESTING=ON`: to build the testing tree

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,4 +12,6 @@
 if (BUILD_IDLLIB)
   add_subdirectory(idlcxx)
 endif()
-add_subdirectory(ddscxx)
+if (BUILD_DDSLIB)
+  add_subdirectory(ddscxx)
+endif()


### PR DESCRIPTION
This makes the build of `DDSCXX` optional.
Useful in cross-compiling scenarios where you only need the generator and use the DDS lib from another build.