### PR TITLE
Fix for issue #326

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp
@@ -45,11 +45,11 @@ public:
    *
    * This function is called by the generated streaming functions, and will start a parameter list, if that is relevant for it.
    *
-   * @param[in, out] props The entity whose members might be represented by a parameter list.
+   * @param[in] props The entity whose members might be represented by a parameter list.
    *
    * @return Whether the operation was completed succesfully.
    */
-  bool start_struct(entity_properties_t &props);
+  bool start_struct(const entity_properties_t &props);
 
 };
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp
@@ -391,12 +391,11 @@ public:
      * Depending on the implementation and mode headers may be read from/written to the stream.
      * This function can be overridden in cdr streaming implementations.
      *
-     * @param[in] prop Properties of the entity to start.
      * @param[in] is_set Whether the entity represented by prop is present, if it is an optional entity.
      *
      * @return Whether the operation was completed succesfully.
      */
-    virtual bool start_member(entity_properties_t &prop, bool is_set = true) { prop.is_present = is_set; return true;}
+    virtual bool start_member(const entity_properties_t &, bool is_set = true) { (void) is_set; return true;}
 
     /**
      * @brief
@@ -406,11 +405,13 @@ public:
      * Depending on the implementation and mode header length fields may be completed.
      * This function can be overridden in cdr streaming implementations.
      *
+     * @param[in] props Properties of the member to finish.
+     * @param[in] member_ids Container for the member ids of members succesfully streamed at this level
      * @param[in] is_set Whether the entity represented by prop is present, if it is an optional entity.
      *
      * @return Whether the operation was completed succesfully.
      */
-    virtual bool finish_member(entity_properties_t &, bool is_set = true) { (void) is_set; return true;}
+    virtual bool finish_member(const entity_properties_t &props, member_id_set &member_ids, bool is_set = true);
 
     /**
      * @brief
@@ -419,11 +420,11 @@ public:
      * This function is called by the instance implementation switchbox and will return the next entity to operate on by calling next_prop.
      * This will also call the implementation specific push/pop entity functions to write/finish headers where necessary.
      *
-     * @param[in, out] prop The property tree to get the next entity from.
+     * @param[in] prop The property tree to get the next entity from.
      *
      * @return The next entity to be processed, or the final entity if the current tree level does not hold more entities.
      */
-    virtual entity_properties_t* next_entity(entity_properties_t *prop);
+    virtual const entity_properties_t* next_entity(const entity_properties_t *prop);
 
     /**
      * @brief
@@ -432,11 +433,11 @@ public:
      * Depending on the data structure and the streaming mode, either a header is read from the stream, or a
      * properties entry is pulled from the tree.
      *
-     * @param[in, out] prop The property tree to get the next entity from.
+     * @param[in] prop The property tree to get the next entity from.
      *
      * @return The first entity to be processed, or a nullptr if the current tree level does not hold any entities that match this tree.
      */
-    virtual entity_properties_t* first_entity(entity_properties_t *prop);
+    virtual const entity_properties_t* first_entity(const entity_properties_t *prop);
 
     /**
      * @brief
@@ -445,11 +446,9 @@ public:
      * This function is called by the generated functions for the entity, and will trigger the necessary actions on starting a new struct.
      * I.E. starting a new parameter list, writing headers.
      *
-     * @param[in,out] props The entity whose members might be represented by a parameter list.
-     *
      * @return Whether the operation was completed succesfully.
      */
-    virtual bool start_struct(entity_properties_t &props);
+    virtual bool start_struct(const entity_properties_t &) {return true;}
 
     /**
      * @brief
@@ -458,11 +457,12 @@ public:
      * This function is called by the generated functions for the entity, and will trigger the necessary actions on finishing the current struct.
      * I.E. finishing headers, writing length fields.
      *
-     * @param[in,out] props The entity whose members might be represented by a parameter list.
+     * @param[in] props The entity whose members might be represented by a parameter list.
+     * @param[in] member_ids Container for the member ids of members succesfully streamed at this level.
      *
      * @return Whether the struct is complete and correct.
      */
-    virtual bool finish_struct(entity_properties_t &props);
+    virtual bool finish_struct(const entity_properties_t &props, const member_id_set &member_ids);
 
     /**
      * @brief
@@ -506,9 +506,12 @@ protected:
      *
      * Checks whether all fields which must be understood are present.
      *
-     * @param[in,out] props The struct whose start is recorded.
+     * @param[in] props The struct whose start is recorded.
+     * @param[in] member_ids Container for the member ids of members succesfully streamed at this level.
+     *
+     * @return Whether the members indicated to be necessary in props are present in member_ids.
      */
-    void check_struct_completeness(entity_properties_t &props);
+    bool check_struct_completeness(const entity_properties_t &props, const member_id_set &member_ids);
 
     /**
      * @brief
@@ -518,7 +521,7 @@ protected:
      *
      * @return Pointer to the previous entity, or nullptr if there is any.
      */
-    entity_properties_t* previous_entity(entity_properties_t *prop);
+    const entity_properties_t* previous_entity(const entity_properties_t *prop);
 
     static const size_t m_maximum_depth = 32;     /**< the maximum depth of structures in the streamer*/
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <list>
 #include <vector>
+#include <set>
 #include <map>
 #include <atomic>
 #include <mutex>
@@ -115,6 +116,7 @@ constexpr bit_bound get_bit_bound() { return bb_unset;}
 
 typedef struct entity_properties entity_properties_t;
 typedef std::vector<entity_properties_t> propvec;
+typedef std::set<uint32_t> member_id_set;
 
 /**
  * @brief
@@ -152,21 +154,12 @@ struct OMG_DDS_API entity_properties
   bool ignore = false;                            /**< Indicates that this field must be ignored.*/
   bool is_optional = false;                       /**< Indicates that this field can be empty (length 0) for reading/writing purposes.*/
   bool is_key = false;                            /**< Indicates that this field is a key field.*/
-  bool is_present = false;                        /**< Indicates that this entity is present in the read stream.*/
   bit_bound e_bb = bb_unset;                      /**< The minimum number of bytes necessary to represent this entity/bitmask.*/
 
   entity_properties_t  *next_on_level = nullptr,  /**< Pointer to the next entity on the same level.*/
                        *prev_on_level = nullptr,  /**< Pointer to the previous entity on the same level.*/
                        *parent        = nullptr,  /**< Pointer to the parent of this entity.*/
                        *first_member  = nullptr;  /**< Pointer to the first entity which is a member of this entity.*/
-
-  /**
-   * @brief
-   * Reset function.
-   *
-   * This function will reset the fields that may have been set through streaming (is_present).
-   */
-  void reset();
 
   /**
    * @brief
@@ -254,7 +247,7 @@ struct OMG_DDS_API entity_properties
  * @return propvec "Tree" representing the type.
  */
 template<typename T>
-propvec& get_type_props();
+const propvec& get_type_props();
 
 }
 }

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.hpp
@@ -45,12 +45,12 @@ public:
    *
    * Determines whether a header is necessary for this entity through header_necessary, and if it is, handles the header.
    *
-   * @param[in, out] prop Properties of the member to start.
+   * @param[in] prop Properties of the member to start.
    * @param[in] is_set Whether the entity represented by prop is present, if it is an optional entity.
    *
    * @return Whether the operation was completed succesfully.
    */
-  bool start_member(entity_properties_t &prop, bool is_set = true);
+  bool start_member(const entity_properties_t &prop, bool is_set = true);
 
   /**
    * @brief
@@ -58,12 +58,13 @@ public:
    *
    * Determines whether a header is necessary for this entity through header_necessary, and if it is, completes the previous header.
    *
-   * @param[in, out] prop Properties of the member to finish.
+   * @param[in] prop Properties of the member to finish.
+   * @param[in] member_ids Container for the member ids of members succesfully streamed at this level
    * @param[in] is_set Whether the entity represented by prop is present, if it is an optional entity.
    *
    * @return Whether the operation was completed succesfully.
    */
-  bool finish_member(entity_properties_t &prop, bool is_set = true);
+  bool finish_member(const entity_properties_t &prop, member_id_set &member_ids, bool is_set = true);
 
   /**
    * @brief
@@ -72,11 +73,11 @@ public:
    * Depending on the data structure and the streaming mode, either a header is read from the stream, or a
    * properties entry is pulled from the tree.
    *
-   * @param[in, out] prop The property tree to get the next entity from.
+   * @param[in] prop The property tree to get the next entity from.
    *
    * @return The next entity to be processed, or a nullptr if the current tree level does not hold more entities that match this tree.
    */
-  entity_properties_t* next_entity(entity_properties_t *prop);
+  const entity_properties_t* next_entity(const entity_properties_t *prop);
 
   /**
    * @brief
@@ -85,11 +86,11 @@ public:
    * Depending on the data structure and the streaming mode, either a header is read from the stream, or a
    * properties entry is pulled from the tree.
    *
-   * @param[in, out] prop The property tree to get the next entity from.
+   * @param[in] prop The property tree to get the next entity from.
    *
    * @return The first entity to be processed, or a nullptr if the current tree level does not hold any entities that match this tree.
    */
-  entity_properties_t *first_entity(entity_properties_t *prop);
+  const entity_properties_t *first_entity(const entity_properties_t *prop);
 
   /**
    * @brief
@@ -97,11 +98,12 @@ public:
    *
    * Adds the final parameter list entry if necessary when writing to the stream.
    *
-   * @param[in, out] props The property tree to get the next entity from.
+   * @param[in] props The property tree to get the next entity from.
+   * @param[in] member_ids Container for the member ids of members succesfully streamed at this level
    *
    * @return Whether the struct is complete and correct.
    */
-  bool finish_struct(entity_properties_t &props);
+  bool finish_struct(const entity_properties_t &props, const member_id_set &member_ids);
 
 private:
 
@@ -159,23 +161,23 @@ private:
    * If header_necessary returns true for a field, then this function needs to be called first to write the
    * header to the stream before the contents of the field are written.
    *
-   * @param[in, out] props The properties of the entity.
+   * @param[in] props The properties of the entity.
    *
-   * @return Whether the header was read succesfully.
+   * @return Whether the placeholder for the header was written succesfully.
    */
-  bool write_header(entity_properties_t &props);
+  bool write_header(const entity_properties_t &props);
 
   /**
    * @brief
    * Finishes a header field in the stream.
    *
-   * Goes back to the offset of the length field that was unfinished in 
+   * Goes back to the offset of the length field that was unfinished in write_header
    *
-   * @param[in, out] props The properties of the entity.
+   * @param[in] props The properties of the entity.
    *
-   * @return Whether the header was read succesfully.
+   * @return Whether the header has succesfully finished writing.
    */
-  bool finish_write_header(entity_properties_t &props);
+  bool finish_write_header(const entity_properties_t &props);
 
   /**
    * @brief

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
@@ -53,10 +53,10 @@ public:
    *
    * Determines whether a header is necessary for this entity through em_header_necessary, and if it is, handles the header.
    *
-   * @param[in, out] prop Properties of the member to start.
+   * @param[in] prop Properties of the member to start.
    * @param[in] is_set Whether the entity represented by prop is present, if it is an optional entity.
    */
-  bool start_member(entity_properties_t &prop, bool is_set = true);
+  bool start_member(const entity_properties_t &prop, bool is_set = true);
 
   /**
    * @brief
@@ -64,12 +64,13 @@ public:
    *
    * Determines whether a header is necessary for this entity through em_header_necessary, and if it is, completes the previous header.
    *
-   * @param[in, out] prop Properties of the member to finish.
+   * @param[in] prop Properties of the member to finish.
+   * @param[in] member_ids Container for the member ids of members succesfully streamed at this level
    * @param[in] is_set Whether the entity represented by prop is present, if it is an optional entity.
    *
    * @return Whether the operation was completed succesfully.
    */
-  bool finish_member(entity_properties_t &prop, bool is_set = true);
+  bool finish_member(const entity_properties_t &prop, member_id_set &member_ids, bool is_set = true);
 
   /**
    * @brief
@@ -78,11 +79,11 @@ public:
    * Depending on the data structure and the streaming mode, either a header is read from the stream, or a
    * properties entry is pulled from the tree.
    *
-   * @param[in, out] prop The property tree to get the next entity from.
+   * @param[in] prop The property tree to get the next entity from.
    *
    * @return The next entity to be processed, or a nullptr if the current tree level does not hold more entities that match this tree.
    */
-  entity_properties_t* next_entity(entity_properties_t *prop);
+  const entity_properties_t* next_entity(const entity_properties_t *prop);
 
   /**
    * @brief
@@ -91,11 +92,11 @@ public:
    * Depending on the data structure and the streaming mode, either a header is read from the stream, or a
    * properties entry is pulled from the tree.
    *
-   * @param[in, out] prop The property tree to get the next entity from.
+   * @param[in] prop The property tree to get the next entity from.
    *
    * @return The first entity to be processed, or a nullptr if the current tree level does not hold any entities that match this tree.
    */
-  entity_properties_t *first_entity(entity_properties_t *prop);
+  const entity_properties_t *first_entity(const entity_properties_t *prop);
 
   /**
    * @brief
@@ -103,11 +104,11 @@ public:
    *
    * This function is called by the generated streaming functions, and will start a parameter list, if that is relevant for it.
    *
-   * @param[in, out] props The entity whose members might be represented by a parameter list.
+   * @param[in] props The entity whose members might be represented by a parameter list.
    *
    * @return Whether the operation was completed succesfully.
    */
-  bool start_struct(entity_properties_t &props);
+  bool start_struct(const entity_properties_t &props);
 
   /**
    * @brief
@@ -115,11 +116,12 @@ public:
    *
    * This function is called by the generated streaming functions, and will finish the current parameter list, if that is relevant for it.
    *
-   * @param[in, out] props The entity whose members might be represented by a parameter list.
+   * @param[in] props The entity whose members might be represented by a parameter list.
+   * @param[in] member_ids Container for the member ids of members succesfully streamed at this level
    *
    * @return Whether the struct is complete and correct.
    */
-  bool finish_struct(entity_properties_t &props);
+  bool finish_struct(const entity_properties_t &props, const member_id_set &member_ids);
 
   /**
    * @brief
@@ -226,11 +228,11 @@ private:
    * @brief
    * Writes an EM-header to the stream.
    *
-   * @param[in, out] prop The entity to write the EM-header for.
+   * @param[in] prop The entity to write the EM-header for.
    *
-   * @return Whether the header was read succesfully.
+   * @return Whether the EM-header was written succesfully.
    */
-  bool write_em_header(entity_properties_t &prop);
+  bool write_em_header(const entity_properties_t &prop);
 
   /**
    * @brief

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.cpp
@@ -18,7 +18,7 @@ namespace cyclonedds {
 namespace core {
 namespace cdr {
 
-bool basic_cdr_stream::start_struct(entity_properties_t &props)
+bool basic_cdr_stream::start_struct(const entity_properties_t &props)
 {
   if (!is_key() && props.xtypes_necessary && status(unsupported_xtypes))
     return false;

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/entity_properties.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/entity_properties.cpp
@@ -103,11 +103,6 @@ void entity_properties_t::finish(propvec &props, const key_endpoint &keys)
   add_key(keys, props[0]);
 }
 
-void entity_properties_t::reset()
-{
-  is_present = false;
-}
-
 void entity_properties_t::print() const
 {
   std::cout <<  std::string( 2*depth, ' ' ) << "id: " << m_id << std::endl;

--- a/src/ddscxx/tests/GeneratedEntities.cpp
+++ b/src/ddscxx/tests/GeneratedEntities.cpp
@@ -50,7 +50,7 @@ void compare_endpoints_with_entity(const key_endpoint &ke, const entity_properti
 template<typename T>
 void test_props(const std::list<std::list<uint32_t> > &endpoints)
 {
-  auto props = get_type_props<T>();
+  const auto &props = get_type_props<T>();
 
   key_endpoint ke;
   for (const auto &endpoint:endpoints)

--- a/src/ddscxx/tests/Regression.cpp
+++ b/src/ddscxx/tests/Regression.cpp
@@ -337,7 +337,7 @@ TEST_F(Regression, key_value_of_appendables)
 
 TEST_F(Regression, memberless_struct)
 {
-  auto &props = get_type_props<s_memberless>();
+  const auto &props = get_type_props<s_memberless>();
 
   xcdr_v1_stream v1(endianness::big_endian);
   v1.set_mode(cdr_stream::stream_mode::read, false);

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -1129,7 +1129,8 @@ print_switchbox_open(struct streams *streams)
 
 static idl_retcode_t
 print_constructed_type_close(
-  struct streams *streams)
+  struct streams *streams,
+  const void* node)
 {
   const char *fmt =
     "  return streamer.finish_struct(*props, member_ids);\n"
@@ -1139,9 +1140,25 @@ print_constructed_type_close(
     "  initialized.store(true, std::memory_order_release);\n"
     "  return props;\n"
     "}\n\n";
+  static const char *pfmt2 =
+    "static const propvec &properties_%1$s = get_type_props<%2$s>();\n\n";
+
+
+  char *fullname = NULL, *newname = NULL;
+  if (IDL_PRINTA(&fullname, get_cpp11_fully_scoped_name, node, streams->generator) < 0 ||
+      IDL_PRINTA(&newname, get_cpp11_fully_scoped_name, node, streams->generator) < 0)
+    return IDL_RETCODE_NO_MEMORY;
+
+  char *ptr = newname;
+  while (*ptr) {
+    if (*ptr == ':')
+      *ptr = '_';
+    ptr++;
+  }
 
   if (multi_putf(streams, ALL, fmt)
-   || putf(&streams->props, pfmt))
+   || putf(&streams->props, pfmt)
+   || idl_fprintf(streams->generator->header.handle, pfmt2, newname, fullname) < 0)
     return IDL_RETCODE_NO_MEMORY;
 
   return IDL_RETCODE_OK;
@@ -1239,7 +1256,7 @@ process_struct(
 
   if (revisit) {
     if (print_switchbox_close(user_data)
-     || print_constructed_type_close(user_data)
+     || print_constructed_type_close(user_data, node)
      || (!is_nested(node) && print_entry_point_functions(streams, fullname)))
       return IDL_RETCODE_NO_MEMORY;
 
@@ -1309,7 +1326,7 @@ process_union(
 
   if (revisit) {
     if (multi_putf(streams, MAX, pfmt)
-     || print_constructed_type_close(user_data)
+     || print_constructed_type_close(user_data, node)
      || (!is_nested(node) && print_entry_point_functions(streams, fullname))) /*only add entry point functions for non-nested (topic) types*/
       return IDL_RETCODE_NO_MEMORY;
 

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -819,11 +819,11 @@ add_member_finish(
     if (IDL_PRINTA(&accessor, get_instance_accessor, decl, &loc) < 0
      || multi_putf(streams, (WRITE|MOVE), "      }\n")
      || multi_putf(streams, ALL,
-          "      if (!streamer.finish_member(*prop, %1$s.has_value()))\n"
+          "      if (!streamer.finish_member(*prop, member_ids, %1$s.has_value()))\n"
           "        return false;\n", accessor))
       return IDL_RETCODE_NO_MEMORY;
   } else {
-    if (multi_putf(streams, ALL, "      if (!streamer.finish_member(*prop))\n"
+    if (multi_putf(streams, ALL, "      if (!streamer.finish_member(*prop, member_ids))\n"
                                  "        return false;\n"))
       return IDL_RETCODE_NO_MEMORY;
   }
@@ -932,10 +932,8 @@ process_case(
                                   : "      instance.%1$s(obj, d);\n"
                                     "    }\n"
                                     "    break;\n";
-  const char* get_props = constructed_type    ? "      auto prop = get_type_props<%1$s>().data();\n"
-                                              : "",
-            * check_props = constructed_type  ? "      props->is_present = prop->is_present;\n"
-                                              : "      props->is_present = true;\n";
+  const char* get_props = constructed_type    ? "      const auto &prop = &(get_type_props<%1$s>()[0]);\n"
+                                              : "";
 
   if (revisit) {
     const char *name = get_cpp11_name(_case->declarator);
@@ -955,9 +953,6 @@ process_case(
     if ((_switch->key.value && multi_putf(streams, ALL, "      if (!streamer.is_key()) {\n"))
      || process_entity(pstate, streams, _case->declarator, _case->type_spec, loc)
      || (_switch->key.value && multi_putf(streams, ALL, "      } //!streamer.is_key()\n")))
-      return IDL_RETCODE_NO_MEMORY;
-
-    if (multi_putf(streams, READ, check_props))
       return IDL_RETCODE_NO_MEMORY;
 
     if (multi_putf(streams, (WRITE | MOVE), "      }\n      break;\n")
@@ -1016,7 +1011,7 @@ process_key(
   const idl_type_spec_t *type_spec = _struct;
   const idl_declarator_t *decl = NULL;
 
-  if (putf(&streams->props, "    keylist.add_key_endpoint(std::list<uint32_t>{"))
+  if (putf(&streams->props, "  keylist.add_key_endpoint(std::list<uint32_t>{"))
     return IDL_RETCODE_NO_MEMORY;
 
   for (size_t i = 0; i < key->field_name->length; i++) {
@@ -1070,31 +1065,23 @@ print_constructed_type_open(struct streams *streams, const idl_node_t *node)
 
   static const char *fmt =
     "template<typename T, std::enable_if_t<std::is_base_of<cdr_stream, T>::value, bool> = true >\n"
-    "bool {T}(T& streamer, {C}%1$s& instance, entity_properties_t *props) {\n"
-    "  (void)instance;\n";
+    "bool {T}(T& streamer, {C}%1$s& instance, const entity_properties_t *props) {\n"
+    "  (void)instance;\n"
+    "  member_id_set member_ids;\n";
   static const char *pfmt1 =
     "template<>\n"
-    "propvec &get_type_props<%s>()%s";
+    "const propvec &get_type_props<%s>()%s";
   static const char *pfmt2 =
     " {\n"
-    "  static thread_local std::mutex mtx;\n"
-    "  static thread_local propvec props;\n"
-    "  static thread_local entity_properties_t *props_end = nullptr;\n"
-    "  static thread_local std::atomic_bool initialized {false};\n"
+    "  static std::mutex mtx;\n"
+    "  static propvec props;\n"
+    "  static std::atomic_bool initialized {false};\n"
     "  key_endpoint keylist;\n"
-    "  if (initialized.load(std::memory_order_relaxed)) {\n"
-    "    auto ptr = props.data();\n"
-    "    while (ptr < props_end)\n"
-    "      (ptr++)->is_present = false;\n"
+    "  if (initialized.load(std::memory_order_relaxed))\n"
     "    return props;\n"
-    "  }\n"
     "  std::lock_guard<std::mutex> lock(mtx);\n"
-    "  if (initialized.load(std::memory_order_relaxed)) {\n"
-    "    auto ptr = props.data();\n"
-    "    while (ptr < props_end)\n"
-    "      (ptr++)->is_present = false;\n"
+    "  if (initialized.load(std::memory_order_relaxed))\n"
     "    return props;\n"
-    "  }\n"
     "  props.clear();\n\n";
   static const char *sfmt =
     "  if (!streamer.start_struct(*props))\n"
@@ -1145,11 +1132,10 @@ print_constructed_type_close(
   struct streams *streams)
 {
   const char *fmt =
-    "  return streamer.finish_struct(*props);\n"
+    "  return streamer.finish_struct(*props, member_ids);\n"
     "}\n\n";
   static const char *pfmt =
     "\n  entity_properties_t::finish(props, keylist);\n"
-    "  props_end = props.data() + props.size();\n"
     "  initialized.store(true, std::memory_order_release);\n"
     "  return props;\n"
     "}\n\n";
@@ -1183,7 +1169,7 @@ print_entry_point_functions(
   static const char *fmt =
     "template<typename S, std::enable_if_t<std::is_base_of<cdr_stream, S>::value, bool> = true >\n"
     "bool {T}(S& str, {C}%1$s& instance, bool as_key) {\n"
-    "  auto &props = get_type_props<%1$s>();\n"
+    "  const auto &props = get_type_props<%1$s>();\n"
     "  str.set_mode(cdr_stream::stream_mode::{T}, as_key);\n"
     "  return {T}(str, instance, props.data()); \n"
     "}\n\n";
@@ -1316,8 +1302,6 @@ process_union(
   static const char *pfmt =
     "  streamer.position(union_max);\n"
     "  streamer.alignment(alignment_max);\n";
-  static const char *mfmt =
-    "  props->is_present = true;\n";
 
   char *fullname = NULL;
   if (IDL_PRINTA(&fullname, get_cpp11_fully_scoped_name, node, streams->generator) < 0)
@@ -1325,7 +1309,6 @@ process_union(
 
   if (revisit) {
     if (multi_putf(streams, MAX, pfmt)
-     || multi_putf(streams, MOVE | MAX, mfmt)
      || print_constructed_type_close(user_data)
      || (!is_nested(node) && print_entry_point_functions(streams, fullname))) /*only add entry point functions for non-nested (topic) types*/
       return IDL_RETCODE_NO_MEMORY;
@@ -1381,7 +1364,8 @@ process_typedef_decl(
   static const char* fmt =
     "template<typename T, std::enable_if_t<std::is_base_of<cdr_stream, T>::value, bool> = true >\n"
     "bool {T}_%1$s(T& streamer, {C}%2$s& instance) {\n"
-    "  (void)instance;\n";
+    "  (void)instance;\n"
+    "  member_id_set member_ids;\n";
   char* name = NULL;
   if (IDL_PRINTA(&name, get_cpp11_name_typedef, declarator, streams->generator) < 0)
     return IDL_RETCODE_NO_MEMORY;
@@ -1401,20 +1385,13 @@ process_typedef_decl(
   if (!idl_is_base_type(ts) && !idl_is_enum(ts) && !idl_is_string(ts) && !idl_is_alias(ts)) {
     char* unrolled_name = NULL;
     if (IDL_PRINTA(&unrolled_name, get_cpp11_fully_scoped_name, ts, streams->generator) < 0 ||
-        multi_putf(streams, ALL, "  auto prop = &(get_type_props<%1$s>()[0]);\n  prop->is_present = true;\n", unrolled_name))
+        multi_putf(streams, ALL, "  const auto &prop = &(get_type_props<%1$s>()[0]);\n", unrolled_name))
       return IDL_RETCODE_NO_MEMORY;
   }
 
-  if (process_entity(pstate, streams, declarator, type_spec, loc))
-    return IDL_RETCODE_NO_MEMORY;
-
-  if (idl_is_base_type(ts) || idl_is_enum(ts) || idl_is_string(ts) || idl_is_alias(ts)) {
-    if (multi_putf(streams, ALL, "  return true;\n}\n\n"))
+  if (process_entity(pstate, streams, declarator, type_spec, loc) ||
+      multi_putf(streams, ALL, "  return true;\n}\n\n"))
       return IDL_RETCODE_NO_MEMORY;
-  } else {
-    if (multi_putf(streams, ALL, "  return prop->is_present;\n}\n\n"))
-      return IDL_RETCODE_NO_MEMORY;
-  }
 
   return flush(streams->generator, streams);
 }

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -1141,7 +1141,9 @@ print_constructed_type_close(
     "  return props;\n"
     "}\n\n";
   static const char *pfmt2 =
-    "static const propvec &properties_%1$s = get_type_props<%2$s>();\n\n";
+    "namespace {\n"
+    "  static const volatile propvec &properties_%1$s = get_type_props<%2$s>();\n"
+    "}\n\n";
 
 
   char *fullname = NULL, *newname = NULL;


### PR DESCRIPTION
The type-specific entity_properties are now completely static, no longer thread_local
The getters for the entity_properties are also all const now, as the presence of struct fields is logged inside the streaming functions, and no modification of the member fields is necessary

@sumanth-nirmal, I can count on you to do a review of this PR?