### PR TITLE
Add GitHub workflow for checking MISRA rule regressions

### DIFF
--- a/.github/codeql/resolved-misra-rules.yml
+++ b/.github/codeql/resolved-misra-rules.yml
@@ -1,0 +1,5 @@
+disable-default-queries: true
+
+# List of MISRA rules that have been resolved to check for regressions against.
+queries:
+  - uses: ./codeql-coding-standards/c/misra/src/rules/RULE-3-1/CharacterSequencesAndUsedWithinAComment.ql

--- a/.github/workflows/misra-regressions-check.yml
+++ b/.github/workflows/misra-regressions-check.yml
@@ -1,0 +1,76 @@
+# Check against the set of MISRA rules that have already been
+# resolved to prevent regressions.
+name: "MISRA regressions check"
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ["master"]
+  schedule:
+    - cron: "16 12 * * 3"
+
+env:
+  CYCLONEDDS_HOME: ${{ github.workspace }}/cyclonedds/build/install
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: "ubuntu-latest"
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        language: ["cpp"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Checkout Cyclone DDS
+        uses: actions/checkout@v3
+        with:
+          repository: eclipse-cyclonedds/cyclonedds
+          path: cyclonedds/
+
+      - name: Install Cyclone DDS
+        run: |
+          mkdir cyclonedds/build
+          cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$CYCLONEDDS_HOME -B cyclonedds/build cyclonedds
+          cmake --build cyclonedds/build --target install
+
+      # Pull in the codeql-coding-standards qlpack repository.
+      # https://github.com/github/codeql-coding-standards
+      - name: Checkout codeql-coding-standards
+        uses: actions/checkout@v3
+        with:
+          repository: github/codeql-coding-standards
+          path: codeql-coding-standards/
+          ref: 39f8f9801307e058d6d9f07dcbe7c7d229c18dd0
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          # Points at the config file containing the MISRA rules that have been resolved.
+          config-file: ./.github/codeql/resolved-misra-rules.yml
+
+      - name: Build Cyclone DDS CXX
+        run: |
+          mkdir build
+          cmake -DCMAKE_INSTALL_PREFIX=install -DCMAKE_PREFIX_PATH="$CYCLONEDDS_HOME" -DENABLE_TOPIC_DISCOVERY=TRUE -DENABLE_TYPE_DISCOVERY=TRUE -B build
+          cmake --build build
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "MISRA"


### PR DESCRIPTION
This PR adds a GitHub workflow for checking MISRA rule violations. It currently includes a check for MISRA rule 3.1 but more will be added as the code-base becomes more compliant.

See eclipse-cyclonedds/cyclonedds#1673 for the same PR included in the core Cyclone repository. The only major difference in is that the build for the code-base is manually specified in this workflow instead of being identified by auto-build ([misra-regressions-check.yml:64-71](https://github.com/eclipse-cyclonedds/cyclonedds-cxx/compare/master...NoxPardalis:cyclonedds-cxx:master?expand=1#diff-ff15e3d24fedce3faac6a63b42d98272ad5bb80ec6fbf00fddc6cd5ff1567e68R67-R71))

See #403 for the PR that solves the rules checked for by the workflow introduced within this PR.