### PR TITLE
Fix build problem when type/topic discovery disabled

### DIFF
--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -115,6 +115,8 @@ steps:
             -DCMAKE_PREFIX_PATH="${BUILD_SOURCESDIRECTORY}/iceoryx/build/install" \
             -DSANITIZER=${SANITIZER:-none} \
             -DENABLE_SHM=${ICEORYX:-off} \
+            -DENABLE_TYPE_DISCOVERY=${TYPE_DISCOVERY:-on} \
+            -DENABLE_TOPIC_DISCOVERY=${TOPIC_DISCOVERY:-on} \
             ${GENERATOR:+-G} "${GENERATOR}" -A "${PLATFORM}" -T "${TOOLSET}" ..
       cmake --build . --config ${BUILD_TYPE} --target install -- ${BUILD_TOOL_OPTIONS}
     name: install_cyclonedds

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,6 +77,13 @@ strategy:
       sanitizer: address
       cc: clang-12
       cxx: clang++-12
+    'Ubuntu 22.04 LTS with GCC 12 (Debug, x86_64, no type discovery)':
+      image: ubuntu-22.04
+      sanitizer: address
+      cc: gcc-12
+      cxx: g++-12
+      type_discovery: off
+      topic_discovery: off
     'macOS 11 with Clang 12 (Debug, x86_64)':
       image: macOS-11
       sanitizer: address

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 gtest/1.12.1
-boost/1.78.0
+boost/1.81.0
 
 [generators]
 cmake

--- a/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
@@ -307,6 +307,9 @@ dds::topic::detail::Topic<T>::discover_topic(
         const std::string& name,
         const dds::core::Duration& timeout)
 {
+    // One would think it is possible to do some of this for locally defined topics even when
+    // topic discovery is not in the build.
+#ifdef DDSCXX_HAS_TOPIC_DISCOVERY
     dds::topic::Topic<T> found = dds::core::null;
     std::unique_ptr<dds_typeinfo_t, std::function<void(dds_typeinfo_t *)> >
       type_info(org::eclipse::cyclonedds::topic::TopicTraits<T>::getTypeInfo(nullptr),
@@ -348,6 +351,10 @@ dds::topic::detail::Topic<T>::discover_topic(
     }
 
     return found;
+#else
+    (void)dp; (void)name; (void)timeout;
+    throw dds::core::UnsupportedError(std::string("Cyclone DDS was built without topic discovery"));
+#endif
 }
 
 

--- a/src/ddscxx/tests/CMakeLists.txt
+++ b/src/ddscxx/tests/CMakeLists.txt
@@ -45,7 +45,6 @@ set(sources
   Conversions.cpp
   FindDataWriter.cpp
   FindDataReader.cpp
-  FindTopic.cpp
   Topic.cpp
   Publisher.cpp
   Serdata.cpp
@@ -71,7 +70,9 @@ set(sources
 
 if (ENABLE_TYPE_DISCOVERY AND ENABLE_TOPIC_DISCOVERY)
   # Add topic/type discovery tests
-  list(APPEND sources TopicTypeDiscovery.cpp)
+  list(APPEND sources
+    FindTopic.cpp
+    TopicTypeDiscovery.cpp)
 endif()
 
 if(ENABLE_SHM)


### PR DESCRIPTION
This makes it possible again to build without type/topic discovery support, and also adds a CI configuration to reduce the likelihood of this breaking again.

I've also bumped the boost version used on the CI, simply because I noticed that it was building the old version of boost from scratch and figured that the new version would be more likely to have binaries available for the updated set of platforms. (So far, so good.)

@reicheratwork my fix is not the most elegant because I completely disabled the "find topic" operation, but I think there are some cases that can be supported even when these parts of discovery are disabled. In the grand scheme of things, I think it is better to disable it altogether in this case than for it not to work at all, so I am in favour of merging this quickly and possibly improving the fix later. But I'd be interested in your opinion on this.

Fixes #370 #374