### PR TITLE
CLI formatting added to idlcxx

### DIFF
--- a/docs/manual/idlcxx.rst
+++ b/docs/manual/idlcxx.rst
@@ -57,30 +57,30 @@ the idlcxx library. For example:
 Sequences
 ---------
 
-The default container for both bounded and unbounded IDL sequences is std::vector.
+The default container for both bounded and unbounded IDL sequences is ``std::vector``.
 The custom containers for bounded and unbounded sequences can be defined independently.
-Any user-supplied container class that replaces std::vector must comply
+Any user-supplied container class that replaces ``std::vector`` must comply
 with the following interface (with the same effect as these functions in std::vector):
 
-- size
+- ``size``
 
-- resize
+- ``resize``
 
-- data
+- ``data``
 
-- operator==
+- ``operator==``
 
-- operator[]
+- ``operator[]``
 
-- copy assignment operator
+- ``copy assignment operator``
 
-- copy constructor
+- ``copy constructor``
 
 The command line options for custom sequence containers are:
 
 - ``bounded-sequence-template``
 
-  - template used for bounded sequences instead of std::vector
+  - template used for bounded sequences instead of ``std::vector``
 
   - replaced tags: ``{TYPE}``, ``{BOUND}``
 
@@ -90,7 +90,7 @@ The command line options for custom sequence containers are:
 
 - ``sequence-template``
 
-  - template used for sequences instead of std::vector
+  - template used for sequences instead of ``std::vector``
 
   - replaced tags: ``{TYPE}``
 
@@ -101,28 +101,28 @@ The command line options for custom sequence containers are:
 Strings
 -------
 
-The default container used for both bounded and unbounded IDL strings is std::string.
+The default container used for both bounded and unbounded IDL strings is ``std::string``.
 The custom containers for bounded and unbounded strings can be defined independently.
-Any user-supplied container class that replaces std::string must comply
-with the following interface (with the same effect as these functions in std::string):
+Any user-supplied container class that replaces ``std::string`` must comply
+with the following interface (with the same effect as these functions in ``std::string``):
 
-- length
+- ``length``
 
-- assign
+- ``assign``
 
   - the variant taking an input pointer and a length
 
-- operator==
+- ``operator==``
 
-- copy assignment operator
+- ``copy assignment operator``
 
-- copy constructor
+- ``copy constructor``
 
 The command line options for custom string containers are:
 
 - ``bounded-string-template``
 
-  - template to use for strings instead of std::string
+  - template to use for strings instead of ``std::string``
 
   - replaced tags: ``{BOUND}``
 
@@ -132,7 +132,7 @@ The command line options for custom string containers are:
 
 - ``string-template``
 
-  - template to use for strings instead of std::string
+  - template to use for strings instead of ``std::string``
 
   - replaced tags: none
 
@@ -143,9 +143,9 @@ The command line options for custom string containers are:
 Arrays
 ------
 
-The default container used for IDL arrays is std::array.
-Any user-supplied container class that replaces std::array must comply
-with the following interface (with the same effect as these functions in std::array):
+The default container used for IDL arrays is ``std::array``.
+Any user-supplied container class that replaces ``std::array`` must comply
+with the following interface (with the same effect as these functions in ``std::array``):
 
 - support auto-range for loops
 
@@ -157,7 +157,7 @@ The command line options for custom array containers are:
 
 - ``array-template``
 
-  - template to use for arrays instead of std::array
+  - template to use for arrays instead of ``std::array``
 
   - replaced tags: ``{TYPE}``, ``{DIMENSION}``
 
@@ -168,7 +168,7 @@ The command line options for custom array containers are:
 Unions
 ------
 
-IDL unions use the std::variant class by default as the container for the union values.
+IDL unions use the ``std::variant`` class by default as the container for the union values.
 The only function needed from the custom union container is the templated getter function:
 
 .. code:: c++
@@ -183,7 +183,7 @@ The command line options for custom variant containers are:
 
 - ``union-template``
 
-  - template to use for unions instead of std::variant, copied verbatim
+  - template to use for unions instead of ``std::variant``, copied verbatim
 
 - ``union-include``
 


### PR DESCRIPTION
Minor edit to  apply cli formatting to the Sequences, Strings, Arrays and Unions sections