### PR TITLE
Fix for issue #378

### DIFF
--- a/src/ddscxx/include/dds/pub/detail/DataWriterImpl.hpp
+++ b/src/ddscxx/include/dds/pub/detail/DataWriterImpl.hpp
@@ -389,14 +389,13 @@ dds::pub::detail::DataWriter<T>::DataWriter(
 
     std::string name = topic.name() + "_datawriter";
 
-    dds_entity_t ddsc_writer = dds_create_writer (ddsc_pub, ddsc_topic, ddsc_qos, NULL);
+    this->listener(listener, mask);
+    dds_entity_t ddsc_writer = dds_create_writer (ddsc_pub, ddsc_topic, ddsc_qos, this->listener_callbacks);
     dds_delete_qos(ddsc_qos);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ddsc_writer, "Could not create DataWriter.");
     topic_.delegate()->incrNrDependents();
 
     this->set_ddsc_entity(ddsc_writer);
-
-    this->listener(listener, mask);
 }
 
 template <typename T>

--- a/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
@@ -499,7 +499,8 @@ dds::sub::detail::DataReader<T>::common_constructor(
     c_value *params = this->AnyDataReaderDelegate::td_.delegate()->reader_parameters();
 #endif
 
-    dds_entity_t ddsc_reader = dds_create_reader(ddsc_sub, ddsc_top, ddsc_qos, NULL);
+    this->listener(listener, mask);
+    dds_entity_t ddsc_reader = dds_create_reader(ddsc_sub, ddsc_top, ddsc_qos, this->listener_callbacks);
     dds_delete_qos(ddsc_qos);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ddsc_reader, "Could not create DataReader.");
 
@@ -507,7 +508,6 @@ dds::sub::detail::DataReader<T>::common_constructor(
 
     this->AnyDataReaderDelegate::setSample(&this->typed_sample_);
     this->set_ddsc_entity(ddsc_reader);
-    this->listener(listener, mask);
 }
 
 template <typename T>

--- a/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
@@ -175,8 +175,10 @@ dds::topic::detail::Topic<T>::Topic(const dds::domain::DomainParticipant& dp,
 
     ser_type_ = org::eclipse::cyclonedds::topic::TopicTraits<T>::getSerType();
 
+    this->listener(listener, mask);
+
     dds_entity_t ddsc_topic = dds_create_topic_sertype(
-      ddsc_par, name.c_str(), &ser_type_, ddsc_qos, NULL, NULL);
+      ddsc_par, name.c_str(), &ser_type_, ddsc_qos, this->listener_callbacks, NULL);
 
     dds_delete_qos(ddsc_qos);
 
@@ -186,8 +188,6 @@ dds::topic::detail::Topic<T>::Topic(const dds::domain::DomainParticipant& dp,
     }
 
     this->set_ddsc_entity(ddsc_topic);
-
-    this->listener(listener, mask);
 
     this->AnyTopicDelegate::set_sample(&this->sample_);
 }

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
@@ -81,7 +81,8 @@ org::eclipse::cyclonedds::domain::DomainParticipantDelegate::DomainParticipantDe
     }
 
     ddsc_qos = qos.delegate().ddsc_qos();
-    ddsc_par = dds_create_participant(static_cast<dds_domainid_t>(domain_id_), ddsc_qos, NULL);
+    this->listener(listener, event_mask);
+    ddsc_par = dds_create_participant(static_cast<dds_domainid_t>(domain_id_), ddsc_qos, this->listener_callbacks);
 
     dds_delete_qos (ddsc_qos);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ddsc_par, "Could not create DomainParticipant.");
@@ -92,8 +93,6 @@ org::eclipse::cyclonedds::domain::DomainParticipantDelegate::DomainParticipantDe
     this->domain_id_ = static_cast<uint32_t>(did);
 
     this->set_ddsc_entity(ddsc_par);
-
-    this->listener(listener, event_mask);
 
     if (config.empty()) {
         /* Try to find implicit domain by using the domain id of
@@ -146,7 +145,8 @@ org::eclipse::cyclonedds::domain::DomainParticipantDelegate::DomainParticipantDe
        * that one automatically. */
     }
 
-    ddsc_par = dds_create_participant(static_cast<dds_domainid_t>(id), ddsc_qos, NULL);
+    this->listener(listener, event_mask);
+    ddsc_par = dds_create_participant(static_cast<dds_domainid_t>(id), ddsc_qos, this->listener_callbacks);
 
     dds_delete_qos(ddsc_qos);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ddsc_par, "Could not create DomainParticipant.");
@@ -157,8 +157,6 @@ org::eclipse::cyclonedds::domain::DomainParticipantDelegate::DomainParticipantDe
     this->domain_id_ = static_cast<uint32_t>(did);
 
     this->set_ddsc_entity(ddsc_par);
-
-    this->listener(listener, event_mask);
 
     if (this->domain_ref_) {
       /* Add new domain to registry. */

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/PublisherDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/PublisherDelegate.cpp
@@ -58,12 +58,11 @@ PublisherDelegate::PublisherDelegate(const dds::domain::DomainParticipant& dp,
         ISOCPP_THROW_EXCEPTION(ISOCPP_ERROR, "Could not convert publisher QoS.");
     }
 
-    ddsc_pub = dds_create_publisher(ddsc_par, ddsc_qos, NULL);
+    this->listener(listener, event_mask);
+    ddsc_pub = dds_create_publisher(ddsc_par, ddsc_qos, this->listener_callbacks);
     dds_delete_qos(ddsc_qos);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ddsc_pub, "Could not create publisher.");
     this->set_ddsc_entity(ddsc_pub);
-
-    this->listener(listener, event_mask);
 }
 
 PublisherDelegate::~PublisherDelegate()

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/SubscriberDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/SubscriberDelegate.cpp
@@ -57,13 +57,12 @@ SubscriberDelegate::SubscriberDelegate(
         ISOCPP_THROW_EXCEPTION(ISOCPP_ERROR, "Could not convert subscriber QoS.");
     }
 
-    ddsc_sub = dds_create_subscriber(ddsc_par, ddsc_qos, NULL);
+    this->listener(listener, event_mask);
+    ddsc_sub = dds_create_subscriber(ddsc_par, ddsc_qos, this->listener_callbacks);
 
     dds_delete_qos(ddsc_qos);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ddsc_sub, "Could not create subscriber.");
     this->set_ddsc_entity(ddsc_sub);
-
-    this->listener(listener, event_mask);
 }
 
 SubscriberDelegate::~SubscriberDelegate()


### PR DESCRIPTION
In case of a listener is passed to the constructor of an entity, the listener is expected to be set while creating the entity, otherwise, events happen between the entity creation and listener setting may get lost