### PR TITLE
Pipeline fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,14 +27,14 @@ strategy:
       cxx: g++-10
     'Ubuntu 22.04 LTS with GCC 12 (Debug, x86_64)':
       image: ubuntu-22.04
-      analyzer: on
+      #analyzer: on #analyzer is disabled here, due to the sheer number of false positives
       sanitizer: address
       cc: gcc-12
       cxx: g++-12
     'Ubuntu 22.04 LTS with GCC 12 (Debug, x86_64, Iceoryx)':
       image: ubuntu-22.04
       iceoryx: on
-      analyzer: on
+      #analyzer: on #analyzer is disabled here, due to the sheer number of false positives
       sanitizer: address
       cc: gcc-12
       cxx: g++-12

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,43 +15,75 @@ pr: [ '*' ]
 
 strategy:
   matrix:
-    'Ubuntu 20.04 LTS with GCC 10 (Debug, x86_64)':
-      image: ubuntu-20.04
-      analyzer: on
-      sanitizer: address
-      iceoryx: on
-      examples: off
-      cc: gcc-10
-      cxx: g++-10
-    'Ubuntu 20.04 LTS with GCC 10 (Release, x86_64)':
-      image: ubuntu-20.04
-      build_type: Release
-      cc: gcc-10
-      cxx: g++-10
-    'Ubuntu 18.04 LTS with GCC 7 (Debug, x86_64)':
-      image: ubuntu-18.04
-      conanfile: conanfile102.txt
-      cc: gcc-7
-      gxx: g++-7
-    'Ubuntu 20.04 LTS with Clang 10 (Debug, x86_64)':
-      image: ubuntu-20.04
-      analyzer: on
-      sanitizer: address
-      iceoryx: on
-      cc: clang-10
-      cxx: clang++-10
     'Ubuntu 20.04 LTS with Clang 10 (Release, x86_64)':
       image: ubuntu-20.04
       build_type: Release
       cc: clang-10
       cxx: clang++-10
-    'macOS 10.15 with Clang 12 (Debug, x86_64)':
-      image: macOS-10.15
+    'Ubuntu 20.04 LTS with GCC 10 (Release, x86_64)':
+      image: ubuntu-20.04
+      build_type: Release
+      cc: gcc-10
+      cxx: g++-10
+    'Ubuntu 22.04 LTS with GCC 12 (Debug, x86_64)':
+      image: ubuntu-22.04
+      analyzer: on
+      sanitizer: address
+      cc: gcc-12
+      cxx: g++-12
+    'Ubuntu 22.04 LTS with GCC 12 (Debug, x86_64, Iceoryx)':
+      image: ubuntu-22.04
+      iceoryx: on
+      analyzer: on
+      sanitizer: address
+      cc: gcc-12
+      cxx: g++-12
+    'Ubuntu 22.04 LTS with GCC 12 (Release, x86_64)':
+      image: ubuntu-22.04
+      build_type: Release
+      sanitizer: address
+      cc: gcc-12
+      cxx: g++-12
+    'Ubuntu 22.04 LTS with GCC 12 (Release, x86_64, Iceoryx)':
+      image: ubuntu-22.04
+      build_type: Release
+      iceoryx: on
+      sanitizer: address
+      cc: gcc-12
+      cxx: g++-12
+    'Ubuntu 22.04 LTS with CLang 12 (Debug, x86_64)':
+      image: ubuntu-22.04
+      analyzer: on
+      sanitizer: address
+      cc: clang-12
+      cxx: clang++-12
+    'Ubuntu 22.04 LTS with CLang 12 (Debug, x86_64, Iceoryx)':
+      image: ubuntu-22.04
+      iceoryx: on
+      analyzer: on
+      sanitizer: address
+      cc: clang-12
+      cxx: clang++-12
+    'Ubuntu 22.04 LTS with CLang 12 (Release, x86_64)':
+      image: ubuntu-22.04
+      build_type: Release
+      sanitizer: address
+      cc: clang-12
+      cxx: clang++-12
+    'Ubuntu 22.04 LTS with CLang 12 (Release, x86_64, Iceoryx)':
+      image: ubuntu-22.04
+      build_type: Release
+      iceoryx: on
+      sanitizer: address
+      cc: clang-12
+      cxx: clang++-12
+    'macOS 11 with Clang 12 (Debug, x86_64)':
+      image: macOS-11
       sanitizer: address
       cc: clang
       cxx: clang++
-    'macOS 10.15 with Clang 12 (Release, x86_64)':
-      image: macOS-10.15
+    'macOS 11 with Clang 12 (Release, x86_64)':
+      image: macOS-11
       build_type: Release
       cc: clang
       cxx: clang++

--- a/src/ddscxx/tests/Regression.cpp
+++ b/src/ddscxx/tests/Regression.cpp
@@ -9,6 +9,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
+
+#include "dds/ddsrt/misc.h"
+
+DDSRT_WARNING_GNUC_OFF(maybe-uninitialized)
+
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "RegressionModels.hpp"
@@ -350,3 +355,5 @@ TEST_F(Regression, memberless_struct)
   auto ptr2 = v2.first_entity(props.data());
   EXPECT_EQ(ptr2, nullptr);
 }
+
+DDSRT_WARNING_GNUC_ON(maybe-uninitialized)

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -48,6 +48,8 @@ static int makefmtp(
       if (str[src] == '}' && (num = istok(str+tok, src-tok, toks))) {
         const char *flag;
         assert(toks && flags);
+        if (!flags)
+          return -1;
         flag = flags[num-1];
         len += (size_t)snprintf(buf, sizeof(buf), FMT, num, flag);
         tok = 0;

--- a/src/idlcxx/src/types.c
+++ b/src/idlcxx/src/types.c
@@ -951,16 +951,25 @@ emit_union(
     ncases++;
   }
 
-  const idl_case_t **cases = ncases ? malloc(sizeof(const idl_case_t *)*ncases) : NULL;
-  if (!cases)
-    return IDL_RETCODE_NO_MEMORY;
+  const idl_case_t **cases = NULL;
+  if (ncases) {
+    cases = malloc(sizeof(const idl_case_t *)*ncases);
+    if (!cases)
+      return IDL_RETCODE_NO_MEMORY;
+    memset(((void*)cases),0x0,sizeof(const idl_case_t *)*ncases);
+  }
 
   size_t i = 0;
   /*deduplicate types in cases*/
   IDL_FOREACH(_case, _union->cases) {
     bool type_already_present = false;
     for (size_t j = 0; j < i && !type_already_present; j++) {
-      if ((ret = is_same_type(pstate, cases[j]->type_spec, cases[j]->declarator, _case->type_spec, _case->declarator, &type_already_present)))
+      assert(cases[j]);
+      if (!cases[j])
+        ret = IDL_RETCODE_BAD_PARAMETER;
+      else
+        ret = is_same_type(pstate, cases[j]->type_spec, cases[j]->declarator, _case->type_spec, _case->declarator, &type_already_present);
+      if (ret != IDL_RETCODE_OK)
         goto cleanup;
     }
 


### PR DESCRIPTION
Removed deprecated pipelines (Ubuntu 18, macOS 10)
Added more modern pipelines (Ubuntu 22, macOS 11)

Fix uninitialized variable issues uncovered by analyzer

Disabled analyzer for Ubuntu GCC12 Debug builds