### PR TITLE
Add howto guides for basic DDS concepts

### DIFF
--- a/docs/manual/howto.rst
+++ b/docs/manual/howto.rst
@@ -1,0 +1,23 @@
+..
+   Copyright(c) 2022 ZettaScale Technology and others
+
+   This program and the accompanying materials are made available under the
+   terms of the Eclipse Public License v. 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+   v. 1.0 which is available at
+   http://www.eclipse.org/org/documents/edl-v10.php.
+
+   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+
+Eclipse Cyclone DDS CXX HowTo Guide
+=====================================
+
+.. toctree::
+   :maxdepth: 2
+
+   howtos/exchange.rst
+   howtos/qos.rst
+   howtos/listener.rst
+   howtos/waitset.rst
+   howtos/status.rst

--- a/docs/manual/howtos/exchange.rst
+++ b/docs/manual/howtos/exchange.rst
@@ -1,0 +1,312 @@
+..
+   Copyright(c) 2022 ZettaScale Technology and others
+
+   This program and the accompanying materials are made available under the
+   terms of the Eclipse Public License v. 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+   v. 1.0 which is available at
+   http://www.eclipse.org/org/documents/edl-v10.php.
+
+   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+Exchanging Data
+=========
+
+This guide will show the user some basic concepts behind DDS data exchange.
+
+DomainParticipant
+---------
+
+A Domain is a specific subsection of the DDS shared dataspace and identified by their domain ID which is a 32 bit unsigned integer
+Data exchanges stay limited to the domain they are made on, e.g. data exchanged on domain 456 is not visible on domain 789.
+To be able to exchange data you will need to create a DomainParticipant, which is an entrypoint for the program on the shared dataspace's domain.
+
+You can either specify the default domain ID:
+
+.. code:: C++
+
+	dds::domain::DomainParticipant participant(domain::default_id());
+
+, or, if you want to have more control over the process, select your own ID:
+
+.. code:: C++
+	
+	dds::domain::DomainParticipant participant(123456);
+
+The main part here is that you have the same ID on the reading side as the writing, because they won't be visible to eachother otherwise.
+???Explain more about setting QoSes???
+
+Topic
+---------
+
+A Topic is a subsection of a DDS Domain which allows exchange of data of a specific type which adheres to certain restrictions on the exchange before exchange can occur. 
+A Topic is identifiable by:
+
+- a Name
+	- identifies the topic on the Domain
+	- has to be unique on the Domain
+- a Type
+	- the type of data being exchanged
+	- is the template parameter of the dds::topic::Topic class
+- a Quality of Service
+	- determines the restrictions on the exchange occurring
+	- this is an optional parameter, and can be derived from fallbacks to the participant or defaults
+
+A Topic is for exchanging data of the Type Data_Type is created on the DomainParticipant participant in the following manner:
+
+.. code:: C++
+
+	dds::topic::Topic<Data_Type> topic(participant, "DataType Topic");
+
+The data type of the topic is generated from the user's IDL files by using CycloneDDS's idlc generator with the idlcxx library.
+Using types other than those generated from idlc+idlcxx in the template will not have the prerequisite traits and therefore not result in working code.
+
+Publishers
+---------
+
+A Publisher is a producer of data on a Domain. It uses the DomainParticipant to gain access to the Domain and is created using it.
+A Publisher allows the DataWriters associated with it to share the same behaviour, such as:
+
+- liveliness notifications
+- QoS policies
+- listener callbacks
+- etc.
+
+You can either use the default settings:
+
+.. code:: C++
+
+	dds::pub::Publisher pub(participant);
+
+Or supply your own:
+
+.. code:: C++
+
+	dds::pub::NoOpPublisherListener listener; /*you need to create your own class that derives from this listener, and implement your own callbacks*/
+	/*the listener implementation should implement the on_publication_matched virtual function as we will rely on it later*/
+	dds::pub::qos::PublisherQos pubqos; /*add custom QoS policies that you want for this publisher*/
+	dds::pub::Publisher pub(participant, pubqos, &listener, dds::core::status::StatusMask::publication_matched()); /*in this case, the only status we are interested in is publication_matched*/
+
+Now, any DataWriters created using pub will inherit the qos and listener functionality as set through it.
+
+Subscribers
+---------
+
+A Subscriber is a consumer of data on a Domain. It uses the DomainParticipant to gain access to the Domain and is created using it.
+A Subscriber allows the DataReaders associated with it to share the same behaviour, such as:
+
+- liveliness notifications
+- QoS policies
+- listener callbacks
+- etc.
+
+You can either use the default settings:
+
+.. code:: C++
+
+	dds::sub::Subscriber sub(participant);
+
+Or supply your own:
+
+.. code:: C++
+
+	dds::sub::NoOpSubscriberListener listener; /*you need to create your own class that derives from this listener, and implement your own callbacks*/
+	/*the listener implementation should implement the on_subscription_matched virtual function as we will rely on it later*/
+	dds::sub::qos::SubscriberQos subqos; /*add custom QoS policies that you want for this subscriber*/
+	dds::sub::Subscriber sub(participant, subqos, &listener, dds::core::status::StatusMask::subscription_matched());
+
+Now, any DataReaders created using sub will inherit the qos and listener functionality as set through it.
+
+DataReaders
+---------
+
+DataReaders allow the user access to the data received by a Subscriber on a Topic, and take as a template parameter the data type being exchanged. The settings for the reader are either inheriting from the subscriber:
+
+.. code:: C++
+
+	dds::sub::DataReader<DataType> reader(sub, topic);
+
+, or explicitly setting its own QoS policies and listener:
+
+.. code:: C++
+
+	dds::sub::NoOpAnyDataReaderListener listener; /*you need to create your own class that derives from this listener, and implement your own callback functions*/
+	/*the listener implementation should implement the on_data_available virtual function as we will rely on it later*/
+	dds::sub::qos::DataReaderQos rqos;
+	dds::sub::DataReader<DataType> reader(sub, topic, rqos, &listener, dds::core::status::StatusMask::data_available());
+
+The data is accessed by either `reading` or `taking` the samples from the reader.
+Both return a container of `dds::sub::Sample`s which have the received sample of the exchanged datatype accessed through `data()` and the metadata for the received sample accessed through `info()`.
+The metadata contains such information as:
+
+- sample timestamp (time of writing)
+- data validity (whether the call to `data()` will return anything that should be processed)
+- sample state (READ/NOT_READ/...)
+- ...
+
+The difference between these two different access methods is the state of the reader after the access is finished.
+The `take` operation only returns samples which have not yet been returned in a `take` operation, whereas the `read` operation returns all samples currently stored by the reader.
+
+.. code:: C++
+
+	auto samples = reader.take();
+	for (const auto & sample:samples) {
+		if (!sample.valid())
+			continue;
+		const auto &data = sample.data();
+		/*print the data?*/
+	}
+
+.. code:: C++
+
+	auto samples = reader.read();
+	for (const auto & sample:samples) {
+		if (!sample.valid() ||
+			sample.state() != dds::sub::status::SampleState::not_read())
+			continue;
+		const auto &data = sample.data();
+		/*print the data?*/
+	}
+
+DataWriters
+---------
+
+DataWriters allow the user to write data to a Topic using a Publisher, and take as a template parameter the data type being exchanged. The settings for the writer are either inheriting from the publisher:
+
+.. code:: C++
+
+	dds::pub::DataWriter<DataType> writer(pub, topic);
+
+, or explicitly setting its own QoS policies and listener:
+
+.. code:: C++
+
+	dds::pub::NoOpAnyDataWriterListener listener; /*you need to create your own class that derives from this listener, and implement your own callback functions*/
+	/*the listener implementation should implement the on_publication_matched virtual function as we will rely on it later*/
+	dds::pub::qos::DataWriterQos wqos;
+	dds::pub::DataWriter<DataType> writer(pub, topic, wqos, &listener, dds::core::status::StatusMask::publication_matched());
+
+A writer can simply write a sample:
+
+.. code:: C++
+
+	DataType sample;
+	writer.write(sample);
+
+A sample with a specific timestamp:
+
+.. code:: C++
+
+	DataType sample;
+	dds::core::Time timestamp(123 /*seconds*/, 456 /*nanoseconds*/);
+	writer.write(sample, timestamp);
+
+Or a range of samples:
+
+.. code:: C++
+
+	std::vector<DataType> samples;
+	writer.write(samples.begin(), samples.end());
+
+Or update existing instances through handles, which we will not go into here.
+
+Small Example
+---------
+
+Putting it all together we can create the following code for writing data of the type DataType:
+
+.. code:: C++
+
+	/* for std::this_thread */
+	#include <thread>
+
+	/* include C++ DDS API. */
+	#include "dds/dds.hpp"
+
+	/* include the c++ data type, generated from idlcxx */
+	#include "DataType.hpp"
+
+	using namespace org::eclipse::cyclonedds;
+
+	int main() {
+		/*errors in construction/etc are indicated by exceptions*/
+		try {
+			dds::domain::DomainParticipant participant(domain::default_id());
+
+			dds::topic::Topic<DataType> topic(participant, "DataType Topic");
+
+			dds::pub::Publisher publisher(participant);
+
+			dds::pub::DataWriter<DataType> writer(publisher, topic);
+
+			/*we wait for a reader to appear*/
+			while (writer.publication_matched_status().current_count() == 0)
+				std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+			DataType msg;
+
+			/*modify msg*/
+
+			writer.write(msg);
+
+            /*we wait for the reader to disappear*/
+			while (writer.publication_matched_status().current_count() > 0)
+				std::this_thread::sleep_for(std::chrono::milliseconds(50));
+		} catch (const dds::core::Exception& e) {
+			std::cerr << "An exception occurred: " << e.what() << std::endl;
+			exit(1);
+		}
+		return 0;
+	}
+
+This writer will wait for a reader to appear and then write a single sample to the DDS service, after that it will wait for the reader to disappear and then exit.
+And for reading data:
+
+.. code:: C++
+
+	/* for std::this_thread */
+	#include <thread>
+
+	/* include C++ DDS API. */
+	#include "dds/dds.hpp"
+
+	/* include the c++ data type, generated from idlcxx */
+	#include "DataType.hpp"
+
+	using namespace org::eclipse::cyclonedds;
+
+	int main() {
+
+		/*errors in construction/etc are indicated by exceptions*/
+		try {
+			dds::domain::DomainParticipant participant(domain::default_id());
+
+			dds::topic::Topic<DataType> topic(participant, "DataType Topic");
+
+			dds::sub::Subscriber subscriber(participant);
+
+			dds::sub::DataReader<DataType> reader(subscriber, topic);
+
+			/*we periodically check the reader for new samples*/
+			bool reading = true;
+			while (reading) {
+				std::this_thread::sleep_for(std::chrono::milliseconds(20));
+				auto samples = reader.take();
+				for (const auto & p:samples) {
+					const auto& info = p.info(); /*metadata*/
+					if (info.valid()) {
+						/*this sample contains valid data*/
+						const auto& msg = p.data(); /* the actual data */
+						std::cout << "Message received." << std::endl;
+						reading = false; /*we are done reading*/
+					}
+				}
+			}
+		} catch (const dds::core::Exception& e) {
+			std::cerr << "An exception occurred: " << e.what() << std::endl;
+			exit(1);
+		}
+		return 0;
+	}
+
+The reader will periodically (every 20ms) check for received data, and when it has received some, will stop.

--- a/docs/manual/howtos/qos.rst
+++ b/docs/manual/howtos/qos.rst
@@ -1,0 +1,164 @@
+..
+   Copyright(c) 2022 ZettaScale Technology and others
+
+   This program and the accompanying materials are made available under the
+   terms of the Eclipse Public License v. 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+   v. 1.0 which is available at
+   http://www.eclipse.org/org/documents/edl-v10.php.
+
+   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+Quality of Service
+==================
+
+Quality of Service is the collection of different restrictions and expectations called QoSPolicies on the behaviour of the different components of CycloneDDS.
+Some QoSPolicies only affect a single type of DDS entity, whereas others affect multiple, and QoSPolicies on a DDS entity cannot be modified after creating the entity as they affect matching/discovery of entities.
+The QoS used is linked to a type of DDS entity the QoS is used for, e.g.: a SubscriberQoS is not accepted when creating a DataReader.
+The entity-specific QoSes can be found in the `qos` sub-namespace of the same namespace the entity is defined in, whereas the different QoSPolicies are located in the `dds::core::policy` namespace.
+
+.. table:: DDS entity types and associated QoSes
+
+	+-----------------------+----------------------+
+	| CDDS-CXX Entity Type  | QoS Type             |
+	+=======================+======================+
+	| DomainParticipant     | DomainParticipantQos |
+	+-----------------------+----------------------+
+	| Publisher             | PublisherQos         |
+	+-----------------------+----------------------+
+	| Subscriber            | SubscriberQos        |
+	+-----------------------+----------------------+
+	| Topic                 | TopicQos             |
+	+-----------------------+----------------------+
+	| DataWriter            | DataWriterQos        |
+	+-----------------------+----------------------+
+	| DataReader            | DataReaderQos        |
+	+-----------------------+----------------------+
+
+.. table:: QoSPolicies and associated QoSes:
+
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| QoSPolicy                  | DomainParticipantQos | PublisherQos | SubscriberQos | TopicQos | DataWriterQos | DataReaderQos |
+	+============================+======================+==============+===============+==========+===============+===============+
+	| UserData                   | Y                    | N            | N             | N        | Y             | Y             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| EntityFactory              | Y                    | Y            | Y             | Y        | Y             | Y             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| TopicData                  | N                    | N            | N             | Y        | N             | N             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| Durability                 | N                    | N            | N             | Y        | Y             | Y             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| DurabilityService          | N                    | N            | N             | Y        | Y             | N             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| Deadline                   | N                    | N            | N             | Y        | Y             | Y             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| LatencyBudget              | N                    | N            | N             | Y        | Y             | Y             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| Liveliness                 | N                    | N            | N             | Y        | Y             | Y             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| Reliability                | N                    | N            | N             | Y        | Y             | Y             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| DestinationOrder           | N                    | N            | N             | Y        | Y             | Y             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| History                    | N                    | N            | N             | Y        | Y             | Y             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| ResourceLimits             | N                    | N            | N             | Y        | Y             | Y             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| TransportPriority          | N                    | N            | N             | Y        | Y             | N             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| Lifespan                   | N                    | N            | N             | Y        | Y             | N             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| Ownership                  | N                    | N            | N             | Y        | Y             | Y             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| Presentation               | N                    | Y            | Y             | N        | N             | N             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| Partition                  | N                    | Y            | Y             | N        | N             | N             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| GroupData                  | N                    | Y            | Y             | N        | N             | N             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| OwnershipStrength          | N                    | N            | N             | N        | Y             | N             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| WriterDataLifecycle        | N                    | N            | N             | N        | Y             | N             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| TimeBasedFilter            | N                    | N            | N             | N        | N             | Y             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| ReaderDataLifecycle        | N                    | N            | N             | N        | Y             | N             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| DataRepresentation         | N                    | N            | N             | Y        | Y             | Y             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+	| TypeConsistencyEnforcement | N                    | N            | N             | Y        | Y             | Y             |
+	+----------------------------+----------------------+--------------+---------------+----------+---------------+---------------+
+
+Setting of QoSPolicies can be done either through left-shifting the QoSPolicy "into" the QoS:
+
+.. code:: C++
+
+	dds::sub::qos::DataReaderQos rqos;
+	rqos << dds::core::policy::Durability(dds::core::policy::DurabilityKind::TRANSIENT_LOCAL);
+
+, or passing it as the parameter of the `policy` function:
+
+.. code:: C++
+
+	dds::pub::qos::DataWriterQos wqos;
+	dds::core::policy::Reliability rel(dds::core::policy::ReliabilityKind::RELIABLE, dds::core::Duration(8, 8));
+	wqos.policy(rel);
+
+Whereas getting of QoSPolicies can be done either through the right-shifting the QoSPolicy "out of" the QoS:
+
+.. code:: C++
+
+	dds::topic::qos::TopicQos tqos;
+	dds::core::policy::TopicData td;
+	tqos >> td;
+
+, or through the `policy` function, which is templated to indicate which QoSPolicy is being accessed:
+
+.. code:: C++
+
+	dds::domain::qos::DomainParticipantQos dqos;
+	auto ud = dqos.policy<dds::core::policy::UserData>();
+
+For a more detailed explanation of the different QoSPolicies and their effects on the behaviour of CycloneDDS, the user is referred to the OMG DDS Spec v1.4 section 2.2.3.
+
+Default and Inherited QoSes
+------------
+
+QoSes have a number of default settings that are falled back to when none are provided upon creation.
+These defaults are either defined in the DDS standard, or propagated from "superior" entities.
+The default inherited QoS for entities is set through the following functions:
+
+.. table:: Default QoSes and accessors
+
+	+-------------------+--------------------+------------------------+
+	| Superior Entity   | Subordinate Entity | Default QoS accessor   |
+	+===================+====================+========================+
+	| DomainParticipant | Topic              | default_topic_qos      |
+	|                   +--------------------+------------------------+
+	|                   | Publisher          | default_publisher_qos  |
+	|                   +--------------------+------------------------+
+	|                   | Subscriber         | default_subscriber_qos |
+	+-------------------+--------------------+------------------------+
+	| Topic             | DataReader         | default_datareader_qos |
+	|                   +--------------------+------------------------+
+	|                   | DataWriter         | default_datawriter_qos |
+	+-------------------+--------------------+------------------------+
+	| Publisher         | DataWriter         | default_datawriter_qos |
+	+-------------------+--------------------+------------------------+
+	| Subscriber        | DataReader         | default_datareader_qos |
+	+-------------------+--------------------+------------------------+
+
+So in the following case:
+
+.. code:: C++
+
+	dds::sub::Subscriber sub(participant);
+	dds::sub::qos::DataReaderQos qos1, qos2;
+	qos1 << dds::core::policy::Durability(dds::core::policy::DurabilityKind::TRANSIENT_LOCAL);
+	qos2 << dds::core::policy::DestinationOrder(dds::core::policy::DestinationOrderKind::BY_SOURCE_TIMESTAMP);
+	sub.default_datareader_qos(qos1);
+	dds::sub::DataReader<DataType> reader(sub,topic,qos2);
+
+, `reader` will have its `DestinationOrder` QoSPolicy set to the value set in the QoS supplied in its constructor, being `BY_SOURCE_TIMESTAMP`.
+On the other hand, the `Durability` QoSPolicy defaults to the one set as default on the Subscriber, being `TRANSIENT_LOCAL`.
+Lastly all other QosPolicies will default to the DDS Spec, for instance the `Ownership` QoSPolicy will have the value `SHARED`.

--- a/docs/manual/howtos/status.rst
+++ b/docs/manual/howtos/status.rst
@@ -1,0 +1,171 @@
+..
+   Copyright(c) 2022 ZettaScale Technology and others
+
+   This program and the accompanying materials are made available under the
+   terms of the Eclipse Public License v. 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+   v. 1.0 which is available at
+   http://www.eclipse.org/org/documents/edl-v10.php.
+
+   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+Statuses
+=========
+
+Entities in DDS have statuses indicating the internal state and/or history of said entity.
+These statuses are used to signal Waitsets and Listeners, and are different between types of DDS entities.
+Below is a table explaining enumerating the fields for each status and their meaning:
+
+.. table:: CycloneDDS-CXX Status entities and fields
+	
+	+-----------------------+--------------------------------+--------------------------+------------------------------------------------------+
+	| CDDS-CXX Entity Type  | Status Entity                  | Associated Fields        | Meaning of field                                     |
+	+=======================+================================+==========================+======================================================+
+	| DomainParticipant     |                                |                          |                                                      |
+	+-----------------------+--------------------------------+--------------------------+------------------------------------------------------+
+	| Publisher             |                                |                          |                                                      |
+	+-----------------------+--------------------------------+--------------------------+------------------------------------------------------+
+	| Subscriber            |                                |                          |                                                      |
+	+-----------------------+--------------------------------+--------------------------+------------------------------------------------------+
+	| Topic                 | InconsistentTopicStatus        | total_count              | the total number of times an inconsistent topic was  |
+	|                       |                                |                          | encountered                                          |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | total_count_change       | the change in total_count since last being retrieved |
+	+-----------------------+--------------------------------+--------------------------+------------------------------------------------------+
+	| DataWriter            | OfferedDeadlineMissedStatus    | total_count              | the total number of times an offered deadline was    |
+	|                       |                                |                          | missed by the writer committing itself to the        |
+	|                       |                                |                          | deadline                                             |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | total_count_change       | the change in total_count since last being retrieved |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | last_instance_handle     | handle to the last instance in a writer missing a    |
+	|                       |                                |                          | committed deadline                                   |
+	|                       +--------------------------------+--------------------------+------------------------------------------------------+
+	|                       | OfferedIncompatibleQosStatus   | total_count              | the total number of times the writer encountered a   |
+	|                       |                                |                          | reader requesting a QoS which was was not compatible |
+	|                       |                                |                          | with the one offered by the writer                   |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | total_count_change       | the change in total_count since last being retrieved |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | last_policy_id           | the last id of the QoSPolicy which was incompatible  |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | policies                 | a collection of QoSPolicy ids and the number times   |
+	|                       |                                |                          | they were found to be incompatible                   |
+	|                       +--------------------------------+--------------------------+------------------------------------------------------+
+	|                       | LivelinessLostStatus           | total_count              | the total number of times a writer became "dead" by  |
+	|                       |                                |                          | not asserting its liveliness often enough            |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | total_count_change       | the change in total_count since last being retrieved |
+	|                       +--------------------------------+--------------------------+------------------------------------------------------+
+	|                       | PublicationMatchedStatus       | total_count              | the total number of times a writer has encountered a |
+	|                       |                                |                          | reader it has a "match" with                         |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | total_count_change       | the change in total_count since last being retrieved |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | current_count            | the current number of readers a writer has a "match" |
+	|                       |                                |                          | with                                                 |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | current_count_change     | the change in current_count since last being         |
+	|                       |                                |                          | retrieved                                            |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | last_subscription_handle | handle to the last reader causing this status to     |
+	|                       |                                |                          | change                                               |
+	+-----------------------+--------------------------------+--------------------------+------------------------------------------------------+
+	| DataReader            | RequestedDeadlineMissedStatus  | total_count              | total number of missed deadlines for instances read  |
+	|                       |                                |                          | by the reader                                        |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | total_count_change       | the change in total_count since last being retrieved |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | last_instance_handle     | the last instance handle to miss a deadline          |
+	|                       +--------------------------------+--------------------------+------------------------------------------------------+
+	|                       | RequestedIncompatibleQosStatus | total_count              | the total number of times the reader encountered a   |
+	|                       |                                |                          | writer offering a QoS which was was not compatible   |
+	|                       |                                |                          | with the one requested by the reader                 |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | total_count_change       | the change in total_count since last being retrieved |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | last_policy_id           | the last id of the QoSPolicy which was incompatible  |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | policies                 | a collection of QoSPolicy ids and the number times   |
+	|                       |                                |                          | they were found to be incompatible                   |
+	|                       +--------------------------------+--------------------------+------------------------------------------------------+
+	|                       | SampleRejectedStatus           | total_count              | total number of samples rejected by the reader       |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | total_count_change       | the change in total_count since last being retrieved |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | last_reason              | the last reason for rejecting a sample               |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | last_instance_handle     | handle to last instance encountering a rejected      |
+	|                       |                                |                          | sample                                               |
+	|                       +--------------------------------+--------------------------+------------------------------------------------------+
+	|                       | LivelinessChangedStatus        | alive_count              | the total number of matching writers that are alive  |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | alive_count_change       | the change in alive_count since last being retrieved |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | not_alive_count          | the total number of matching writers that are dead   |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | not_alive_count_change   | the change in not_alive_count since last being       |
+	|                       |                                |                          | retrieved                                            |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | last_publication_handle  | handle to the last writer causing this to change     |
+	|                       +--------------------------------+--------------------------+------------------------------------------------------+
+	|                       | SubscriptionMatchedStatus      | total_count              | the total number of times a reader has encountered a |
+	|                       |                                |                          | writer it has a "match" with                         |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | total_count_change       | the change in total_count since last being retrieved |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | current_count            | the current number of writers a reader has a "match" |
+	|                       |                                |                          | with                                                 |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | current_count_change     | the change in current_count since last being         |
+	|                       |                                |                          | retrieved                                            |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | last_publication_handle  | handle to the writer causing this status to change   |
+	|                       +--------------------------------+--------------------------+------------------------------------------------------+
+	|                       | SampleLostStatus               | total_count              | the total number of samples lost in the topic        |
+	|                       |                                +--------------------------+------------------------------------------------------+
+	|                       |                                | total_count_change       | the change in total_count since last being retrieved |
+	+-----------------------+--------------------------------+--------------------------+------------------------------------------------------+
+
+Fields of status objects containing counts of events will have both a cumulative and interval count,
+where the cumulative count will keep track of all changes during the lifetime of the DDS entity,
+and the interval count is the number of changes since the previous readout of the status.
+The statuses can be accessed by the following functions on the entity:
+
+.. table:: CycloneDDS-CXX Status accessors
+	
+	+-----------------------+--------------------------------+----------------------------------+
+	| CDDS-CXX Entity Type  | Status Entity                  | Accessor                         |
+	+=======================+================================+==================================+
+	| Topic                 | InconsistentTopicStatus        | inconsistent_topic_status        |
+	+-----------------------+--------------------------------+----------------------------------+
+	| DataWriter            | OfferedDeadlineMissedStatus    | offered_deadline_missed_status   |
+	|                       +--------------------------------+----------------------------------+
+	|                       | OfferedIncompatibleQosStatus   | offered_incompatible_qos_status  |
+	|                       +--------------------------------+----------------------------------+
+	|                       | LivelinessLostStatus           | liveliness_lost_status           |
+	|                       +--------------------------------+----------------------------------+
+	|                       | PublicationMatchedStatus       | publication_matched_status       |
+	+-----------------------+--------------------------------+----------------------------------+
+	| DataReader            | RequestedDeadlineMissedStatus  | requested_deadline_missed_status |
+	|                       +--------------------------------+----------------------------------+
+	|                       | RequestedIncompatibleQosStatus | requested_incompatible_status    |
+	|                       +--------------------------------+----------------------------------+
+	|                       | SampleRejectedStatus           | sample_rejected_status           |
+	|                       +--------------------------------+----------------------------------+
+	|                       | LivelinessChangedStatus        | liveliness_changed_status        |
+	|                       +--------------------------------+----------------------------------+
+	|                       | SubscriptionMatchedStatus      | subscription_matched_status      |
+	|                       +--------------------------------+----------------------------------+
+	|                       | SampleLostStatus               | sample_lost_status               |
+	+-----------------------+--------------------------------+----------------------------------+
+
+The following piece of code shows using statuses to make a writer wait until readers are present:
+
+.. code:: C++
+
+	dds::pub::DataWriter<DataType> wr(publisher, topic);
+	while (0 == wr.publication_matched_status().current_count())
+		std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+, here the writer will poll the total number of readers that are receiving data from it at a 20 millisecond interval for as long as there are no readers.

--- a/docs/manual/howtos/waitset.rst
+++ b/docs/manual/howtos/waitset.rst
@@ -1,0 +1,87 @@
+..
+   Copyright(c) 2022 ZettaScale Technology and others
+
+   This program and the accompanying materials are made available under the
+   terms of the Eclipse Public License v. 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+   v. 1.0 which is available at
+   http://www.eclipse.org/org/documents/edl-v10.php.
+
+   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+Waitsets
+=========
+
+Waitsets are a tool in CycloneDDS to hold execution of the program until a specific condition is reached, or an amount of time has expired.
+Waitsets and listeners cover two different requirement sets.
+Whereas Listeners can only react to changes in state, a Waitset also allows the code to react when nothing changes.
+On the other hand, Listeners allow instant callbacks to specific changes.
+A waitset uses a StatusCondition linked to an Entity to signal to the waitset that its wait is finished.
+The StatusCondition has a list of enabled statuses, which describe the changes in status which should trigger the waitset to finish its wait.
+When creating a StatusCondition, the enabled statuses should match the type of entity it is attached to.
+Different StatusConditions linked to different Entities can be attached to a Waitset through the `attach_condition` function, and detached through the `detach_condition` function.
+After having created a Waitset with StatusConditions attached, a wait can be triggered for the Duration specified, and triggering the wait will cause one of two things to happen:
+
+- the wait will time out, causing an exception of the type dds::core::TimeoutError to be thrown
+- a status change of one of the attached conditions will occur, and the returned container will contain the conditions that have triggered the end of the wait
+
+So the following code will work, since subscription_matched is a status associated with a DataReader:
+
+.. code:: C++
+
+	dds::sub::DataReader<DataType> reader(sub, topic);
+	dds::core::cond::StatusCondition rsc(reader);
+	rsc.enabled_statuses(dds::core::status::StatusMask::subscription_matched());
+
+But the following code will fail, since liveliness_lost is not a status associated with a Topic:
+
+.. code:: C++
+
+	dds::topic::Topic<DataType> topic(participant,"topic");
+	dds::core::cond::StatusCondition tsc(topic);
+	tsc.enabled_statuses(dds::core::status::StatusMask::liveliness_lost());
+
+So as an example, the following code will attempt to wait a specified amount of time for readers and writers to see their counterparts, allowing two-way communication to occur:
+
+.. code:: C++
+
+	template<typename T>
+	bool match_reader_and_writer(dds::sub::DataReader<T> &rd, dds::pub::DataWriter<T> &wr, const dds::core::Duration &dur) {
+		try {
+
+			dds::core::cond::StatusCondition wsc(wr), rsc(rd);
+			wsc.enabled_statuses(dds::core::status::StatusMask::publication_matched());
+			rsc.enabled_statuses(dds::core::status::StatusMask::subscription_matched());
+
+			dds::core::cond::WaitSet waitset;
+			waitset.attach_condition(wsc);
+			waitset.attach_condition(rsc);
+
+			auto start = std::chrono::steady_clock::now();
+			auto result = waitset.wait(dur);
+
+			bool is_pub = false;
+			if (result.empty()) {
+				return false;
+			} if (result[0] == wsc) {
+				is_pub = true;
+				waitset.detach_condition(wsc);
+			} else if (result[0] == rsc) {
+				waitset.detach_condition(rsc);
+			} else {
+				return false;
+			}
+
+			auto diff = std::chrono::steady_clock::now()-start;
+			dur -= dds::core::Duration(std::chrono::duration_cast<std::chrono::seconds>(diff).count(), std::chrono::duration_cast<std::chrono::nanoseconds>(diff).count()%1000000000);
+			result = waitset.wait(dur);
+
+			if (result.empty() || (is_pub && result[0] != rsc) || (!is_pub && result[0] != wsc))
+				return false;
+		} catch (const dds::core::TimeoutError &) {
+			return false;
+		}
+		return true;
+	}
+
+The above function will return true if the reader and writer have encountered matching publications and subscriptions before the timeout's duration expired, and false otherwise.


### PR DESCRIPTION
Added howto guides explaining the following basic DDS concepts:
- data exchange
- Quality of Service settings
- listeners
- waitsets
- statuses All guides are accompanied by code snippets giving examples of the use of the explained concepts

Signed-off-by: Martijn Reicher <martijn.reicher@zettascale.tech>