### PR TITLE
Fix for issue #336

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -224,7 +224,7 @@ bool read_header(const void *buffer, encoding_version &ver, endianness &end)
       break;
     case extensibility::ext_appendable:
       switch (field) {
-        case PL_CDR:
+        case PLAIN_CDR:
           ver = encoding_version::xcdr_v1;
           break;
         case D_CDR:


### PR DESCRIPTION
Incorrect encoding flag for xcdr_v1 appendable types was being required The read_header function was expecting the flag PL_CDR, but this should be PLAIN_CDR

Signed-off-by: Martijn Reicher <martijn.reicher@zettascale.tech>