### PR TITLE
Added missing export of QoSPolicy non-const accessor functions

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/domain/qos/DomainParticipantQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/domain/qos/DomainParticipantQosDelegate.hpp
@@ -75,7 +75,7 @@ DomainParticipantQosDelegate::policy<dds::core::policy::UserData> () const
 }
 
 template<>
-dds::core::policy::UserData&
+OMG_DDS_API dds::core::policy::UserData&
 DomainParticipantQosDelegate::policy<dds::core::policy::UserData> ();
 
 
@@ -87,7 +87,7 @@ DomainParticipantQosDelegate::policy<dds::core::policy::EntityFactory> () const
 }
 
 template<>
-dds::core::policy::EntityFactory&
+OMG_DDS_API dds::core::policy::EntityFactory&
 DomainParticipantQosDelegate::policy<dds::core::policy::EntityFactory> ();
 
 }

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.hpp
@@ -111,7 +111,7 @@ DataWriterQosDelegate::policy<dds::core::policy::UserData>() const
     return user_data_;
 }
 
-template<> dds::core::policy::UserData&
+template<> OMG_DDS_API dds::core::policy::UserData&
 DataWriterQosDelegate::policy<dds::core::policy::UserData>();
 
 template<> inline const dds::core::policy::Durability&
@@ -120,7 +120,7 @@ DataWriterQosDelegate::policy<dds::core::policy::Durability>() const
     return durability_;
 }
 
-template<> dds::core::policy::Durability&
+template<> OMG_DDS_API dds::core::policy::Durability&
 DataWriterQosDelegate::policy<dds::core::policy::Durability>();
 
 template<> inline const dds::core::policy::Deadline&
@@ -129,7 +129,7 @@ DataWriterQosDelegate::policy<dds::core::policy::Deadline>() const
     return deadline_;
 }
 
-template<> dds::core::policy::Deadline&
+template<> OMG_DDS_API dds::core::policy::Deadline&
 DataWriterQosDelegate::policy<dds::core::policy::Deadline>();
 
 template<> inline const dds::core::policy::LatencyBudget&
@@ -138,7 +138,7 @@ DataWriterQosDelegate::policy<dds::core::policy::LatencyBudget>() const
     return budget_;
 }
 
-template<> dds::core::policy::LatencyBudget&
+template<> OMG_DDS_API dds::core::policy::LatencyBudget&
 DataWriterQosDelegate::policy<dds::core::policy::LatencyBudget>();
 
 
@@ -148,7 +148,7 @@ DataWriterQosDelegate::policy<dds::core::policy::Liveliness>() const
     return liveliness_;
 }
 
-template<> dds::core::policy::Liveliness&
+template<> OMG_DDS_API dds::core::policy::Liveliness&
 DataWriterQosDelegate::policy<dds::core::policy::Liveliness>();
 
 template<> inline const dds::core::policy::Reliability&
@@ -157,7 +157,7 @@ DataWriterQosDelegate::policy<dds::core::policy::Reliability>() const
     return reliability_;
 }
 
-template<> dds::core::policy::Reliability&
+template<> OMG_DDS_API dds::core::policy::Reliability&
 DataWriterQosDelegate::policy<dds::core::policy::Reliability>();
 
 template<> inline const dds::core::policy::DestinationOrder&
@@ -166,7 +166,7 @@ DataWriterQosDelegate::policy<dds::core::policy::DestinationOrder>() const
     return order_;
 }
 
-template<> dds::core::policy::DestinationOrder&
+template<> OMG_DDS_API dds::core::policy::DestinationOrder&
 DataWriterQosDelegate::policy<dds::core::policy::DestinationOrder>();
 
 template<> inline const dds::core::policy::History&
@@ -175,7 +175,7 @@ DataWriterQosDelegate::policy<dds::core::policy::History>() const
     return history_;
 }
 
-template<> dds::core::policy::History&
+template<> OMG_DDS_API dds::core::policy::History&
 DataWriterQosDelegate::policy<dds::core::policy::History>();
 
 
@@ -185,7 +185,7 @@ DataWriterQosDelegate::policy<dds::core::policy::ResourceLimits>() const
     return resources_;
 }
 
-template<> dds::core::policy::ResourceLimits&
+template<> OMG_DDS_API dds::core::policy::ResourceLimits&
 DataWriterQosDelegate::policy<dds::core::policy::ResourceLimits>();
 
 template<> inline const dds::core::policy::TransportPriority&
@@ -194,7 +194,7 @@ DataWriterQosDelegate::policy<dds::core::policy::TransportPriority>() const
     return priority_;
 }
 
-template<> dds::core::policy::TransportPriority&
+template<> OMG_DDS_API dds::core::policy::TransportPriority&
 DataWriterQosDelegate::policy<dds::core::policy::TransportPriority>();
 
 template<> inline const dds::core::policy::Lifespan&
@@ -203,7 +203,7 @@ DataWriterQosDelegate::policy<dds::core::policy::Lifespan>() const
     return lifespan_;
 }
 
-template<> dds::core::policy::Lifespan&
+template<> OMG_DDS_API dds::core::policy::Lifespan&
 DataWriterQosDelegate::policy<dds::core::policy::Lifespan>();
 
 template<> inline const dds::core::policy::Ownership&
@@ -212,7 +212,7 @@ DataWriterQosDelegate::policy<dds::core::policy::Ownership>() const
     return ownership_;
 }
 
-template<> dds::core::policy::Ownership&
+template<> OMG_DDS_API dds::core::policy::Ownership&
 DataWriterQosDelegate::policy<dds::core::policy::Ownership>();
 
 #ifdef  OMG_DDS_OWNERSHIP_SUPPORT
@@ -222,7 +222,7 @@ DataWriterQosDelegate::policy<dds::core::policy::OwnershipStrength>() const
     return strength_;
 }
 
-template<> dds::core::policy::OwnershipStrength&
+template<> OMG_DDS_API dds::core::policy::OwnershipStrength&
 DataWriterQosDelegate::policy<dds::core::policy::OwnershipStrength>();
 #endif  // OMG_DDS_OWNERSHIP_SUPPORT
 
@@ -232,7 +232,7 @@ DataWriterQosDelegate::policy<dds::core::policy::WriterDataLifecycle>() const
     return lifecycle_;
 }
 
-template<> dds::core::policy::WriterDataLifecycle&
+template<> OMG_DDS_API dds::core::policy::WriterDataLifecycle&
 DataWriterQosDelegate::policy<dds::core::policy::WriterDataLifecycle>();
 
 #ifdef OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
@@ -243,7 +243,7 @@ DataWriterQosDelegate::policy<dds::core::policy::DataRepresentation>() const
     return datarepresentation_;
 }
 
-template<> dds::core::policy::DataRepresentation&
+template<> OMG_DDS_API dds::core::policy::DataRepresentation&
 DataWriterQosDelegate::policy<dds::core::policy::DataRepresentation>();
 
 template<> inline const  dds::core::policy::TypeConsistencyEnforcement&
@@ -252,7 +252,7 @@ DataWriterQosDelegate::policy<dds::core::policy::TypeConsistencyEnforcement>() c
     return typeconsistencyenforcement_;
 }
 
-template<> dds::core::policy::TypeConsistencyEnforcement&
+template<> OMG_DDS_API dds::core::policy::TypeConsistencyEnforcement&
 DataWriterQosDelegate::policy<dds::core::policy::TypeConsistencyEnforcement>();
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/qos/PublisherQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/qos/PublisherQosDelegate.hpp
@@ -78,7 +78,7 @@ PublisherQosDelegate::policy<dds::core::policy::Presentation>() const
 }
 
 template<>
-dds::core::policy::Presentation&
+OMG_DDS_API dds::core::policy::Presentation&
 PublisherQosDelegate::policy<dds::core::policy::Presentation>();
 
 template<>
@@ -89,7 +89,7 @@ PublisherQosDelegate::policy<dds::core::policy::Partition>() const
 }
 
 template<>
-dds::core::policy::Partition&
+OMG_DDS_API dds::core::policy::Partition&
 PublisherQosDelegate::policy<dds::core::policy::Partition>();
 
 template<>
@@ -100,7 +100,7 @@ PublisherQosDelegate::policy<dds::core::policy::GroupData>() const
 }
 
 template<>
-dds::core::policy::GroupData&
+OMG_DDS_API dds::core::policy::GroupData&
 PublisherQosDelegate::policy<dds::core::policy::GroupData>();
 
 template<>
@@ -111,7 +111,7 @@ PublisherQosDelegate::policy<dds::core::policy::EntityFactory>() const
 }
 
 template<>
-dds::core::policy::EntityFactory&
+OMG_DDS_API dds::core::policy::EntityFactory&
 PublisherQosDelegate::policy<dds::core::policy::EntityFactory>();
 
 }

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.hpp
@@ -105,7 +105,7 @@ DataReaderQosDelegate::policy<dds::core::policy::Durability>() const
 }
 
 template<>
-dds::core::policy::Durability&
+OMG_DDS_API dds::core::policy::Durability&
 DataReaderQosDelegate::policy<dds::core::policy::Durability>();
 
 template<>
@@ -115,7 +115,7 @@ DataReaderQosDelegate::policy<dds::core::policy::UserData>() const
     return user_data_;
 }
 template<>
-dds::core::policy::UserData&
+OMG_DDS_API dds::core::policy::UserData&
 DataReaderQosDelegate::policy<dds::core::policy::UserData>();
 
 template<> inline const dds::core::policy::Deadline&
@@ -125,7 +125,7 @@ DataReaderQosDelegate::policy<dds::core::policy::Deadline>() const
 }
 
 template<>
-dds::core::policy::Deadline&
+OMG_DDS_API dds::core::policy::Deadline&
 DataReaderQosDelegate::policy<dds::core::policy::Deadline>();
 
 template<> inline const dds::core::policy::LatencyBudget&
@@ -135,7 +135,7 @@ DataReaderQosDelegate::policy<dds::core::policy::LatencyBudget>() const
 }
 
 template<>
-dds::core::policy::LatencyBudget&
+OMG_DDS_API dds::core::policy::LatencyBudget&
 DataReaderQosDelegate::policy<dds::core::policy::LatencyBudget>();
 
 template<> inline const dds::core::policy::Liveliness&
@@ -145,7 +145,7 @@ DataReaderQosDelegate::policy<dds::core::policy::Liveliness>() const
 }
 
 template<>
-dds::core::policy::Liveliness&
+OMG_DDS_API dds::core::policy::Liveliness&
 DataReaderQosDelegate::policy<dds::core::policy::Liveliness>();
 
 template<> inline const dds::core::policy::Reliability&
@@ -155,7 +155,7 @@ DataReaderQosDelegate::policy<dds::core::policy::Reliability>() const
 }
 
 template<>
-dds::core::policy::Reliability&
+OMG_DDS_API dds::core::policy::Reliability&
 DataReaderQosDelegate::policy<dds::core::policy::Reliability>();
 
 template<> inline const dds::core::policy::DestinationOrder&
@@ -165,7 +165,7 @@ DataReaderQosDelegate::policy<dds::core::policy::DestinationOrder>() const
 }
 
 template<>
-dds::core::policy::DestinationOrder&
+OMG_DDS_API dds::core::policy::DestinationOrder&
 DataReaderQosDelegate::policy<dds::core::policy::DestinationOrder>();
 
 template<> inline const dds::core::policy::History&
@@ -175,7 +175,7 @@ DataReaderQosDelegate::policy<dds::core::policy::History>() const
 }
 
 template<>
-dds::core::policy::History&
+OMG_DDS_API dds::core::policy::History&
 DataReaderQosDelegate::policy<dds::core::policy::History>();
 
 
@@ -186,7 +186,7 @@ DataReaderQosDelegate::policy<dds::core::policy::ResourceLimits>() const
 }
 
 template<>
-dds::core::policy::ResourceLimits&
+OMG_DDS_API dds::core::policy::ResourceLimits&
 DataReaderQosDelegate::policy<dds::core::policy::ResourceLimits>();
 
 template<> inline const dds::core::policy::Ownership&
@@ -196,7 +196,7 @@ DataReaderQosDelegate::policy<dds::core::policy::Ownership>() const
 }
 
 template<>
-dds::core::policy::Ownership&
+OMG_DDS_API dds::core::policy::Ownership&
 DataReaderQosDelegate::policy<dds::core::policy::Ownership>();
 
 template<> inline const dds::core::policy::TimeBasedFilter&
@@ -206,7 +206,7 @@ DataReaderQosDelegate::policy<dds::core::policy::TimeBasedFilter>() const
 }
 
 template<>
-dds::core::policy::TimeBasedFilter&
+OMG_DDS_API dds::core::policy::TimeBasedFilter&
 DataReaderQosDelegate::policy<dds::core::policy::TimeBasedFilter>();
 
 template<> inline const dds::core::policy::ReaderDataLifecycle&
@@ -216,7 +216,7 @@ DataReaderQosDelegate::policy<dds::core::policy::ReaderDataLifecycle>() const
 }
 
 template<>
-dds::core::policy::ReaderDataLifecycle&
+OMG_DDS_API dds::core::policy::ReaderDataLifecycle&
 DataReaderQosDelegate::policy<dds::core::policy::ReaderDataLifecycle>();
 
 #ifdef OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
@@ -226,7 +226,8 @@ DataReaderQosDelegate::policy<dds::core::policy::DataRepresentation>() const
     return datarepresentation_;
 }
 
-template<> dds::core::policy::DataRepresentation&
+template<>
+OMG_DDS_API dds::core::policy::DataRepresentation&
 DataReaderQosDelegate::policy<dds::core::policy::DataRepresentation>();
 
 template<> inline const  dds::core::policy::TypeConsistencyEnforcement&
@@ -235,7 +236,8 @@ DataReaderQosDelegate::policy<dds::core::policy::TypeConsistencyEnforcement>() c
     return typeconsistencyenforcement_;
 }
 
-template<> dds::core::policy::TypeConsistencyEnforcement&
+template<>
+OMG_DDS_API dds::core::policy::TypeConsistencyEnforcement&
 DataReaderQosDelegate::policy<dds::core::policy::TypeConsistencyEnforcement>();
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/qos/SubscriberQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/qos/SubscriberQosDelegate.hpp
@@ -79,7 +79,7 @@ SubscriberQosDelegate::policy<dds::core::policy::Presentation>() const
 }
 
 template<>
-dds::core::policy::Presentation&
+OMG_DDS_API dds::core::policy::Presentation&
 SubscriberQosDelegate::policy<dds::core::policy::Presentation>();
 
 template<>
@@ -90,7 +90,7 @@ SubscriberQosDelegate::policy<dds::core::policy::Partition>() const
 }
 
 template<>
-dds::core::policy::Partition&
+OMG_DDS_API dds::core::policy::Partition&
 SubscriberQosDelegate::policy<dds::core::policy::Partition>();
 
 template<>
@@ -101,7 +101,7 @@ SubscriberQosDelegate::policy<dds::core::policy::GroupData>() const
 }
 
 template<>
-dds::core::policy::GroupData&
+OMG_DDS_API dds::core::policy::GroupData&
 SubscriberQosDelegate::policy<dds::core::policy::GroupData>();
 
 
@@ -113,7 +113,7 @@ SubscriberQosDelegate::policy<dds::core::policy::EntityFactory>() const
 }
 
 template<>
-dds::core::policy::EntityFactory&
+OMG_DDS_API dds::core::policy::EntityFactory&
 SubscriberQosDelegate::policy<dds::core::policy::EntityFactory>();
 
 }

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/qos/TopicQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/qos/TopicQosDelegate.hpp
@@ -107,7 +107,7 @@ TopicQosDelegate::policy<dds::core::policy::TopicData>() const
     return topic_data_;
 }
 
-template<> dds::core::policy::TopicData&
+template<> OMG_DDS_API dds::core::policy::TopicData&
 TopicQosDelegate::policy<dds::core::policy::TopicData>();
 
 template<> inline const dds::core::policy::Durability&
@@ -116,7 +116,7 @@ TopicQosDelegate::policy<dds::core::policy::Durability>() const
     return durability_;
 }
 
-template<> dds::core::policy::Durability&
+template<> OMG_DDS_API dds::core::policy::Durability&
 TopicQosDelegate::policy<dds::core::policy::Durability>();
 
 #ifdef  OMG_DDS_PERSISTENCE_SUPPORT
@@ -126,7 +126,7 @@ TopicQosDelegate::policy<dds::core::policy::DurabilityService>() const
     return durability_service_;
 }
 
-template<> dds::core::policy::DurabilityService&
+template<> OMG_DDS_API dds::core::policy::DurabilityService&
 TopicQosDelegate::policy<dds::core::policy::DurabilityService>();
 #endif  // OMG_DDS_PERSISTENCE_SUPPORT
 
@@ -136,7 +136,7 @@ TopicQosDelegate::policy<dds::core::policy::Deadline>() const
     return deadline_;
 }
 
-template<> dds::core::policy::Deadline&
+template<> OMG_DDS_API dds::core::policy::Deadline&
 TopicQosDelegate::policy<dds::core::policy::Deadline>();
 
 template<> inline const dds::core::policy::LatencyBudget&
@@ -145,7 +145,7 @@ TopicQosDelegate::policy<dds::core::policy::LatencyBudget>() const
     return budget_;
 }
 
-template<> dds::core::policy::LatencyBudget&
+template<> OMG_DDS_API dds::core::policy::LatencyBudget&
 TopicQosDelegate::policy<dds::core::policy::LatencyBudget>();
 
 template<> inline const dds::core::policy::Liveliness&
@@ -154,7 +154,7 @@ TopicQosDelegate::policy<dds::core::policy::Liveliness>() const
     return liveliness_;
 }
 
-template<> dds::core::policy::Liveliness&
+template<> OMG_DDS_API dds::core::policy::Liveliness&
 TopicQosDelegate::policy<dds::core::policy::Liveliness>();
 
 template<> inline const dds::core::policy::Reliability&
@@ -163,7 +163,7 @@ TopicQosDelegate::policy<dds::core::policy::Reliability>() const
     return reliability_;
 }
 
-template<> dds::core::policy::Reliability&
+template<> OMG_DDS_API dds::core::policy::Reliability&
 TopicQosDelegate::policy<dds::core::policy::Reliability>();
 
 template<> inline const dds::core::policy::DestinationOrder&
@@ -172,7 +172,7 @@ TopicQosDelegate::policy<dds::core::policy::DestinationOrder>() const
     return order_;
 }
 
-template<> dds::core::policy::DestinationOrder&
+template<> OMG_DDS_API dds::core::policy::DestinationOrder&
 TopicQosDelegate::policy<dds::core::policy::DestinationOrder>();
 
 template<> inline const dds::core::policy::History&
@@ -181,7 +181,7 @@ TopicQosDelegate::policy<dds::core::policy::History>() const
     return history_;
 }
 
-template<> dds::core::policy::History&
+template<> OMG_DDS_API dds::core::policy::History&
 TopicQosDelegate::policy<dds::core::policy::History>();
 
 template<> inline const dds::core::policy::ResourceLimits&
@@ -190,7 +190,7 @@ TopicQosDelegate::policy<dds::core::policy::ResourceLimits>() const
     return resources_;
 }
 
-template<> dds::core::policy::ResourceLimits&
+template<> OMG_DDS_API dds::core::policy::ResourceLimits&
 TopicQosDelegate::policy<dds::core::policy::ResourceLimits>();
 
 template<> inline const dds::core::policy::TransportPriority&
@@ -199,7 +199,7 @@ TopicQosDelegate::policy<dds::core::policy::TransportPriority>() const
     return priority_;
 }
 
-template<> dds::core::policy::TransportPriority&
+template<> OMG_DDS_API dds::core::policy::TransportPriority&
 TopicQosDelegate::policy<dds::core::policy::TransportPriority>();
 
 template<> inline const dds::core::policy::Lifespan&
@@ -208,7 +208,7 @@ TopicQosDelegate::policy<dds::core::policy::Lifespan>() const
     return lifespan_;
 }
 
-template<> dds::core::policy::Lifespan&
+template<> OMG_DDS_API dds::core::policy::Lifespan&
 TopicQosDelegate::policy<dds::core::policy::Lifespan>();
 
 template<> inline const  dds::core::policy::Ownership&
@@ -217,7 +217,7 @@ TopicQosDelegate::policy<dds::core::policy::Ownership>() const
     return ownership_;
 }
 
-template<> dds::core::policy::Ownership&
+template<> OMG_DDS_API dds::core::policy::Ownership&
 TopicQosDelegate::policy<dds::core::policy::Ownership>();
 
 #ifdef OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
@@ -227,7 +227,7 @@ TopicQosDelegate::policy<dds::core::policy::DataRepresentation>() const
     return datarepresentation_;
 }
 
-template<> dds::core::policy::DataRepresentation&
+template<> OMG_DDS_API dds::core::policy::DataRepresentation&
 TopicQosDelegate::policy<dds::core::policy::DataRepresentation>();
 
 template<> inline const  dds::core::policy::TypeConsistencyEnforcement&
@@ -236,7 +236,7 @@ TopicQosDelegate::policy<dds::core::policy::TypeConsistencyEnforcement>() const
     return typeconsistencyenforcement_;
 }
 
-template<> dds::core::policy::TypeConsistencyEnforcement&
+template<> OMG_DDS_API dds::core::policy::TypeConsistencyEnforcement&
 TopicQosDelegate::policy<dds::core::policy::TypeConsistencyEnforcement>();
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
 


### PR DESCRIPTION
These functions were previously inline, and therefore did not need to be exported, but with commit 7b1f434 these are no longer inline and need to be exported for Windows compiles
Added exports for these functions now

Signed-off-by: Martijn Reicher <martijn.reicher@zettascale.tech>