### PR TITLE
Rely on release branch in CI

### DIFF
--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -104,7 +104,7 @@ steps:
   - bash: |
       set -e -x
       git clone --single-branch \
-                --branch "${CYCLONEDDS_BRANCH:-master}" \
+                --branch "${CYCLONEDDS_BRANCH:-releases/0.10.x}" \
                 "${CYCLONEDDS_REPOSITORY:-https://github.com/eclipse-cyclonedds/cyclonedds.git}" \
                 cyclonedds
       mkdir cyclonedds/build


### PR DESCRIPTION
I thought the CI in #387 was failing because of a `CYCLONEDDS_BRANCH` variable being set only for building release branch, but not for a PR. It turns out that this is not the case and that it was using `master` all the time and I never noticed because there was no problem way back when.

Since I can't quickly figure out how to set it in Azure, this PR forces the correct branch of the `cyclonedds` repo to be built by changing the CI configuration files. It kinda makes sense that the CI configuration of the 0.10.x release branch of the C++ repo says it should use `releases/0.10.x` of the `cyclonedds` repository.