### PR TITLE
Fix for coverity issue 73406

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/SampleInfoImpl.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/SampleInfoImpl.hpp
@@ -130,7 +130,7 @@ private:
                     const dds::sub::status::DataState& s1,
                     const dds::sub::status::DataState& s2)
     {
-        return s1.instance_state() == s1.instance_state()
+        return s1.instance_state() == s2.instance_state()
                && s1.view_state() == s2.view_state()
                && s1.sample_state() == s2.sample_state();
     }


### PR DESCRIPTION
This is a simple copy/paste error, and I forgot to change the second comparison parameter away from the first.

Signed-off-by: Martijn Reicher <martijn.reicher@zettascale.tech>