### PR TITLE
feat: add OUTPUT_DIR to IDLCXX_GENERATE

### DIFF
--- a/src/idlcxx/Generate.cmake
+++ b/src/idlcxx/Generate.cmake
@@ -11,7 +11,7 @@
 #
 
 function(IDLCXX_GENERATE)
-  set(one_value_keywords TARGET DEFAULT_EXTENSIBILITY)
+  set(one_value_keywords TARGET DEFAULT_EXTENSIBILITY OUTPUT_DIR)
   set(multi_value_keywords FILES FEATURES INCLUDES WARNINGS)
   cmake_parse_arguments(
     IDLCXX "" "${one_value_keywords}" "${multi_value_keywords}" "" ${ARGN})
@@ -40,6 +40,7 @@ function(IDLCXX_GENERATE)
     WARNINGS ${IDLCXX_WARNINGS}
     DEFAULT_EXTENSIBILITY ${IDLCXX_DEFAULT_EXTENSIBILITY}
     SUFFIXES .hpp .cpp
+    OUTPUT_DIR ${IDLCXX_OUTPUT_DIR}
     DEPENDS ${_idlcxx_depends}
   )
   if(CYCLONEDDS_CXX_ENABLE_LEGACY)


### PR DESCRIPTION
Depends on https://github.com/eclipse-cyclonedds/cyclonedds/pull/1603

Allows to set OUTPUT_DIR for IDLCXX_GENERATE

Does not fully work yet, due to #383 