### PR TITLE
Lifetime fix

### DIFF
--- a/src/ddscxx/include/dds/pub/detail/DataWriterImpl.hpp
+++ b/src/ddscxx/include/dds/pub/detail/DataWriterImpl.hpp
@@ -930,11 +930,15 @@ void dds::pub::detail::DataWriter<T>::on_offered_deadline_missed(dds_entity_t,
     dds::core::status::OfferedDeadlineMissedStatus s;
     s.delegate() = sd;
 
-    dds::pub::DataWriter<T, dds::pub::detail::DataWriter> dw = wrapper();
+    auto sr = this->get_strong_ref();
+    if (sr) {
+        dds::pub::DataWriter<T, dds::pub::detail::DataWriter> dw = wrapper();
 
-    dds::pub::DataWriterListener<T> *l =
-            reinterpret_cast<dds::pub::DataWriterListener<T> *>(this->listener_get());
-    l->on_offered_deadline_missed(dw, s);
+        dds::pub::DataWriterListener<T> *l =
+                reinterpret_cast<dds::pub::DataWriterListener<T> *>(this->listener_get());
+        if (l)
+          l->on_offered_deadline_missed(dw, s);
+    }
 }
 
 template <typename T>
@@ -944,11 +948,15 @@ void dds::pub::detail::DataWriter<T>::on_offered_incompatible_qos(dds_entity_t,
     dds::core::status::OfferedIncompatibleQosStatus s;
     s.delegate() = sd;
 
-    dds::pub::DataWriter<T, dds::pub::detail::DataWriter> dw = wrapper();
+    auto sr = this->get_strong_ref();
+    if (sr) {
+        dds::pub::DataWriter<T, dds::pub::detail::DataWriter> dw = wrapper();
 
-    dds::pub::DataWriterListener<T> *l =
-            reinterpret_cast<dds::pub::DataWriterListener<T> *>(this->listener_get());
-    l->on_offered_incompatible_qos(dw, s);
+        dds::pub::DataWriterListener<T> *l =
+                reinterpret_cast<dds::pub::DataWriterListener<T> *>(this->listener_get());
+        if (l)
+          l->on_offered_incompatible_qos(dw, s);
+    }
 }
 
 template <typename T>
@@ -958,11 +966,15 @@ void dds::pub::detail::DataWriter<T>::on_liveliness_lost(dds_entity_t,
     dds::core::status::LivelinessLostStatus s;
     s.delegate() = sd;
 
-    dds::pub::DataWriter<T, dds::pub::detail::DataWriter> dw = wrapper();
+    auto sr = this->get_strong_ref();
+    if (sr) {
+        dds::pub::DataWriter<T, dds::pub::detail::DataWriter> dw = wrapper();
 
-    dds::pub::DataWriterListener<T> *l =
-            reinterpret_cast<dds::pub::DataWriterListener<T> *>(this->listener_get());
-    l->on_liveliness_lost(dw, s);
+        dds::pub::DataWriterListener<T> *l =
+                reinterpret_cast<dds::pub::DataWriterListener<T> *>(this->listener_get());
+        if (l)
+          l->on_liveliness_lost(dw, s);
+    }
 }
 
 template <typename T>
@@ -972,11 +984,15 @@ void dds::pub::detail::DataWriter<T>::on_publication_matched(dds_entity_t,
     dds::core::status::PublicationMatchedStatus s;
     s.delegate() = sd;
 
-    dds::pub::DataWriter<T, dds::pub::detail::DataWriter> dw = wrapper();
+    auto sr = this->get_strong_ref();
+    if (sr) {
+        dds::pub::DataWriter<T, dds::pub::detail::DataWriter> dw = wrapper();
 
-    dds::pub::DataWriterListener<T> *l =
-            reinterpret_cast<dds::pub::DataWriterListener<T> *>(this->listener_get());
-    l->on_publication_matched(dw, s);
+        dds::pub::DataWriterListener<T> *l =
+                reinterpret_cast<dds::pub::DataWriterListener<T> *>(this->listener_get());
+        if (l)
+          l->on_publication_matched(dw, s);
+    }
 }
 
 #endif /* OMG_DDS_PUB_DATA_WRITER_IMPL_HPP_ */

--- a/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
@@ -1351,11 +1351,15 @@ void dds::sub::detail::DataReader<T>::on_requested_deadline_missed(dds_entity_t,
     dds::core::status::RequestedDeadlineMissedStatus s;
     s.delegate() = sd;
 
-    dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+    auto sr = this->get_strong_ref();
+    if (sr) {
+        dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
 
-    dds::sub::DataReaderListener<T> *l =
-        reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
-    l->on_requested_deadline_missed(dr, s);
+        dds::sub::DataReaderListener<T> *l =
+            reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
+        if (l)
+          l->on_requested_deadline_missed(dr, s);
+    }
 }
 
 template <typename T>
@@ -1365,11 +1369,15 @@ void dds::sub::detail::DataReader<T>::on_requested_incompatible_qos(dds_entity_t
     dds::core::status::RequestedIncompatibleQosStatus s;
     s.delegate() = sd;
 
-    dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+    auto sr = this->get_strong_ref();
+    if (sr) {
+        dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
 
-    dds::sub::DataReaderListener<T> *l =
-        reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
-    l->on_requested_incompatible_qos(dr, s);
+        dds::sub::DataReaderListener<T> *l =
+            reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
+        if (l)
+          l->on_requested_incompatible_qos(dr, s);
+    }
 }
 
 template <typename T>
@@ -1379,11 +1387,15 @@ void dds::sub::detail::DataReader<T>::on_sample_rejected(dds_entity_t,
     dds::core::status::SampleRejectedStatus s;
     s.delegate() = sd;
 
-    dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+    auto sr = this->get_strong_ref();
+    if (sr) {
+        dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
 
-    dds::sub::DataReaderListener<T> *l =
+        dds::sub::DataReaderListener<T>* l =
             reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
-    l->on_sample_rejected(dr, s);
+        if (l)
+          l->on_sample_rejected(dr, s);
+    }
 }
 
 
@@ -1394,21 +1406,29 @@ void dds::sub::detail::DataReader<T>::on_liveliness_changed(dds_entity_t,
     dds::core::status::LivelinessChangedStatus s;
     s.delegate() = sd;
 
-    dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+    auto sr = this->get_strong_ref();
+    if (sr) {
+        dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
 
-    dds::sub::DataReaderListener<T> *l =
+        dds::sub::DataReaderListener<T>* l =
             reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
-    l->on_liveliness_changed(dr, s);
+        if (l)
+          l->on_liveliness_changed(dr, s);
+    }
 }
 
 template <typename T>
 void dds::sub::detail::DataReader<T>::on_data_available(dds_entity_t)
 {
-    dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+    auto sr = this->get_strong_ref();
+    if (sr) {
+        dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
 
-    dds::sub::DataReaderListener<T> *l =
-        reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
-    l->on_data_available(dr);
+        dds::sub::DataReaderListener<T>* l =
+            reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
+        if (l)
+          l->on_data_available(dr);
+    }
 }
 
 template <typename T>
@@ -1418,11 +1438,15 @@ void dds::sub::detail::DataReader<T>::on_subscription_matched(dds_entity_t,
     dds::core::status::SubscriptionMatchedStatus s;
     s.delegate() = sd;
 
-    dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+    auto sr = this->get_strong_ref();
+    if (sr) {
+        dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
 
-    dds::sub::DataReaderListener<T> *l =
-        reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
-    l->on_subscription_matched(dr, s);
+        dds::sub::DataReaderListener<T>* l =
+            reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
+        if (l)
+          l->on_subscription_matched(dr, s);
+    }
 }
 
 template <typename T>
@@ -1432,11 +1456,15 @@ void dds::sub::detail::DataReader<T>::on_sample_lost(dds_entity_t,
     dds::core::status::SampleLostStatus s;
     s.delegate() = sd;
 
-    dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
+    auto sr = this->get_strong_ref();
+    if (sr) {
+        dds::sub::DataReader<T, dds::sub::detail::DataReader> dr = wrapper();
 
-    dds::sub::DataReaderListener<T> *l =
-        reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
-    l->on_sample_lost(dr, s);
+        dds::sub::DataReaderListener<T> *l =
+            reinterpret_cast<dds::sub::DataReaderListener<T> *>(this->listener_get());
+        if (l)
+          l->on_sample_lost(dr, s);
+    }
 }
 
 // End of implementation

--- a/src/ddscxx/tests/CMakeLists.txt
+++ b/src/ddscxx/tests/CMakeLists.txt
@@ -67,7 +67,8 @@ set(sources
   Regression.cpp
   External.cpp
   DataModels.cpp
-  SampleInfo.cpp)
+  SampleInfo.cpp
+  DeferredDestruction.cpp)
 
 if (ENABLE_TYPE_DISCOVERY AND ENABLE_TOPIC_DISCOVERY)
   # Add topic/type discovery tests

--- a/src/ddscxx/tests/DeferredDestruction.cpp
+++ b/src/ddscxx/tests/DeferredDestruction.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright(c) 2023 ZettaScale Technologies
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include "HelloWorldData.hpp"
+
+#include <chrono>
+#include <dds/dds.hpp>
+#include <gtest/gtest.h>
+#include <thread>
+
+#include "dds/ddsrt/process.h"
+#include "dds/ddsrt/threads.h"
+
+#if DDSCXX_USE_BOOST
+#include <boost/optional.hpp>
+#define DDSCXX_STD_IMPL boost
+#else
+#include <optional>
+#define DDSCXX_STD_IMPL std
+#endif
+
+using HelloWorldData::Msg;
+
+std::string generate_unique_topic_name(const std::string &prefix)
+{
+    static std::atomic<uint64_t> count(0);
+
+    return prefix + std::to_string(count.load()) + "_pid" +  std::to_string(ddsrt_getpid()) + "_tid" +  std::to_string(ddsrt_gettid());
+}
+
+std::string topicName_ = generate_unique_topic_name("DeferredDestruction");
+
+template<typename T>
+class FakeDataReaderListener : public dds::sub::NoOpDataReaderListener<T>
+{
+public:
+    FakeDataReaderListener()
+    {
+        std::cout << "Creating data reader listener for topic: " << topicName_ << std::endl;
+    }
+
+    void on_subscription_matched([[maybe_unused]] dds::sub::DataReader<T>& reader,
+                                 [[maybe_unused]] const dds::core::status::SubscriptionMatchedStatus& status) override
+    {
+        std::cout << "topic: " << topicName_ << " data reader listener: on_subscription_matched called" << std::endl;
+    }
+
+    void on_liveliness_changed([[maybe_unused]] dds::sub::DataReader<T>& reader,
+                               [[maybe_unused]] const dds::core::status::LivelinessChangedStatus& status) override
+    {
+        std::cout << "topic: " << topicName_ << " data reader listener: on_liveliness_changed called "
+                  << " alive count: " << status.alive_count() << " not alive count: " << status.not_alive_count()
+                  << "alive count change: " << status.alive_count_change()
+                  << " not alive count change: " << status.not_alive_count_change() << std::endl;
+    }
+
+    void on_data_available([[maybe_unused]] dds::sub::DataReader<T>& reader) override
+    {
+        std::cout << "topic: " << topicName_ << " data reader listener: on_data_available called" << std::endl;
+    }
+};
+
+template<typename T>
+class FakeDataWriterListener : public dds::pub::NoOpDataWriterListener<T>
+{
+public:
+    FakeDataWriterListener()
+    {
+        std::cout << "Creating data writer listener for topic: " << topicName_ << std::endl;
+    }
+
+    void on_publication_matched([[maybe_unused]] dds::pub::DataWriter<T>& writer,
+                                [[maybe_unused]] const dds::core::status::PublicationMatchedStatus& status) override
+    {
+        std::cout << "topic: " << topicName_ << " data writer listener: on_publication_matched called" << std::endl;
+    }
+    void on_liveliness_lost([[maybe_unused]] dds::pub::DataWriter<T>& writer,
+                            [[maybe_unused]] const dds::core::status::LivelinessLostStatus& status) override
+    {
+        std::cout << "topic: " << topicName_ << " data writer listener: on_liveliness_lost called" << std::endl;
+    }
+};
+
+// This function could run into deadlock
+void multiReaderSingleWriter([[maybe_unused]] uint32_t readerCnt)
+{
+
+    // declare writer
+    dds::domain::DomainParticipant participant{0};
+    dds::topic::Topic<Msg> topic(participant, topicName_);
+    dds::pub::Publisher pub{participant};
+    dds::pub::qos::DataWriterQos writeQos{};
+    FakeDataWriterListener<Msg> writeListener;
+    dds::core::status::StatusMask mask{dds::core::status::StatusMask::all()};
+    DDSCXX_STD_IMPL::optional<dds::pub::DataWriter<Msg>> writer;
+    EXPECT_NO_THROW(writer.emplace(pub, topic, writeQos, &writeListener, mask));
+
+    // declare readers in multithreads
+    std::vector<std::thread> threads;
+    for (uint32_t i = 0; i < readerCnt; i++) {
+        threads.emplace_back(std::thread([&participant, &topic] {
+            using namespace std::literals;
+            dds::sub::Subscriber sub{participant};
+            dds::sub::qos::DataReaderQos readQos{};
+            FakeDataReaderListener<Msg> readListener;
+            dds::core::status::StatusMask readMask{dds::core::status::StatusMask::none()};
+            auto reader = dds::sub::DataReader<Msg>{sub, topic, readQos, &readListener, readMask};
+        }));
+    }
+
+    writer.reset();
+
+    for (auto&& t : threads) {
+        if (t.joinable()) {
+            t.join();
+        }
+    }
+}
+
+// This function could cause assertation to false on exit
+void multiWriterSingleReader([[maybe_unused]] uint32_t writerCount)
+{
+    // declare reader
+    dds::domain::DomainParticipant participant{0};
+    dds::topic::Topic<Msg> topic(participant, topicName_);
+
+    dds::sub::Subscriber sub{participant};
+    dds::sub::qos::DataReaderQos readQos{};
+    FakeDataReaderListener<Msg> readListener;
+    dds::core::status::StatusMask readMask{dds::core::status::StatusMask::all()};
+    DDSCXX_STD_IMPL::optional<dds::sub::DataReader<Msg>> reader;
+    EXPECT_NO_THROW(reader.emplace(sub, topic, readQos, &readListener, readMask));
+
+    // declare writers in multithreads
+    std::vector<std::thread> threads;
+    for (uint32_t i = 0; i < writerCount; i++) {
+        threads.emplace_back(std::thread([&participant, &topic] {
+            using namespace std::literals;
+
+            dds::pub::Publisher pub{participant};
+            dds::pub::qos::DataWriterQos writeQos{};
+            FakeDataWriterListener<Msg> writeListener;
+            dds::core::status::StatusMask writeMask{dds::core::status::StatusMask::none()};
+            dds::pub::DataWriter<Msg> writer(pub, topic, writeQos, &writeListener, writeMask);
+        }));
+    }
+
+    reader.reset();
+
+    for (auto&& t : threads) {
+        if (t.joinable()) {
+            t.join();
+        }
+    }
+}
+
+// could lead to assert(false)
+TEST(DeferredDestruction, MultiWriterSingleReader)
+{
+    multiWriterSingleReader(50);
+}
+
+// could lead to a deadlock
+TEST(DeferredDestruction, MultiReaderSingleWriter)
+{
+    multiReaderSingleWriter(50);
+}


### PR DESCRIPTION
Add some fixes for lifetimes of entities not matching up with callback functions onto the same entities.
This causes issues like null dereferences and deadlocks.

This fix includes:
- reproducer for the issue
- ensurances that the lifetimes of entities are at least as long as the their callback functions
- listeners are present when callbacks are executed

This will not fix the entire issue, which lies at some choices made in the CycloneDDS-C layer.
If similar issues are still encountered, we advise to set the listener on an entity to `nullptr` before destroying it.