### PR TITLE
Add fix for Conan update

### DIFF
--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -76,7 +76,7 @@ steps:
     name: cache_conan
   - bash: |
       set -e -x
-      pip install conan --user
+      pip install "conan==1.59.0" --user
       conan profile new default --detect
     name: install_conan
   - bash: |


### PR DESCRIPTION
The default Conan version was updated to 2.0, so now we force fix the version to 1.59.0 as the current CUnit version (2.3.1) is currently not compatible with Conan v2.0