### PR TITLE
Fix setting of DurabilityService policy in DataWriter QoS

### DIFF
--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.cpp
@@ -363,6 +363,10 @@ DataWriterQosDelegate::operator =(const org::eclipse::cyclonedds::topic::qos::To
 {
     if (tqos.present() & DDSI_QP_DURABILITY)
       policy(tqos.policy<dds::core::policy::Durability>());
+#ifdef  OMG_DDS_PERSISTENCE_SUPPORT
+    if (tqos.present() & DDSI_QP_DURABILITY_SERVICE)
+      policy(tqos.policy<dds::core::policy::DurabilityService>());
+#endif  // OMG_DDS_PERSISTENCE_SUPPORT
     if (tqos.present() & DDSI_QP_DEADLINE)
       policy(tqos.policy<dds::core::policy::Deadline>());
     if (tqos.present() & DDSI_QP_LATENCY_BUDGET)

--- a/src/ddscxx/tests/Qos.cpp
+++ b/src/ddscxx/tests/Qos.cpp
@@ -336,6 +336,9 @@ TEST(Qos, DataWriter)
     DataWriterQos dwQosShifted;
     dwQosShifted << nonDefaultUserData
                  << nonDefaultDurability
+#ifdef  OMG_DDS_PERSISTENCE_SUPPORT
+                 << nonDefaultDurabilityService
+#endif  // OMG_DDS_PERSISTENCE_SUPPORT
                  << nonDefaultDeadline
                  << nonDefaultBudget
                  << nonDefaultLiveliness
@@ -380,6 +383,9 @@ TEST(Qos, DataWriter)
     /* Compare the Policies (getting them in different ways). */
     dwQosShifted >> tmpUserData;
     dwQosShifted >> tmpDurability;
+#ifdef  OMG_DDS_PERSISTENCE_SUPPORT
+    dwQosShifted >> tmpDurabilityService;
+#endif  // OMG_DDS_PERSISTENCE_SUPPORT
     dwQosShifted >> tmpDeadline;
     dwQosShifted >> tmpBudget;
     dwQosShifted >> tmpLiveliness;
@@ -397,6 +403,9 @@ TEST(Qos, DataWriter)
 #endif //  OMG_DDS_EXTENSIBLE_AND_DYNAMIC_TOPIC_TYPE_SUPPORT
     ASSERT_EQ(nonDefaultUserData,    tmpUserData);
     ASSERT_EQ(nonDefaultDurability,  tmpDurability);
+#ifdef  OMG_DDS_PERSISTENCE_SUPPORT
+    ASSERT_EQ(nonDefaultDurabilityService,  tmpDurabilityService);
+#endif  // OMG_DDS_PERSISTENCE_SUPPORT
     ASSERT_EQ(nonDefaultDeadline,    tmpDeadline);
     ASSERT_EQ(nonDefaultBudget,      tmpBudget);
     ASSERT_EQ(nonDefaultLiveliness,  tmpLiveliness);
@@ -415,6 +424,9 @@ TEST(Qos, DataWriter)
 
     ASSERT_EQ(nonDefaultUserData,    dwQosWConstructed.policy<UserData>());
     ASSERT_EQ(nonDefaultDurability,  dwQosWConstructed.policy<Durability>());
+#ifdef  OMG_DDS_PERSISTENCE_SUPPORT
+    ASSERT_EQ(nonDefaultDurabilityService,  dwQosWConstructed.policy<DurabilityService>());
+#endif  // OMG_DDS_PERSISTENCE_SUPPORT
     ASSERT_EQ(nonDefaultDeadline,    dwQosWConstructed.policy<Deadline>());
     ASSERT_EQ(nonDefaultBudget,      dwQosWConstructed.policy<LatencyBudget>());
     ASSERT_EQ(nonDefaultLiveliness,  dwQosWConstructed.policy<Liveliness>());


### PR DESCRIPTION
The DurabilityService QoSPolicy was not being copied correctly when initializing a DataWriter QoS from a Topic QoS
This issue was missed as the DurabilityService policy of the DataWriter QoS was not being checked for its values in the unittests, this was also fixed