### PR TITLE
Fix for wrong calculation of padding bytes in CDR header

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -186,7 +186,7 @@ template<typename T>
 bool finish_header(void *buffer, size_t bytes_written)
 {
   CHECK_FOR_NULL(buffer);
-  auto alignbytes = static_cast<unsigned char>(4 % (4 - bytes_written % 4));
+  auto alignbytes = static_cast<unsigned char>((4 - (bytes_written % 4)) % 4);
   auto ptr = static_cast<unsigned char*>(calc_offset(buffer, 3));
 
   *ptr = alignbytes;


### PR DESCRIPTION
The alignment bytes were calculated in the wrong manner, in stead of taking the remainder of a modulo 4 as the padding bytes, the modulo 4 of a remainder was used.