### PR TITLE
Address MISRA rule 3.1 violations

### DIFF
--- a/src/ddscxx/include/dds/core/Duration.hpp
+++ b/src/ddscxx/include/dds/core/Duration.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_DURATION_HPP_
 #define OMG_DDS_CORE_DURATION_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/types.hpp>
 

--- a/src/ddscxx/include/dds/core/Entity.hpp
+++ b/src/ddscxx/include/dds/core/Entity.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_ENTITY_HPP_
 #define OMG_DDS_CORE_ENTITY_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/detail/Entity.hpp>
 namespace dds

--- a/src/ddscxx/include/dds/core/Exception.hpp
+++ b/src/ddscxx/include/dds/core/Exception.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_EXCEPTION_HPP_
 #define OMG_DDS_CORE_EXCEPTION_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <stdexcept>
 #include <string>

--- a/src/ddscxx/include/dds/core/Exception.hpp
+++ b/src/ddscxx/include/dds/core/Exception.hpp
@@ -70,36 +70,34 @@ public:
     /** @endcond */
 
 public:
-    /**
-     * Retrieve information about the exception that was thrown.
-     *
-     * Example
-     * @code{.cpp}
-     * try {
-     *     // Do something that will trigger a dds exception, like:
-     *     dds::domain::DomainParticipant participant = dds::core::null;
-     *     participant.domain_id();
-     * } catch (const dds::core::Exception& e) {
-     *     std::cout << e.what() << std::endl;
-     * }
-     * @endcode
-     * %Exception information (of the NullReferenceError in this case)
-     * @code
-     * Null reference: Reference[157] == dds::core::null
-     * ========================================================================================
-     * Context     : dds::domain::DomainParticipant::domain_id
-     * Date        : Wed Oct 21 19:28:00 CET 2015
-     * Node        : DeLorean
-     * Process     : flux_capacitor <15423>
-     * Thread      : mr_fusion b6f25700
-     * Internals   : ReferenceImpl.hpp/157/V6.6.0
-     * ----------------------------------------------------------------------------------------
-     * Report      : Null reference: Reference[157] == dds::core::null
-     * Internals   : dds::core::Reference<DELEGATE>::delegate/ReferenceImpl.hpp/157
-     * @endcode
-     *
-     * @return Exception information
-     */
+    /// Retrieve information about the exception that was thrown.
+    ///
+    /// Example
+    /// @code{.cpp}
+    /// try {
+    ///     // Do something that will trigger a dds exception, like:
+    ///     dds::domain::DomainParticipant participant = dds::core::null;
+    ///     participant.domain_id();
+    /// } catch (const dds::core::Exception& e) {
+    ///     std::cout << e.what() << std::endl;
+    /// }
+    /// @endcode
+    /// %Exception information (of the NullReferenceError in this case)
+    /// @code
+    /// Null reference: Reference[157] == dds::core::null
+    /// ========================================================================================
+    /// Context     : dds::domain::DomainParticipant::domain_id
+    /// Date        : Wed Oct 21 19:28:00 CET 2015
+    /// Node        : DeLorean
+    /// Process     : flux_capacitor <15423>
+    /// Thread      : mr_fusion b6f25700
+    /// Internals   : ReferenceImpl.hpp/157/V6.6.0
+    /// ----------------------------------------------------------------------------------------
+    /// Report      : Null reference: Reference[157] == dds::core::null
+    /// Internals   : dds::core::Reference<DELEGATE>::delegate/ReferenceImpl.hpp/157
+    /// @endcode
+    ///
+    /// @return Exception information
     virtual const char* what() const throw() = 0;
 };
 

--- a/src/ddscxx/include/dds/core/External.hpp
+++ b/src/ddscxx/include/dds/core/External.hpp
@@ -1,22 +1,20 @@
 #ifndef OMG_DDS_CORE_EXTERNAL_HPP_
 #define OMG_DDS_CORE_EXTERNAL_HPP_
 
-/*
- * Copyright(c) 2022 ZettaScale Technology and others
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright(c) 2022 ZettaScale Technology and others
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <memory>
 #include <dds/core/Exception.hpp>

--- a/src/ddscxx/include/dds/core/InstanceHandle.hpp
+++ b/src/ddscxx/include/dds/core/InstanceHandle.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_INSTANCE_HANDLE_HPP_
 #define OMG_DDS_CORE_INSTANCE_HANDLE_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <vector>
 #include <dds/core/detail/InstanceHandle.hpp>

--- a/src/ddscxx/include/dds/core/LengthUnlimited.hpp
+++ b/src/ddscxx/include/dds/core/LengthUnlimited.hpp
@@ -1,24 +1,22 @@
 #ifndef OMG_DDS_CORE_LENGTH_UNLIMITED_HPP_
 #define OMG_DDS_CORE_LENGTH_UNLIMITED_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace dds
 {

--- a/src/ddscxx/include/dds/core/QosProvider.hpp
+++ b/src/ddscxx/include/dds/core/QosProvider.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_QOS_PROVIDER_HPP_
 #define OMG_DDS_CORE_QOS_PROVIDER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Inc.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Inc.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/detail/QosProvider.hpp>
 

--- a/src/ddscxx/include/dds/core/Reference.hpp
+++ b/src/ddscxx/include/dds/core/Reference.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_REFERENCE_HPP_
 #define OMG_DDS_CORE_REFERENCE_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Inc.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Inc.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/types.hpp>
 #include <dds/core/refmacros.hpp>

--- a/src/ddscxx/include/dds/core/Reference.hpp
+++ b/src/ddscxx/include/dds/core/Reference.hpp
@@ -225,35 +225,31 @@ public:
      */
     bool is_nil() const;
 
-    /**
-     * Special operator== used to check if this reference object
-     * equals the <i>dds::core::null</i> reference.
-     *
-     * The null-check can be done like this:
-     * @code{.cpp}
-     * if (r == dds::core::null) {
-     *    // Do not use the dds reference object r in its current state
-     * }
-     * @endcode
-     *
-     * @return true if this reference is null.
-     */
+    /// Special operator== used to check if this reference object
+    /// equals the <i>dds::core::null</i> reference.
+    ///
+    /// The null-check can be done like this:
+    /// @code{.cpp}
+    /// if (r == dds::core::null) {
+    ///    // Do not use the dds reference object r in its current state
+    /// }
+    /// @endcode
+    ///
+    /// @return true if this reference is null.
     bool
     operator==(const null_type) const;
 
-    /**
-     * Special operator!= used to check if this reference object
-     * does not equal the <i>dds::core::null</i> reference.
-     *
-     * The non-null-check can be done like this:
-     * @code{.cpp}
-     * if (r != dds::core::null) {
-     *    // Use the dds reference object r
-     * }
-     * @endcode
-     *
-     * @return true if this reference is not null.
-     */
+    /// Special operator!= used to check if this reference object
+    /// does not equal the <i>dds::core::null</i> reference.
+    ///
+    /// The non-null-check can be done like this:
+    /// @code{.cpp}
+    /// if (r != dds::core::null) {
+    ///    // Use the dds reference object r
+    /// }
+    /// @endcode
+    ///
+    /// @return true if this reference is not null.
     bool operator!=(const null_type nil) const;
 
 private:
@@ -319,34 +315,30 @@ protected:
 } /* namespace dds / namespace core */
 
 
-/**
- * Special operator== used to check if this reference object
- * does not equal the <i>dds::core::null</i> reference.
- *
- * The non-null-check can be done like this:
- * @code{.cpp}
- * if (dds::core::null == r) {
- *    // Do not use the dds reference object r in its current state
- * }
- * @endcode
- *
- * @return true if this reference is not null.
- */
+/// Special operator== used to check if this reference object
+/// does not equal the <i>dds::core::null</i> reference.
+///
+/// The non-null-check can be done like this:
+/// @code{.cpp}
+/// if (dds::core::null == r) {
+///    // Do not use the dds reference object r in its current state
+/// }
+/// @endcode
+///
+/// @return true if this reference is not null.
 template <class D> bool operator == (dds::core::null_type, const dds::core::Reference<D>& r);
 
-/**
- * Special operator!= used to check if this reference object
- * does not equal the <i>dds::core::null</i> reference.
- *
- * The non-null-check can be done like this:
- * @code{.cpp}
- * if (dds::core::null != r) {
- *    // Use the dds reference object r
- * }
- * @endcode
- *
- * @return true if this reference is not null.
- */
+/// Special operator!= used to check if this reference object
+/// does not equal the <i>dds::core::null</i> reference.
+///
+/// The non-null-check can be done like this:
+/// @code{.cpp}
+/// if (dds::core::null != r) {
+///    // Use the dds reference object r
+/// }
+/// @endcode
+///
+/// @return true if this reference is not null.
 template <class D> bool operator != (dds::core::null_type, const dds::core::Reference<D>& r);
 
 #endif /* OMG_DDS_CORE_REFERENCE_HPP_ */

--- a/src/ddscxx/include/dds/core/SafeEnumeration.hpp
+++ b/src/ddscxx/include/dds/core/SafeEnumeration.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef OMG_DDS_CORE_SAFEENUMERATION_HPP_
 #define OMG_DDS_CORE_SAFEENUMERATION_HPP_
 

--- a/src/ddscxx/include/dds/core/TEntity.hpp
+++ b/src/ddscxx/include/dds/core/TEntity.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_TDDS_CORE_ENTITY_HPP_
 #define OMG_TDDS_CORE_ENTITY_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <string>
 

--- a/src/ddscxx/include/dds/core/TEntityQos.hpp
+++ b/src/ddscxx/include/dds/core/TEntityQos.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_TDDS_CORE_QOS_ENTITY_QOS_HPP_
 #define OMG_TDDS_CORE_QOS_ENTITY_QOS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/Value.hpp>
 

--- a/src/ddscxx/include/dds/core/TInstanceHandle.hpp
+++ b/src/ddscxx/include/dds/core/TInstanceHandle.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_TDDS_CORE_INSTANCE_HANDLE_HPP_
 #define OMG_TDDS_CORE_INSTANCE_HANDLE_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/types.hpp>
 #include <dds/core/Value.hpp>

--- a/src/ddscxx/include/dds/core/TQosProvider.hpp
+++ b/src/ddscxx/include/dds/core/TQosProvider.hpp
@@ -2,23 +2,22 @@
 #define OMG_DDS_CORE_QOS_TPROVIDER_HPP_
 
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Inc.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Inc.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/Reference.hpp>
 

--- a/src/ddscxx/include/dds/core/Time.hpp
+++ b/src/ddscxx/include/dds/core/Time.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_TIME_HPP_
 #define OMG_DDS_CORE_TIME_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/types.hpp>
 

--- a/src/ddscxx/include/dds/core/Value.hpp
+++ b/src/ddscxx/include/dds/core/Value.hpp
@@ -1,24 +1,22 @@
 #ifndef OMG_DDS_CORE_VALUE_HPP_
 #define OMG_DDS_CORE_VALUE_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace dds
 {

--- a/src/ddscxx/include/dds/core/WeakReference.hpp
+++ b/src/ddscxx/include/dds/core/WeakReference.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_WEAK_REFERENCE_HPP_
 #define OMG_DDS_CORE_WEAK_REFERENCE_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/Reference.hpp>
 

--- a/src/ddscxx/include/dds/core/array.hpp
+++ b/src/ddscxx/include/dds/core/array.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef  ORG_OMG_DDS_CORE_ARRAY_HPP_
 #define  ORG_OMG_DDS_CORE_ARRAY_HPP_
 

--- a/src/ddscxx/include/dds/core/cond/Condition.hpp
+++ b/src/ddscxx/include/dds/core/cond/Condition.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_COND_CONDITION_HPP_
 #define OMG_DDS_CORE_COND_CONDITION_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/cond/detail/Condition.hpp>
 

--- a/src/ddscxx/include/dds/core/cond/GuardCondition.hpp
+++ b/src/ddscxx/include/dds/core/cond/GuardCondition.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_COND_GUARDCONDITION_HPP_
 #define OMG_DDS_CORE_COND_GUARDCONDITION_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/cond/detail/GuardCondition.hpp>
 #include <dds/core/cond/detail/TGuardConditionImpl.hpp>

--- a/src/ddscxx/include/dds/core/cond/StatusCondition.hpp
+++ b/src/ddscxx/include/dds/core/cond/StatusCondition.hpp
@@ -1,23 +1,23 @@
 #ifndef OMG_DDS_CORE_STATUSCONDITION_HPP_
 #define OMG_DDS_CORE_STATUSCONDITION_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <dds/core/cond/detail/StatusCondition.hpp>
 #include <dds/core/cond/detail/TStatusConditionImpl.hpp>
 

--- a/src/ddscxx/include/dds/core/cond/TCondition.hpp
+++ b/src/ddscxx/include/dds/core/cond/TCondition.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_TDDS_DDS_CORE_COND_CONDITION_HPP_
 #define OMG_TDDS_DDS_CORE_COND_CONDITION_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/Reference.hpp>
 #include <dds/core/cond/detail/GuardCondition.hpp>

--- a/src/ddscxx/include/dds/core/cond/TGuardCondition.hpp
+++ b/src/ddscxx/include/dds/core/cond/TGuardCondition.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_TDDS_CORE_COND_GUARD_CONDITION_HPP_
 #define OMG_TDDS_CORE_COND_GUARD_CONDITION_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/cond/Condition.hpp>
 

--- a/src/ddscxx/include/dds/core/cond/TGuardCondition.hpp
+++ b/src/ddscxx/include/dds/core/cond/TGuardCondition.hpp
@@ -33,35 +33,33 @@ class TGuardCondition;
 }
 }
 
-/**
- * @brief
- * A GuardCondition object is a specific Condition whose trigger_value is
- * completely under the control of the application.
- *
- * When a GuardCondition is initially created, the trigger_value is FALSE.
- *
- * The purpose of the GuardCondition is to provide the means for the
- * application to manually triggering a WaitSet to stop waiting. This is accomplished by
- * attaching the GuardCondition to the WaitSet and then setting the
- * trigger_value by means of the set trigger_value operation.
- *
- * @code{.cpp}
- * dds::core::cond::GuardCondition guard;
- * dds::core::cond::WaitSet waitset;
- * waitset.attach_condition(guard);
- * waitset.wait();
- * ...
- * // To wakeup waitset, do in another thread:
- * guard.trigger_value(true);
- * @endcode
- * See the @ref anchor_dds_core_cond_waitset_examples "WaitSet examples" for more examples.<br>
- * Although the WaitSet examples use the StatusCondition, the basic usage of this Condition
- * with a WaitSet is the same.
- *
- * @see dds::core::cond::Condition
- * @see for more information: @ref DCPS_Modules_Infrastructure_Waitset "WaitSet concept"
- * @see for more information: @ref anchor_dds_core_cond_waitset_examples "WaitSet examples"
- */
+/// @brief
+/// A GuardCondition object is a specific Condition whose trigger_value is
+/// completely under the control of the application.
+///
+/// When a GuardCondition is initially created, the trigger_value is FALSE.
+///
+/// The purpose of the GuardCondition is to provide the means for the
+/// application to manually triggering a WaitSet to stop waiting. This is accomplished by
+/// attaching the GuardCondition to the WaitSet and then setting the
+/// trigger_value by means of the set trigger_value operation.
+///
+/// @code{.cpp}
+/// dds::core::cond::GuardCondition guard;
+/// dds::core::cond::WaitSet waitset;
+/// waitset.attach_condition(guard);
+/// waitset.wait();
+/// ...
+/// // To wakeup waitset, do in another thread:
+/// guard.trigger_value(true);
+/// @endcode
+/// See the @ref anchor_dds_core_cond_waitset_examples "WaitSet examples" for more examples.<br>
+/// Although the WaitSet examples use the StatusCondition, the basic usage of this Condition
+/// with a WaitSet is the same.
+///
+/// @see dds::core::cond::Condition
+/// @see for more information: @ref DCPS_Modules_Infrastructure_Waitset "WaitSet concept"
+/// @see for more information: @ref anchor_dds_core_cond_waitset_examples "WaitSet examples"
 template <typename DELEGATE>
 class dds::core::cond::TGuardCondition : public dds::core::cond::TCondition<DELEGATE>
 {

--- a/src/ddscxx/include/dds/core/cond/TStatusCondition.hpp
+++ b/src/ddscxx/include/dds/core/cond/TStatusCondition.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_T_STATUS_CONDITION_HPP_
 #define OMG_DDS_CORE_T_STATUS_CONDITION_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/status/State.hpp>
 #include <dds/core/cond/Condition.hpp>

--- a/src/ddscxx/include/dds/core/cond/TWaitSet.hpp
+++ b/src/ddscxx/include/dds/core/cond/TWaitSet.hpp
@@ -37,74 +37,72 @@ class TWaitSet;
 }
 
 
-/**
- * @brief
- * A WaitSet object allows an application to wait until one or more of
- * the attached Condition objects has a trigger_value of TRUE or else
- * until the timeout expires.
- *
- * A WaitSet is not necessarily associated with a single DomainParticipant
- * and could be used to wait for Condition objects associated with different
- * DomainParticipant objects.
- *
- * @anchor anchor_dds_core_cond_waitset_examples
- * <b><i>Example with wait()</i></b><br>
- * When using the wait() operation, the triggered Conditions are returned in a list.
- * @code{.cpp}
- * // Create a Condition to attach to a Waitset
- * dds::core::cond::StatusCondition readerSC = dds::core::cond::StatusCondition(reader);
- * readerSC.enabled_statuses(dds::core::status::StatusMask::data_available());
- *
- * // Create WaitSet and attach Condition
- * dds::core::cond::WaitSet waitset;
- * waitset.attach_condition(readerSC); // or waitset += readerSC;
- *
- * dds::core::cond::WaitSet::ConditionSeq conditions;
- * while(true) {
- *     // Wait for any Condition to trigger.
- *     conditions = waitset.wait();
- *
- *     // Loop through the triggered conditions.
- *     for (int i=0; i < conditions.size(); i++) {
- *         // Handle data_available when right Condition triggered.
- *         if (conditions[i] == readerSC) {
- *             // Read samples from the DataReader
- *         }
- *     }
- * }
- * @endcode
-
- * <b><i>Example with dispatch()</i></b><br>
- * When using the dispatch() operation, the Functors of the triggered Conditions
- * will be called.
- * @code{.cpp}
- * // Functor to add to a Condition
- * class FunctorStatusCondition {
- * public:
- *     void operator()(const dds::core::cond::StatusCondition& condition) {
- *         // Possibly get reader from the condition and read some samples.
- *     }
- * };
- * FunctorStatusCondition functor;
- *
- * // Create a Condition with functor to attach to a Waitset
- * dds::core::cond::StatusCondition readerSC = dds::core::cond::StatusCondition(reader, functor);
- * readerSC.enabled_statuses(dds::core::status::StatusMask::data_available());
- *
- * // Create WaitSet and attach Condition
- * dds::core::cond::WaitSet waitset;
- * waitset.attach_condition(readerSC); // or waitset += readerSC;
- *
- * while(true) {
- *     // Wait for any Condition to trigger.
- *     // The functors of the Conditions are automatically called
- *     // when the Condition triggers.
- *     waitset.dispatch();
- * }
- * @endcode
- *
- * @see for more information: @ref DCPS_Modules_Infrastructure_Waitset "WaitSet concept"
- */
+/// @brief
+/// A WaitSet object allows an application to wait until one or more of
+/// the attached Condition objects has a trigger_value of TRUE or else
+/// until the timeout expires.
+///
+/// A WaitSet is not necessarily associated with a single DomainParticipant
+/// and could be used to wait for Condition objects associated with different
+/// DomainParticipant objects.
+///
+/// @anchor anchor_dds_core_cond_waitset_examples
+/// <b><i>Example with wait()</i></b><br>
+/// When using the wait() operation, the triggered Conditions are returned in a list.
+/// @code{.cpp}
+/// // Create a Condition to attach to a Waitset
+/// dds::core::cond::StatusCondition readerSC = dds::core::cond::StatusCondition(reader);
+/// readerSC.enabled_statuses(dds::core::status::StatusMask::data_available());
+///
+/// // Create WaitSet and attach Condition
+/// dds::core::cond::WaitSet waitset;
+/// waitset.attach_condition(readerSC); // or waitset += readerSC;
+///
+/// dds::core::cond::WaitSet::ConditionSeq conditions;
+/// while(true) {
+///     // Wait for any Condition to trigger.
+///     conditions = waitset.wait();
+///
+///     // Loop through the triggered conditions.
+///     for (int i=0; i < conditions.size(); i++) {
+///         // Handle data_available when right Condition triggered.
+///         if (conditions[i] == readerSC) {
+///             // Read samples from the DataReader
+///         }
+///     }
+/// }
+/// @endcode
+///
+/// <b><i>Example with dispatch()</i></b><br>
+/// When using the dispatch() operation, the Functors of the triggered Conditions
+/// will be called.
+/// @code{.cpp}
+/// // Functor to add to a Condition
+/// class FunctorStatusCondition {
+/// public:
+///     void operator()(const dds::core::cond::StatusCondition& condition) {
+///         // Possibly get reader from the condition and read some samples.
+///     }
+/// };
+/// FunctorStatusCondition functor;
+///
+/// // Create a Condition with functor to attach to a Waitset
+/// dds::core::cond::StatusCondition readerSC = dds::core::cond::StatusCondition(reader, functor);
+/// readerSC.enabled_statuses(dds::core::status::StatusMask::data_available());
+///
+/// // Create WaitSet and attach Condition
+/// dds::core::cond::WaitSet waitset;
+/// waitset.attach_condition(readerSC); // or waitset += readerSC;
+///
+/// while(true) {
+///     // Wait for any Condition to trigger.
+///     // The functors of the Conditions are automatically called
+///     // when the Condition triggers.
+///     waitset.dispatch();
+/// }
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Modules_Infrastructure_Waitset "WaitSet concept"
 template <typename DELEGATE>
 class dds::core::cond::TWaitSet final : public dds::core::Reference<DELEGATE>
 {

--- a/src/ddscxx/include/dds/core/cond/TWaitSet.hpp
+++ b/src/ddscxx/include/dds/core/cond/TWaitSet.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_TDDS_CORE_WAIT_SET_HPP_
 #define OMG_TDDS_CORE_WAIT_SET_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <vector>
 

--- a/src/ddscxx/include/dds/core/cond/WaitSet.hpp
+++ b/src/ddscxx/include/dds/core/cond/WaitSet.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_WAITSET_HPP_
 #define OMG_DDS_CORE_WAITSET_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/cond/detail/WaitSet.hpp>
 

--- a/src/ddscxx/include/dds/core/cond/detail/Condition.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/Condition.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+// 
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_COND_DETAIL_CONDITION_HPP_
 #define CYCLONEDDS_DDS_CORE_COND_DETAIL_CONDITION_HPP_
 

--- a/src/ddscxx/include/dds/core/cond/detail/GuardCondition.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/GuardCondition.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_COND_DETAIL_GUARDCONDITION_HPP_
 #define CYCLONEDDS_DDS_CORE_COND_DETAIL_GUARDCONDITION_HPP_
 

--- a/src/ddscxx/include/dds/core/cond/detail/StatusCondition.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/StatusCondition.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_COND_DETAIL_STATUSCONDITION_HPP_
 #define CYCLONEDDS_DDS_CORE_COND_DETAIL_STATUSCONDITION_HPP_
 

--- a/src/ddscxx/include/dds/core/cond/detail/TConditionImpl.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/TConditionImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_COND_TCONDITION_IMPL_HPP_
 #define CYCLONEDDS_DDS_CORE_COND_TCONDITION_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/core/cond/detail/TGuardConditionImpl.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/TGuardConditionImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_COND_TGUARDCONDITION_IMPL_HPP_
 #define CYCLONEDDS_DDS_CORE_COND_TGUARDCONDITION_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/core/cond/detail/TStatusConditionImpl.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/TStatusConditionImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_COND_TSTATUSCONDITION_IMPL_HPP_
 #define CYCLONEDDS_DDS_CORE_COND_TSTATUSCONDITION_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/core/cond/detail/TWaitSetImpl.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/TWaitSetImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_COND_TWAITSET_HPP_
 #define CYCLONEDDS_DDS_CORE_COND_TWAITSET_HPP_
 

--- a/src/ddscxx/include/dds/core/cond/detail/WaitSet.hpp
+++ b/src/ddscxx/include/dds/core/cond/detail/WaitSet.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_COND_DETAIL_WAITSET_HPP_
 #define CYCLONEDDS_DDS_CORE_COND_DETAIL_WAITSET_HPP_
 

--- a/src/ddscxx/include/dds/core/conformance.hpp
+++ b/src/ddscxx/include/dds/core/conformance.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef OMG_DDS_CORE_CONFORMANCE_HPP_
 #define OMG_DDS_CORE_CONFORMANCE_HPP_
 

--- a/src/ddscxx/include/dds/core/ddscore.hpp
+++ b/src/ddscxx/include/dds/core/ddscore.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef OMG_DDS_CORE_PACKAGE_INCLUDE_HPP_
 #define OMG_DDS_CORE_PACKAGE_INCLUDE_HPP_
 

--- a/src/ddscxx/include/dds/core/detail/Entity.hpp
+++ b/src/ddscxx/include/dds/core/detail/Entity.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_DETAIL_ENTITY_IMPL_HPP_
 #define OMG_DDS_CORE_DETAIL_ENTITY_IMPL_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/detail/TEntityImpl.hpp>
 #include <org/eclipse/cyclonedds/core/EntityDelegate.hpp>

--- a/src/ddscxx/include/dds/core/detail/InstanceHandle.hpp
+++ b/src/ddscxx/include/dds/core/detail/InstanceHandle.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_DETAIL_INSTANCE_HANDLE_HPP_
 #define OMG_DDS_CORE_DETAIL_INSTANCE_HANDLE_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/detail/TInstanceHandleImpl.hpp>
 #include <org/eclipse/cyclonedds/core/InstanceHandleDelegate.hpp>

--- a/src/ddscxx/include/dds/core/detail/QosProvider.hpp
+++ b/src/ddscxx/include/dds/core/detail/QosProvider.hpp
@@ -2,23 +2,22 @@
 #define OMG_DDS_CORE_DETAIL_QOS_PROVIDER_HPP_
 
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Inc.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Inc.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/detail/TQosProviderImpl.hpp>
 #include <org/eclipse/cyclonedds/core/QosProviderDelegate.hpp>

--- a/src/ddscxx/include/dds/core/detail/ReferenceImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/ReferenceImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_REFERENCE_IMPL_HPP_
 #define CYCLONEDDS_DDS_CORE_REFERENCE_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/core/detail/TEntityImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/TEntityImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_CORE_TENTITY_IMPL_HPP_
 #define CYCLONEDDS_DDS_CORE_TENTITY_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/core/detail/TEntityQosImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/TEntityQosImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_CORE_TENTITYQOS_IMPL_HPP_
 #define CYCLONEDDS_DDS_CORE_TENTITYQOS_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/core/detail/TInstanceHandleImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/TInstanceHandleImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_TINSTANCEHANDLE_IMPL_HPP_
 #define CYCLONEDDS_DDS_CORE_TINSTANCEHANDLE_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/core/detail/TQosProviderImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/TQosProviderImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_DETAIL_TQOSPROVIDERIMPL_HPP_
 #define CYCLONEDDS_DDS_CORE_DETAIL_TQOSPROVIDERIMPL_HPP_
 

--- a/src/ddscxx/include/dds/core/detail/Value.hpp
+++ b/src/ddscxx/include/dds/core/detail/Value.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_DETAIL_VALUE_HPP_
 #define CYCLONEDDS_DDS_CORE_DETAIL_VALUE_HPP_
 

--- a/src/ddscxx/include/dds/core/detail/WeakReferenceImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/WeakReferenceImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_CORE_WEAK_REFERENCE_IMPL_HPP_
 #define CYCLONEDDS_DDS_CORE_WEAK_REFERENCE_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/core/detail/array.hpp
+++ b/src/ddscxx/include/dds/core/detail/array.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_DETAIL_ARRAY_HPP_
 #define CYCLONEDDS_DDS_CORE_DETAIL_ARRAY_HPP_
 

--- a/src/ddscxx/include/dds/core/detail/conformance.hpp
+++ b/src/ddscxx/include/dds/core/detail/conformance.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_DETAIL_CONFORMANCE_HPP_
 #define CYCLONEDDS_DDS_CORE_DETAIL_CONFORMANCE_HPP_
 

--- a/src/ddscxx/include/dds/core/detail/ddscore.hpp
+++ b/src/ddscxx/include/dds/core/detail/ddscore.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef OMG_DDS_CORE_PACKAGE_DETAIL_INCLUDE_HPP_
 #define OMG_DDS_CORE_PACKAGE_DETAIL_INCLUDE_HPP_
 

--- a/src/ddscxx/include/dds/core/detail/inttypes.hpp
+++ b/src/ddscxx/include/dds/core/detail/inttypes.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_DETAIL_INTTYPES_HPP_
 #define CYCLONEDDS_DDS_CORE_DETAIL_INTTYPES_HPP_
 

--- a/src/ddscxx/include/dds/core/detail/macros.hpp
+++ b/src/ddscxx/include/dds/core/detail/macros.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_DETAIL_MACROS_HPP_
 #define CYCLONEDDS_DDS_CORE_DETAIL_MACROS_HPP_
 

--- a/src/ddscxx/include/dds/core/detail/ref_traits.hpp
+++ b/src/ddscxx/include/dds/core/detail/ref_traits.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_DETAIL_REF_TRAITS_HPP_
 #define CYCLONEDDS_DDS_CORE_DETAIL_REF_TRAITS_HPP_
 

--- a/src/ddscxx/include/dds/core/macros.hpp
+++ b/src/ddscxx/include/dds/core/macros.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_MACROS_HPP_
 #define OMG_DDS_CORE_MACROS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/detail/macros.hpp>
 

--- a/src/ddscxx/include/dds/core/policy/CorePolicy.hpp
+++ b/src/ddscxx/include/dds/core/policy/CorePolicy.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_POLICY_CORE_POLICY_HPP_
 #define OMG_DDS_CORE_POLICY_CORE_POLICY_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/policy/PolicyKind.hpp>
 #include <dds/core/policy/detail/CorePolicy.hpp>

--- a/src/ddscxx/include/dds/core/policy/PolicyKind.hpp
+++ b/src/ddscxx/include/dds/core/policy/PolicyKind.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_POLICY_POLICYKIND_HPP_
 #define OMG_DDS_CORE_POLICY_POLICYKIND_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/detail/conformance.hpp>
 #include <dds/core/SafeEnumeration.hpp>

--- a/src/ddscxx/include/dds/core/policy/QosPolicyCount.hpp
+++ b/src/ddscxx/include/dds/core/policy/QosPolicyCount.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_POLICY_QOS_POLICY_COUNT_HPP_
 #define OMG_DDS_CORE_POLICY_QOS_POLICY_COUNT_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/policy/detail/QosPolicyCount.hpp>
 

--- a/src/ddscxx/include/dds/core/policy/TCorePolicy.hpp
+++ b/src/ddscxx/include/dds/core/policy/TCorePolicy.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_TDDS_CORE_POLICY_CORE_POLICY_HPP_
 #define OMG_TDDS_CORE_POLICY_CORE_POLICY_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/detail/conformance.hpp>
 #include <dds/core/LengthUnlimited.hpp>

--- a/src/ddscxx/include/dds/core/policy/TQosPolicyCount.hpp
+++ b/src/ddscxx/include/dds/core/policy/TQosPolicyCount.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_TDDS_CORE_POLICY_QOS_POLICY_COUNT_HPP_
 #define OMG_TDDS_CORE_POLICY_QOS_POLICY_COUNT_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/Value.hpp>
 

--- a/src/ddscxx/include/dds/core/policy/detail/CorePolicy.hpp
+++ b/src/ddscxx/include/dds/core/policy/detail/CorePolicy.hpp
@@ -1,24 +1,22 @@
 #ifndef OMG_DDS_CORE_POLICY_DETAIL_CORE_POLICY_HPP_
 #define OMG_DDS_CORE_POLICY_DETAIL_CORE_POLICY_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <org/eclipse/cyclonedds/core/policy/PolicyDelegate.hpp>
 #include <dds/core/policy/detail/TCorePolicyImpl.hpp>

--- a/src/ddscxx/include/dds/core/policy/detail/QosPolicyCount.hpp
+++ b/src/ddscxx/include/dds/core/policy/detail/QosPolicyCount.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_POLICY_DETAIL_QOS_POLICY_COUNT_HPP_
 #define OMG_DDS_CORE_POLICY_DETAIL_QOS_POLICY_COUNT_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/policy/detail/TQosPolicyCountImpl.hpp>
 #include <org/eclipse/cyclonedds/core/policy/QosPolicyCountDelegate.hpp>

--- a/src/ddscxx/include/dds/core/policy/detail/TCorePolicyImpl.hpp
+++ b/src/ddscxx/include/dds/core/policy/detail/TCorePolicyImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_POLICY_TCOREPOLICY_IMPL_HPP_
 #define CYCLONEDDS_DDS_CORE_POLICY_TCOREPOLICY_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/core/policy/detail/TCorePolicyImpl.hpp
+++ b/src/ddscxx/include/dds/core/policy/detail/TCorePolicyImpl.hpp
@@ -38,9 +38,9 @@ TUserData<D>::TUserData() : dds::core::Value<D>() { }
 template <typename D>
 TUserData<D>::TUserData(const dds::core::ByteSeq& sequence) : dds::core::Value<D>(sequence) { }
 
-/** @internal @bug OSPL-1746 No implementation
- * @todo Implementation required - see OSPL-1746
- * @see http://jira.prismtech.com:8080/browse/OSPL-1746 */
+/// @internal @bug OSPL-1746 No implementation
+/// @todo Implementation required - see OSPL-1746
+/// @see http://jira.prismtech.com:8080/browse/OSPL-1746
 template <typename D>
 TUserData<D>::TUserData(const uint8_t* value_begin, const uint8_t* value_end)
 {
@@ -59,9 +59,9 @@ TUserData<D>& TUserData<D>::value(const dds::core::ByteSeq& sequence)
     return *this;
 }
 
-/** @internal @bug OSPL-1746 No implementation
- * @todo Implementation required - see OSPL-1746
- * @see http://jira.prismtech.com:8080/browse/OSPL-1746 */
+/// @internal @bug OSPL-1746 No implementation
+/// @todo Implementation required - see OSPL-1746
+/// @see http://jira.prismtech.com:8080/browse/OSPL-1746
 template <typename D>
 template <typename OCTET_ITER>
 TUserData<D>& TUserData<D>::value(OCTET_ITER begin, OCTET_ITER end)
@@ -78,9 +78,9 @@ const dds::core::ByteSeq TUserData<D>::value() const
     return this->delegate().value();
 }
 
-/** @internal @bug OSPL-1746 No implementation
- * @todo Implementation required - see OSPL-1746
- * @see http://jira.prismtech.com:8080/browse/OSPL-1746 */
+/// @internal @bug OSPL-1746 No implementation
+/// @todo Implementation required - see OSPL-1746
+/// @see http://jira.prismtech.com:8080/browse/OSPL-1746
 template <typename D>
 const uint8_t* TUserData<D>::begin() const
 {
@@ -88,9 +88,9 @@ const uint8_t* TUserData<D>::begin() const
     return NULL;
 }
 
-/** @internal @bug OSPL-1746 No implementation
- * @todo Implementation required - see OSPL-1746
- * @see http://jira.prismtech.com:8080/browse/OSPL-1746 */
+/// @internal @bug OSPL-1746 No implementation
+/// @todo Implementation required - see OSPL-1746
+/// @see http://jira.prismtech.com:8080/browse/OSPL-1746
 template <typename D>
 const uint8_t* TUserData<D>::end() const
 {
@@ -124,9 +124,9 @@ TGroupData<D>& TGroupData<D>::value(const dds::core::ByteSeq& sequence)
     return *this;
 }
 
-/** @internal @bug OSPL-1746 No implementation
- * @todo Implementation required - see OSPL-1746
- * @see http://jira.prismtech.com:8080/browse/OSPL-1746 */
+/// @internal @bug OSPL-1746 No implementation
+/// @todo Implementation required - see OSPL-1746
+/// @see http://jira.prismtech.com:8080/browse/OSPL-1746
 template <typename D>
 template <typename OCTET_ITER>
 TGroupData<D>& TGroupData<D>::value(OCTET_ITER begin, OCTET_ITER end)
@@ -143,9 +143,9 @@ const dds::core::ByteSeq TGroupData<D>::value() const
     return this->delegate().value();
 }
 
-/** @internal @bug OSPL-1746 No implementation
- * @todo Implementation required - see OSPL-1746
- * @see http://jira.prismtech.com:8080/browse/OSPL-1746 */
+/// @internal @bug OSPL-1746 No implementation
+/// @todo Implementation required - see OSPL-1746
+/// @see http://jira.prismtech.com:8080/browse/OSPL-1746
 template <typename D>
 const uint8_t* TGroupData<D>::begin() const
 {
@@ -153,9 +153,9 @@ const uint8_t* TGroupData<D>::begin() const
     return NULL;
 }
 
-/** @internal @bug OSPL-1746 No implementation
- * @todo Implementation required - see OSPL-1746
- * @see http://jira.prismtech.com:8080/browse/OSPL-1746 */
+/// @internal @bug OSPL-1746 No implementation
+/// @todo Implementation required - see OSPL-1746
+/// @see http://jira.prismtech.com:8080/browse/OSPL-1746
 template <typename D>
 const uint8_t* TGroupData<D>::end() const
 {
@@ -174,9 +174,9 @@ TTopicData<D>::TTopicData(const dds::core::ByteSeq& sequence) : dds::core::Value
 template <typename D>
 TTopicData<D>::TTopicData(const TTopicData& other) : dds::core::Value<D>(other.delegate()) { }
 
-/** @internal @bug OSPL-1746 No implementation
- * @todo Implementation required - see OSPL-1746
- * @see http://jira.prismtech.com:8080/browse/OSPL-1746 */
+/// @internal @bug OSPL-1746 No implementation
+/// @todo Implementation required - see OSPL-1746
+/// @see http://jira.prismtech.com:8080/browse/OSPL-1746
 template <typename D>
 TTopicData<D>::TTopicData(const uint8_t* value_begin, const uint8_t* value_end)
 {
@@ -192,9 +192,9 @@ TTopicData<D>& TTopicData<D>::value(const dds::core::ByteSeq& sequence)
     return *this;
 }
 
-/** @internal @bug OSPL-1746 No implementation
- * @todo Implementation required - see OSPL-1746
- * @see http://jira.prismtech.com:8080/browse/OSPL-1746 */
+/// @internal @bug OSPL-1746 No implementation
+/// @todo Implementation required - see OSPL-1746
+/// @see http://jira.prismtech.com:8080/browse/OSPL-1746
 template <typename D>
 template <typename OCTET_ITER>
 TTopicData<D>& TTopicData<D>::value(OCTET_ITER begin, OCTET_ITER end)
@@ -211,9 +211,9 @@ const dds::core::ByteSeq TTopicData<D>::value() const
     return this->delegate().value();
 }
 
-/** @internal @bug OSPL-1746 No implementation
- * @todo Implementation required - see OSPL-1746
- * @see http://jira.prismtech.com:8080/browse/OSPL-1746 */
+/// @internal @bug OSPL-1746 No implementation
+/// @todo Implementation required - see OSPL-1746
+/// @see http://jira.prismtech.com:8080/browse/OSPL-1746
 template <typename D>
 const uint8_t* TTopicData<D>::begin() const
 {
@@ -221,9 +221,9 @@ const uint8_t* TTopicData<D>::begin() const
     return NULL;
 }
 
-/** @internal @bug OSPL-1746 No implementation
- * @todo Implementation required - see OSPL-1746
- * @see http://jira.prismtech.com:8080/browse/OSPL-1746 */
+/// @internal @bug OSPL-1746 No implementation
+/// @todo Implementation required - see OSPL-1746
+/// @see http://jira.prismtech.com:8080/browse/OSPL-1746
 template <typename D>
 const uint8_t* TTopicData<D>::end() const
 {

--- a/src/ddscxx/include/dds/core/policy/detail/TQosPolicyCountImpl.hpp
+++ b/src/ddscxx/include/dds/core/policy/detail/TQosPolicyCountImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_POLICY_TQOSPOLICYCOUNT_IMPL_HPP_
 #define CYCLONEDDS_DDS_CORE_POLICY_TQOSPOLICYCOUNT_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/core/ref_traits.hpp
+++ b/src/ddscxx/include/dds/core/ref_traits.hpp
@@ -1,24 +1,22 @@
 #ifndef OMG_DDS_CORE_REF_TRAITS_H_
 #define OMG_DDS_CORE_REF_TRAITS_H_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Inc.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Inc.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace  dds
 {

--- a/src/ddscxx/include/dds/core/refmacros.hpp
+++ b/src/ddscxx/include/dds/core/refmacros.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_REFMACROS_HPP_
 #define OMG_DDS_CORE_REFMACROS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/macros.hpp>
 #include <dds/core/ref_traits.hpp>

--- a/src/ddscxx/include/dds/core/status/State.hpp
+++ b/src/ddscxx/include/dds/core/status/State.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_STATUS_STATE_HPP_
 #define OMG_DDS_CORE_STATUS_STATE_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <bitset>
 #include <dds/core/macros.hpp>

--- a/src/ddscxx/include/dds/core/status/Status.hpp
+++ b/src/ddscxx/include/dds/core/status/Status.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_STATUS_STATUS_HPP_
 #define OMG_DDS_CORE_STATUS_STATUS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/status/detail/Status.hpp>
 #include <dds/core/status/State.hpp>

--- a/src/ddscxx/include/dds/core/status/TStatus.hpp
+++ b/src/ddscxx/include/dds/core/status/TStatus.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_TDDS_CORE_STATUS_STATUS_HPP_
 #define OMG_TDDS_CORE_STATUS_STATUS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/Value.hpp>
 #include <dds/core/InstanceHandle.hpp>

--- a/src/ddscxx/include/dds/core/status/detail/Status.hpp
+++ b/src/ddscxx/include/dds/core/status/detail/Status.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_STATUS_DETAIL_STATUS_HPP_
 #define OMG_DDS_CORE_STATUS_DETAIL_STATUS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/status/detail/TStatusImpl.hpp>
 #include <org/eclipse/cyclonedds/core/status/StatusDelegate.hpp>

--- a/src/ddscxx/include/dds/core/status/detail/TStatusImpl.hpp
+++ b/src/ddscxx/include/dds/core/status/detail/TStatusImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_STATUS_TSTATUS_IMPL_HPP_
 #define CYCLONEDDS_DDS_CORE_STATUS_TSTATUS_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/core/types.hpp
+++ b/src/ddscxx/include/dds/core/types.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_CORE_TYPES_HPP_
 #define OMG_DDS_CORE_TYPES_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // ISO C++ Includes
 #include <string>

--- a/src/ddscxx/include/dds/core/types.hpp
+++ b/src/ddscxx/include/dds/core/types.hpp
@@ -46,18 +46,16 @@ typedef std::vector<std::string> StringSeq;
  * @brief This class is used to create dds::core::null objects.
  */
 class OMG_DDS_API null_type { };
-/**
- * This is the DDS Null-Reference.<br>
- * A dds reference object that doesn't reference to anything can be compared with this object.
- * @code{.cpp}
- * dds::domain::DomainParticipant participant = dds::core::null;
- * ...
- * if (participant == dds::core::null) {
- *     // The participant is not yet properly created.
- *     // Using it now will trigger the dds::core::NullReferenceError exception.
- * }
- * @endcode
- */
+/// This is the DDS Null-Reference.<br>
+/// A dds reference object that doesn't reference to anything can be compared with this object.
+/// @code{.cpp}
+/// dds::domain::DomainParticipant participant = dds::core::null;
+/// ...
+/// if (participant == dds::core::null) {
+///     // The participant is not yet properly created.
+///     // Using it now will trigger the dds::core::NullReferenceError exception.
+/// }
+/// @endcode
 extern const null_type OMG_DDS_API null;
 
 /** @cond

--- a/src/ddscxx/include/dds/dds.hpp
+++ b/src/ddscxx/include/dds/dds.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef __OMG_DDS_DDS_HPP__
 #define __OMG_DDS_DDS_HPP__
 

--- a/src/ddscxx/include/dds/domain/DomainParticipant.hpp
+++ b/src/ddscxx/include/dds/domain/DomainParticipant.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_DOMAIN_DOMAINPARTICIPANT_HPP_
 #define OMG_DDS_DOMAIN_DOMAINPARTICIPANT_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/domain/detail/DomainParticipant.hpp>
 

--- a/src/ddscxx/include/dds/domain/DomainParticipantListener.hpp
+++ b/src/ddscxx/include/dds/domain/DomainParticipantListener.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_DOMAIN_DOMAINPARTICIPANT_LISTENER_HPP_
 #define OMG_DDS_DOMAIN_DOMAINPARTICIPANT_LISTENER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/pub/PublisherListener.hpp>
 #include <dds/sub/SubscriberListener.hpp>

--- a/src/ddscxx/include/dds/domain/DomainParticipantListener.hpp
+++ b/src/ddscxx/include/dds/domain/DomainParticipantListener.hpp
@@ -30,134 +30,132 @@ namespace domain
 
 DDSCXX_WARNING_MSVC_OFF(4250)
 
-/**
- * @brief
- * DomainParticipant events Listener
- *
- * Since a DomainParticipant is an Entity, it has the ability to have a Listener
- * associated with it. In this case, the associated Listener should be of type
- * DomainParticipantListener. This interface must be implemented by the
- * application. A user-defined class must be provided by the application which must
- * extend from the DomainParticipantListener class.
- *
- * <b><i>
- * All operations for this interface must be implemented in the user-defined class, it is
- * up to the application whether an operation is empty or contains some functionality.
- * </i></b>
- *
- * The DomainParticipantListener provides a generic mechanism (actually a
- * callback function) for the Data Distribution Service to notify the application of
- * relevant asynchronous status change events, such as a missed deadline, violation of
- * a QosPolicy setting, etc. The DomainParticipantListener is related to
- * changes in communication status StatusConditions.
- *
- * @code{.cpp}
- * // Application example listener
- * class ExampleListener :
- *                public virtual dds::domain::DomainParticipantListener
- * {
- * public:
- *     virtual void on_inconsistent_topic (
- *         dds::topic::AnyTopic& topic,
- *         const dds::core::status::InconsistentTopicStatus& status)
- *     {
- *         std::cout << "on_inconsistent_topic" << std::endl;
- *     }
- *
- *     virtual void on_offered_deadline_missed (
- *         dds::pub::AnyDataWriter& writer,
- *         const dds::core::status::OfferedDeadlineMissedStatus& status)
- *     {
- *         std::cout << "on_offered_deadline_missed" << std::endl;
- *     }
- *
- *     virtual void on_offered_incompatible_qos (
- *         dds::pub::AnyDataWriter& writer,
- *         const dds::core::status::OfferedIncompatibleQosStatus& status)
- *     {
- *         std::cout << "on_offered_incompatible_qos" << std::endl;
- *     }
- *
- *     virtual void on_liveliness_lost (
- *         dds::pub::AnyDataWriter& writer,
- *         const dds::core::status::LivelinessLostStatus& status)
- *     {
- *         std::cout << "on_liveliness_lost" << std::endl;
- *     }
- *
- *     virtual void on_publication_matched (
- *         dds::pub::AnyDataWriter& writer,
- *         const dds::core::status::PublicationMatchedStatus& status)
- *     {
- *         std::cout << "on_publication_matched" << std::endl;
- *     }
- *
- *     virtual void on_requested_deadline_missed (
- *         dds::sub::AnyDataReader& reader,
- *         const dds::core::status::RequestedDeadlineMissedStatus & status)
- *     {
- *         std::cout << "on_requested_deadline_missed" << std::endl;
- *     }
- *
- *     virtual void on_requested_incompatible_qos (
- *         dds::sub::AnyDataReader& reader,
- *         const dds::core::status::RequestedIncompatibleQosStatus & status)
- *     {
- *         std::cout << "on_requested_incompatible_qos" << std::endl;
- *     }
- *
- *     virtual void on_sample_rejected (
- *         dds::sub::AnyDataReader& reader,
- *         const dds::core::status::SampleRejectedStatus & status)
- *     {
- *         std::cout << "on_sample_rejected" << std::endl;
- *     }
- *
- *     virtual void on_liveliness_changed (
- *         dds::sub::AnyDataReader& reader,
- *         const dds::core::status::LivelinessChangedStatus & status)
- *     {
- *         std::cout << "on_liveliness_changed" << std::endl;
- *     }
- *
- *     virtual void on_data_available (
- *         dds::sub::AnyDataReader& reader)
- *     {
- *         std::cout << "on_data_available" << std::endl;
- *     }
- *
- *     virtual void on_subscription_matched (
- *         dds::sub::AnyDataReader& reader,
- *         const dds::core::status::SubscriptionMatchedStatus & status)
- *     {
- *         std::cout << "on_subscription_matched" << std::endl;
- *     }
- *
- *     virtual void on_sample_lost (
- *         dds::sub::AnyDataReader& reader,
- *         const dds::core::status::SampleLostStatus & status)
- *     {
- *         std::cout << "on_sample_lost" << std::endl;
- *     }
- *
- *     virtual void on_data_on_readers (
- *         dds::sub::Subscriber& subs)
- *     {
- *         std::cout << "on_data_on_readers" << std::endl;
- *     }
- * };
- *
- * // Create DomainParticipant with the listener
- * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id(),
- *                                            dds::domain::DomainParticipant::default_participant_qos(),
- *                                            new ExampleListener(),
- *                                            dds::core::status::StatusMask::all());
- *
- * @endcode
- *
- * @see for more information: @ref DCPS_Modules_DomainParticipant "Domain Participant"
- * @see for more information: @ref DCPS_Modules_Infrastructure_Listener "Listener information"
- */
+/// @brief
+/// DomainParticipant events Listener
+///
+/// Since a DomainParticipant is an Entity, it has the ability to have a Listener
+/// associated with it. In this case, the associated Listener should be of type
+/// DomainParticipantListener. This interface must be implemented by the
+/// application. A user-defined class must be provided by the application which must
+/// extend from the DomainParticipantListener class.
+///
+/// <b><i>
+/// All operations for this interface must be implemented in the user-defined class, it is
+/// up to the application whether an operation is empty or contains some functionality.
+/// </i></b>
+///
+/// The DomainParticipantListener provides a generic mechanism (actually a
+/// callback function) for the Data Distribution Service to notify the application of
+/// relevant asynchronous status change events, such as a missed deadline, violation of
+/// a QosPolicy setting, etc. The DomainParticipantListener is related to
+/// changes in communication status StatusConditions.
+///
+/// @code{.cpp}
+/// // Application example listener
+/// class ExampleListener :
+///                public virtual dds::domain::DomainParticipantListener
+/// {
+/// public:
+///     virtual void on_inconsistent_topic (
+///         dds::topic::AnyTopic& topic,
+///         const dds::core::status::InconsistentTopicStatus& status)
+///     {
+///         std::cout << "on_inconsistent_topic" << std::endl;
+///     }
+///
+///     virtual void on_offered_deadline_missed (
+///         dds::pub::AnyDataWriter& writer,
+///         const dds::core::status::OfferedDeadlineMissedStatus& status)
+///     {
+///         std::cout << "on_offered_deadline_missed" << std::endl;
+///     }
+///
+///     virtual void on_offered_incompatible_qos (
+///         dds::pub::AnyDataWriter& writer,
+///         const dds::core::status::OfferedIncompatibleQosStatus& status)
+///     {
+///         std::cout << "on_offered_incompatible_qos" << std::endl;
+///     }
+///
+///     virtual void on_liveliness_lost (
+///         dds::pub::AnyDataWriter& writer,
+///         const dds::core::status::LivelinessLostStatus& status)
+///     {
+///         std::cout << "on_liveliness_lost" << std::endl;
+///     }
+///
+///     virtual void on_publication_matched (
+///         dds::pub::AnyDataWriter& writer,
+///         const dds::core::status::PublicationMatchedStatus& status)
+///     {
+///         std::cout << "on_publication_matched" << std::endl;
+///     }
+///
+///     virtual void on_requested_deadline_missed (
+///         dds::sub::AnyDataReader& reader,
+///         const dds::core::status::RequestedDeadlineMissedStatus & status)
+///     {
+///         std::cout << "on_requested_deadline_missed" << std::endl;
+///     }
+///
+///     virtual void on_requested_incompatible_qos (
+///         dds::sub::AnyDataReader& reader,
+///         const dds::core::status::RequestedIncompatibleQosStatus & status)
+///     {
+///         std::cout << "on_requested_incompatible_qos" << std::endl;
+///     }
+///
+///     virtual void on_sample_rejected (
+///         dds::sub::AnyDataReader& reader,
+///         const dds::core::status::SampleRejectedStatus & status)
+///     {
+///         std::cout << "on_sample_rejected" << std::endl;
+///     }
+///
+///     virtual void on_liveliness_changed (
+///         dds::sub::AnyDataReader& reader,
+///         const dds::core::status::LivelinessChangedStatus & status)
+///     {
+///         std::cout << "on_liveliness_changed" << std::endl;
+///     }
+///
+///     virtual void on_data_available (
+///         dds::sub::AnyDataReader& reader)
+///     {
+///         std::cout << "on_data_available" << std::endl;
+///     }
+///
+///     virtual void on_subscription_matched (
+///         dds::sub::AnyDataReader& reader,
+///         const dds::core::status::SubscriptionMatchedStatus & status)
+///     {
+///         std::cout << "on_subscription_matched" << std::endl;
+///     }
+///
+///     virtual void on_sample_lost (
+///         dds::sub::AnyDataReader& reader,
+///         const dds::core::status::SampleLostStatus & status)
+///     {
+///         std::cout << "on_sample_lost" << std::endl;
+///     }
+///
+///     virtual void on_data_on_readers (
+///         dds::sub::Subscriber& subs)
+///     {
+///         std::cout << "on_data_on_readers" << std::endl;
+///     }
+/// };
+///
+/// // Create DomainParticipant with the listener
+/// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id(),
+///                                            dds::domain::DomainParticipant::default_participant_qos(),
+///                                            new ExampleListener(),
+///                                            dds::core::status::StatusMask::all());
+///
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Modules_DomainParticipant "Domain Participant"
+/// @see for more information: @ref DCPS_Modules_Infrastructure_Listener "Listener information"
 class OMG_DDS_API DomainParticipantListener :
     public virtual dds::pub::PublisherListener,
     public virtual dds::sub::SubscriberListener,
@@ -170,23 +168,21 @@ public:
 };
 
 
-/**
- * @brief
- * DomainParticipant events Listener
- *
- * This listener is just like DomainParticipantListener, except
- * that the application doesn't have to implement all operations.
- *
- * @code{.cpp}
- * class ExampleListener :
- *                public virtual dds::domain::NoOpDomainParticipantListener
- * {
- *    // Not necessary to implement any Listener operations.
- * };
- * @endcode
- *
- * @see dds::domain::DomainParticipantListener
- */
+/// @brief
+/// DomainParticipant events Listener
+///
+/// This listener is just like DomainParticipantListener, except
+/// that the application doesn't have to implement all operations.
+///
+/// @code{.cpp}
+/// class ExampleListener :
+///                public virtual dds::domain::NoOpDomainParticipantListener
+/// {
+///    // Not necessary to implement any Listener operations.
+/// };
+/// @endcode
+///
+/// @see dds::domain::DomainParticipantListener
 class OMG_DDS_API NoOpDomainParticipantListener :
     public virtual DomainParticipantListener,
     public virtual dds::pub::NoOpPublisherListener,

--- a/src/ddscxx/include/dds/domain/TDomainParticipant.hpp
+++ b/src/ddscxx/include/dds/domain/TDomainParticipant.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_TDDS_DOMAIN_DOMAIN_PARTICIPANT_HPP_
 #define OMG_TDDS_DOMAIN_DOMAIN_PARTICIPANT_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <string>
 

--- a/src/ddscxx/include/dds/domain/ddsdomain.hpp
+++ b/src/ddscxx/include/dds/domain/ddsdomain.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef OMG_DDS_DOMAIN_PACKAGE_INCLUDE_HPP_
 #define OMG_DDS_DOMAIN_PACKAGE_INCLUDE_HPP_
 

--- a/src/ddscxx/include/dds/domain/detail/DomainParticipant.hpp
+++ b/src/ddscxx/include/dds/domain/detail/DomainParticipant.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_DOMAIN_DETAIL_DOMAINPARTICIPANT_HPP_
 #define OMG_DDS_DOMAIN_DETAIL_DOMAINPARTICIPANT_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/domain/detail/TDomainParticipantImpl.hpp>
 //#include <dds/domain/TDomainParticipant.hpp>

--- a/src/ddscxx/include/dds/domain/detail/TDomainParticipantImpl.hpp
+++ b/src/ddscxx/include/dds/domain/detail/TDomainParticipantImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_DOMAIN_TDOMAINPARTICIPANT_IMPL_HPP_
 #define CYCLONEDDS_DDS_DOMAIN_TDOMAINPARTICIPANT_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/domain/detail/ddsdomain.hpp
+++ b/src/ddscxx/include/dds/domain/detail/ddsdomain.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef OMG_DDS_DOMAIN_PACKAGE_DETAIL_INCLUDE_HPP_
 #define OMG_DDS_DOMAIN_PACKAGE_DETAIL_INCLUDE_HPP_
 

--- a/src/ddscxx/include/dds/domain/discovery.hpp
+++ b/src/ddscxx/include/dds/domain/discovery.hpp
@@ -1,24 +1,22 @@
 #ifndef OMG_DDS_DOMAIN_DISCOVERY_HPP_
 #define OMG_DDS_DOMAIN_DISCOVERY_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/InstanceHandle.hpp>
 #include <dds/domain/DomainParticipant.hpp>

--- a/src/ddscxx/include/dds/domain/find.hpp
+++ b/src/ddscxx/include/dds/domain/find.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_DOMAIN_FIND_HPP_
 #define OMG_DDS_DOMAIN_FIND_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/domain/DomainParticipant.hpp>
 

--- a/src/ddscxx/include/dds/domain/qos/DomainParticipantQos.hpp
+++ b/src/ddscxx/include/dds/domain/qos/DomainParticipantQos.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_DOMAIN_QOS_DOMAINPARTICIPANTQOS_HPP_
 #define OMG_DDS_DOMAIN_QOS_DOMAINPARTICIPANTQOS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/domain/qos/detail/DomainParticipantQos.hpp>
 

--- a/src/ddscxx/include/dds/domain/qos/detail/DomainParticipantQos.hpp
+++ b/src/ddscxx/include/dds/domain/qos/detail/DomainParticipantQos.hpp
@@ -1,24 +1,22 @@
 #ifndef OMG_DDS_DOMAIN_QOS_DETAIL_DOMAINPARTICIPANTQOS_HPP_
 #define OMG_DDS_DOMAIN_QOS_DETAIL_DOMAINPARTICIPANTQOS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/detail/TEntityQosImpl.hpp>
 #include <org/eclipse/cyclonedds/domain/qos/DomainParticipantQosDelegate.hpp>

--- a/src/ddscxx/include/dds/pub/AnyDataWriter.hpp
+++ b/src/ddscxx/include/dds/pub/AnyDataWriter.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_PUB_ANY_DATA_WRITER_HPP_
 #define OMG_DDS_PUB_ANY_DATA_WRITER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/pub/detail/AnyDataWriter.hpp>
 

--- a/src/ddscxx/include/dds/pub/AnyDataWriterListener.hpp
+++ b/src/ddscxx/include/dds/pub/AnyDataWriterListener.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_PUB_ANY_DATA_WRITER_LISTENER_HPP_
 #define OMG_DDS_PUB_ANY_DATA_WRITER_LISTENER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/pub/AnyDataWriter.hpp>
 

--- a/src/ddscxx/include/dds/pub/CoherentSet.hpp
+++ b/src/ddscxx/include/dds/pub/CoherentSet.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef OMG_DDS_PUB_COHERENT_SET_HPP_
 #define OMG_DDS_PUB_COHERENT_SET_HPP_
 

--- a/src/ddscxx/include/dds/pub/DataWriter.hpp
+++ b/src/ddscxx/include/dds/pub/DataWriter.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_PUB_DATA_WRITER_HPP_
 #define OMG_DDS_PUB_DATA_WRITER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/InstanceHandle.hpp>
 #include <dds/topic/Topic.hpp>

--- a/src/ddscxx/include/dds/pub/DataWriter.hpp
+++ b/src/ddscxx/include/dds/pub/DataWriter.hpp
@@ -41,49 +41,47 @@ template <typename T> class DataWriterListener;
 }
 /** @endcond */
 
-/**
- * @brief
- * DataWriter allows the application to set the value of the sample to be published
- * under a given Topic.
- *
- * A DataWriter is attached to exactly one Publisher.
- *
- * A DataWriter is bound to exactly one Topic and therefore to exactly one data
- * type. The Topic must exist prior to the DataWriter's creation.
- * DataWriter is an abstract class. It must be specialized for each particular
- * application data type. For a fictional application data type Bar (defined in the
- * module Foo) the specialized class would be dds::pub::DataWriter<Foo::Bar>.
- *
- * The pre-processor generates from IDL type descriptions the application
- * DataWriter<type> classes. For each application data type that is used as Topic
- * data type, a typed class DataWriter<type> is derived from the AnyDataWriter
- * class.
- *
- * For instance, for an application, the definitions are located in the Foo.idl file.
- * The pre-processor will generate a ccpp_Foo.h include file.
- *
- * <b>General note:</b> The name ccpp_Foo.h is derived from the IDL file Foo.idl,
- * that defines Foo::Bar, for all relevant DataWriter<Foo::Bar> operations.
- *
- * @note Apart from idl files, Google protocol buffers are also supported. For the
- *       API itself, it doesn't matter if the type header files were generated from
- *       idl or protocol buffers. The resulting API usage and includes remain the same.
- *
- * @code{.cpp}
- * // Default creation of a DataWriter
- * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
- * dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
- * dds::pub::Publisher publisher(participant);
- * dds::pub::DataWriter<Foo::Bar> writer(publisher, topic);
- *
- * // Default write of a sample on the DataWriter
- * Foo::Bar sample;
- * writer.write(sample);
- * @endcode
- *
- * @see for more information: @ref DCPS_Modules_Publication "Publication concept"
- * @see for more information: @ref DCPS_Modules_Publication_DataWriter "DataWriter concept"
- */
+/// @brief
+/// DataWriter allows the application to set the value of the sample to be published
+/// under a given Topic.
+///
+/// A DataWriter is attached to exactly one Publisher.
+///
+/// A DataWriter is bound to exactly one Topic and therefore to exactly one data
+/// type. The Topic must exist prior to the DataWriter's creation.
+/// DataWriter is an abstract class. It must be specialized for each particular
+/// application data type. For a fictional application data type Bar (defined in the
+/// module Foo) the specialized class would be dds::pub::DataWriter<Foo::Bar>.
+///
+/// The pre-processor generates from IDL type descriptions the application
+/// DataWriter<type> classes. For each application data type that is used as Topic
+/// data type, a typed class DataWriter<type> is derived from the AnyDataWriter
+/// class.
+///
+/// For instance, for an application, the definitions are located in the Foo.idl file.
+/// The pre-processor will generate a ccpp_Foo.h include file.
+///
+/// <b>General note:</b> The name ccpp_Foo.h is derived from the IDL file Foo.idl,
+/// that defines Foo::Bar, for all relevant DataWriter<Foo::Bar> operations.
+///
+/// @note Apart from idl files, Google protocol buffers are also supported. For the
+///       API itself, it doesn't matter if the type header files were generated from
+///       idl or protocol buffers. The resulting API usage and includes remain the same.
+///
+/// @code{.cpp}
+/// // Default creation of a DataWriter
+/// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+/// dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
+/// dds::pub::Publisher publisher(participant);
+/// dds::pub::DataWriter<Foo::Bar> writer(publisher, topic);
+///
+/// // Default write of a sample on the DataWriter
+/// Foo::Bar sample;
+/// writer.write(sample);
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Modules_Publication "Publication concept"
+/// @see for more information: @ref DCPS_Modules_Publication_DataWriter "DataWriter concept"
 template <typename T, template <typename Q> class DELEGATE>
 class dds::pub::DataWriter final : public ::dds::pub::TAnyDataWriter< DELEGATE<T> >
 {
@@ -120,52 +118,50 @@ public:
     DataWriter(const dds::pub::Publisher& pub,
                const ::dds::topic::Topic<T>& topic);
 
-    /**
-     * Create a new DataWriter for the desired Topic, using the given Publisher and
-     * DataWriterQos and attaches the optionally specified DataWriterListener to it.
-     *
-     * <i>QoS</i><br>
-     * A possible application pattern to construct the DataWriterQos for the
-     * DataWriter is to:
-     * @code{.cpp}
-     * // 1) Retrieve the QosPolicy settings on the associated Topic
-     * dds::topic::qos::TopicQos topicQos = topic.qos();
-     * // 2) Retrieve the default DataWriterQos from the related Publisher
-     * dds::pub::qos::DataWriterQos writerQos = publisher.default_datawriter_qos();
-     * // 3) Combine those two lists of QosPolicy settings by overwriting DataWriterQos
-     * //    policies that are also present TopicQos
-     * writerQos = topicQos;
-     * // 4) Selectively modify QosPolicy settings as desired.
-     * writerQos << dds::core::policy::WriterDataLifecycle::ManuallyDisposeUnregisteredInstances();
-     * // 5) Use the resulting QoS to construct the DataWriter.
-     * dds::pub::DataWriter<Foo::Bar> writer(publisher, topic, writerQos);
-     * @endcode
-     *
-     * <i>Listener</i><br>
-     * The following statuses are applicable to the DataWriterListener:
-     *  - dds::core::status::StatusMask::offered_deadline_missed()
-     *  - dds::core::status::StatusMask::offered_incompatible_qos()
-     *  - dds::core::status::StatusMask::liveliness_lost()
-     *  - dds::core::status::StatusMask::publication_matched()
-     *
-     * See @ref DCPS_Modules_Infrastructure_Listener "listener concept",
-     * @ref anchor_dds_pub_datawriter_commstatus "communication status" and
-     * @ref anchor_dds_pub_datawriter_commpropagation "communication propagation"
-     * for more information.
-     *
-     * @param pub the Publisher that will contain this DataWriter
-     * @param topic the Topic associated with this DataWriter
-     * @param qos the DataWriter qos.
-     * @param listener the DataWriter listener.
-     * @param mask the listener event mask.
-     * @throws dds::core::Error
-     *                  An internal error has occurred.
-     * @throws dds::core::OutOfResourcesError
-     *                  The Data Distribution Service ran out of resources to
-     *                  complete this operation.
-     * @throws dds::core::InconsistentPolicyError
-     *                  The parameter qos contains conflicting QosPolicy settings.
-     */
+    /// Create a new DataWriter for the desired Topic, using the given Publisher and
+    /// DataWriterQos and attaches the optionally specified DataWriterListener to it.
+    ///
+    /// <i>QoS</i><br>
+    /// A possible application pattern to construct the DataWriterQos for the
+    /// DataWriter is to:
+    /// @code{.cpp}
+    /// // 1) Retrieve the QosPolicy settings on the associated Topic
+    /// dds::topic::qos::TopicQos topicQos = topic.qos();
+    /// // 2) Retrieve the default DataWriterQos from the related Publisher
+    /// dds::pub::qos::DataWriterQos writerQos = publisher.default_datawriter_qos();
+    /// // 3) Combine those two lists of QosPolicy settings by overwriting DataWriterQos
+    /// //    policies that are also present TopicQos
+    /// writerQos = topicQos;
+    /// // 4) Selectively modify QosPolicy settings as desired.
+    /// writerQos << dds::core::policy::WriterDataLifecycle::ManuallyDisposeUnregisteredInstances();
+    /// // 5) Use the resulting QoS to construct the DataWriter.
+    /// dds::pub::DataWriter<Foo::Bar> writer(publisher, topic, writerQos);
+    /// @endcode
+    ///
+    /// <i>Listener</i><br>
+    /// The following statuses are applicable to the DataWriterListener:
+    ///  - dds::core::status::StatusMask::offered_deadline_missed()
+    ///  - dds::core::status::StatusMask::offered_incompatible_qos()
+    ///  - dds::core::status::StatusMask::liveliness_lost()
+    ///  - dds::core::status::StatusMask::publication_matched()
+    ///
+    /// See @ref DCPS_Modules_Infrastructure_Listener "listener concept",
+    /// @ref anchor_dds_pub_datawriter_commstatus "communication status" and
+    /// @ref anchor_dds_pub_datawriter_commpropagation "communication propagation"
+    /// for more information.
+    ///
+    /// @param pub the Publisher that will contain this DataWriter
+    /// @param topic the Topic associated with this DataWriter
+    /// @param qos the DataWriter qos.
+    /// @param listener the DataWriter listener.
+    /// @param mask the listener event mask.
+    /// @throws dds::core::Error
+    ///                  An internal error has occurred.
+    /// @throws dds::core::OutOfResourcesError
+    ///                  The Data Distribution Service ran out of resources to
+    ///                  complete this operation.
+    /// @throws dds::core::InconsistentPolicyError
+    ///                  The parameter qos contains conflicting QosPolicy settings.
     DataWriter(const dds::pub::Publisher& pub,
                const ::dds::topic::Topic<T>& topic,
                const dds::pub::qos::DataWriterQos& qos,

--- a/src/ddscxx/include/dds/pub/DataWriterListener.hpp
+++ b/src/ddscxx/include/dds/pub/DataWriterListener.hpp
@@ -25,77 +25,75 @@ namespace dds
 namespace pub
 {
 
-/**
- *  * @brief
- * DataWriter events Listener
- *
- * Since a DataWriter is an Entity, it has the ability to have a Listener
- * associated with it. In this case, the associated Listener should be of type
- * DataWriterListener. This interface must be implemented by the
- * application. A user-defined class must be provided by the application which must
- * extend from the DataWriterListener class.
- *
- * <b><i>
- * All operations for this interface must be implemented in the user-defined class, it is
- * up to the application whether an operation is empty or contains some functionality.
- * </i></b>
- *
- * The DataWriterListener provides a generic mechanism (actually a
- * callback function) for the Data Distribution Service to notify the application of
- * relevant asynchronous status change events, such as a missed deadline, violation of
- * a QosPolicy setting, etc. The DataWriterListener is related to
- * changes in communication status StatusConditions.
- *
- * @code{.cpp}
- * // Application example listener
- * class ExampleListener :
- *                public virtual dds::pub::DataWriterListener<Foo::Bar>
- * {
- * public:
- *     virtual void on_offered_deadline_missed (
- *         dds::pub::DataWriter<Foo::Bar>& writer,
- *         const dds::core::status::OfferedDeadlineMissedStatus& status)
- *     {
- *         std::cout << "on_offered_deadline_missed" << std::endl;
- *     }
- *
- *     virtual void on_offered_incompatible_qos (
- *         dds::pub::DataWriter<Foo::Bar>& writer,
- *         const dds::core::status::OfferedIncompatibleQosStatus& status)
- *     {
- *         std::cout << "on_offered_incompatible_qos" << std::endl;
- *     }
- *
- *     virtual void on_liveliness_lost (
- *         dds::pub::DataWriter<Foo::Bar>& writer,
- *         const dds::core::status::LivelinessLostStatus& status)
- *     {
- *         std::cout << "on_liveliness_lost" << std::endl;
- *     }
- *
- *     virtual void on_publication_matched (
- *         dds::pub::DataWriter<Foo::Bar>& writer,
- *         const dds::core::status::PublicationMatchedStatus& status)
- *     {
- *         std::cout << "on_publication_matched" << std::endl;
- *     }
- * };
- *
- * // Create DataWriter with the listener
- * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
- * dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
- * dds::pub::Publisher publisher(participant);
- * dds::pub::DataWriter<Foo::Bar> writer(publisher,
- *                                       topic,
- *                                       publisher.default_datawriter_qos(),
- *                                       new ExampleListener(),
- *                                       dds::core::status::StatusMask::all());
- *
- * @endcode
- *
- * @see for more information: @ref DCPS_Modules_Publication_DataWriter "Data Writer"
- * @see for more information: @ref DCPS_Modules_Infrastructure_Listener "Listener information"
- */
+/// @brief
+/// DataWriter events Listener
+///
+/// Since a DataWriter is an Entity, it has the ability to have a Listener
+/// associated with it. In this case, the associated Listener should be of type
+/// DataWriterListener. This interface must be implemented by the
+/// application. A user-defined class must be provided by the application which must
+/// extend from the DataWriterListener class.
+///
+/// <b><i>
+/// All operations for this interface must be implemented in the user-defined class, it is
+/// up to the application whether an operation is empty or contains some functionality.
+/// </i></b>
+///
+/// The DataWriterListener provides a generic mechanism (actually a
+/// callback function) for the Data Distribution Service to notify the application of
+/// relevant asynchronous status change events, such as a missed deadline, violation of
+/// a QosPolicy setting, etc. The DataWriterListener is related to
+/// changes in communication status StatusConditions.
+///
+/// @code{.cpp}
+/// // Application example listener
+/// class ExampleListener :
+///                public virtual dds::pub::DataWriterListener<Foo::Bar>
+/// {
+/// public:
+///     virtual void on_offered_deadline_missed (
+///         dds::pub::DataWriter<Foo::Bar>& writer,
+///         const dds::core::status::OfferedDeadlineMissedStatus& status)
+///     {
+///         std::cout << "on_offered_deadline_missed" << std::endl;
+///     }
+///
+///     virtual void on_offered_incompatible_qos (
+///         dds::pub::DataWriter<Foo::Bar>& writer,
+///         const dds::core::status::OfferedIncompatibleQosStatus& status)
+///     {
+///         std::cout << "on_offered_incompatible_qos" << std::endl;
+///     }
+///
+///     virtual void on_liveliness_lost (
+///         dds::pub::DataWriter<Foo::Bar>& writer,
+///         const dds::core::status::LivelinessLostStatus& status)
+///     {
+///         std::cout << "on_liveliness_lost" << std::endl;
+///     }
+///
+///     virtual void on_publication_matched (
+///         dds::pub::DataWriter<Foo::Bar>& writer,
+///         const dds::core::status::PublicationMatchedStatus& status)
+///     {
+///         std::cout << "on_publication_matched" << std::endl;
+///     }
+/// };
+///
+/// // Create DataWriter with the listener
+/// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+/// dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
+/// dds::pub::Publisher publisher(participant);
+/// dds::pub::DataWriter<Foo::Bar> writer(publisher,
+///                                       topic,
+///                                       publisher.default_datawriter_qos(),
+///                                       new ExampleListener(),
+///                                       dds::core::status::StatusMask::all());
+///
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Modules_Publication_DataWriter "Data Writer"
+/// @see for more information: @ref DCPS_Modules_Infrastructure_Listener "Listener information"
 template <typename T>
 class DataWriterListener
 {
@@ -201,22 +199,20 @@ public:
 };
 
 
-/**
- * @brief
- * DataWriter events Listener
- *
- * This listener is just like DataWriterListener, except
- * that the application doesn't have to implement all operations.
- *
- * @code{.cpp}
- * class ExampleListener : public virtual dds::pub::NoOpDataWriterListener<Foo::Bar>
- * {
- *    // Not necessary to implement any Listener operations.
- * };
- * @endcode
- *
- * @see dds::pub::DataWriterListener
- */
+/// @brief
+/// DataWriter events Listener
+///
+/// This listener is just like DataWriterListener, except
+/// that the application doesn't have to implement all operations.
+///
+/// @code{.cpp}
+/// class ExampleListener : public virtual dds::pub::NoOpDataWriterListener<Foo::Bar>
+/// {
+///    // Not necessary to implement any Listener operations.
+/// };
+/// @endcode
+///
+/// @see dds::pub::DataWriterListener
 template <typename T>
 class NoOpDataWriterListener : public virtual DataWriterListener<T>
 {

--- a/src/ddscxx/include/dds/pub/DataWriterListener.hpp
+++ b/src/ddscxx/include/dds/pub/DataWriterListener.hpp
@@ -1,24 +1,22 @@
 #ifndef OMG_DDS_PUB_DATA_WRITER_LISTENER_HPP_
 #define OMG_DDS_PUB_DATA_WRITER_LISTENER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/pub/DataWriter.hpp>
 

--- a/src/ddscxx/include/dds/pub/Publisher.hpp
+++ b/src/ddscxx/include/dds/pub/Publisher.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_PUB_PUBLISHER_HPP_
 #define OMG_DDS_PUB_PUBLISHER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/pub/detail/Publisher.hpp>
 

--- a/src/ddscxx/include/dds/pub/PublisherListener.hpp
+++ b/src/ddscxx/include/dds/pub/PublisherListener.hpp
@@ -32,74 +32,72 @@ class NoOpPublisherListener;
 
 DDSCXX_WARNING_MSVC_OFF(4250)
 
-/**
- * @brief
- * Publisher events Listener
- *
- * Since a Publisher is an Entity, it has the ability to have a Listener
- * associated with it. In this case, the associated Listener should be of type
- * PublisherListener. This interface must be implemented by the
- * application. A user-defined class must be provided by the application which must
- * extend from the PublisherListener class.
- *
- * <b><i>
- * All operations for this interface must be implemented in the user-defined class, it is
- * up to the application whether an operation is empty or contains some functionality.
- * </i></b>
- *
- * The PublisherListener provides a generic mechanism (actually a
- * callback function) for the Data Distribution Service to notify the application of
- * relevant asynchronous status change events, such as a missed deadline, violation of
- * a QosPolicy setting, etc. The PublisherListener is related to
- * changes in communication status StatusConditions.
- *
- * @code{.cpp}
- * // Application example listener
- * class ExampleListener :
- *                public virtual dds::pub::PublisherListener
- * {
- * public:
- *     virtual void on_offered_deadline_missed (
- *         dds::pub::AnyDataWriter& writer,
- *         const dds::core::status::OfferedDeadlineMissedStatus& status)
- *     {
- *         std::cout << "on_offered_deadline_missed" << std::endl;
- *     }
- *
- *     virtual void on_offered_incompatible_qos (
- *         dds::pub::AnyDataWriter& writer,
- *         const dds::core::status::OfferedIncompatibleQosStatus& status)
- *     {
- *         std::cout << "on_offered_incompatible_qos" << std::endl;
- *     }
- *
- *     virtual void on_liveliness_lost (
- *         dds::pub::AnyDataWriter& writer,
- *         const dds::core::status::LivelinessLostStatus& status)
- *     {
- *         std::cout << "on_liveliness_lost" << std::endl;
- *     }
- *
- *     virtual void on_publication_matched (
- *         dds::pub::AnyDataWriter& writer,
- *         const dds::core::status::PublicationMatchedStatus& status)
- *     {
- *         std::cout << "on_publication_matched" << std::endl;
- *     }
- * };
- *
- * // Create Publisher with the listener
- * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
- * dds::pub::Publisher publisher(participant,
- *                               participant.default_publisher_qos(),
- *                               new ExampleListener(),
- *                               dds::core::status::StatusMask::all());
- *
- * @endcode
- *
- * @see for more information: @ref DCPS_Modules_Publisher "Publisher"
- * @see for more information: @ref DCPS_Modules_Infrastructure_Listener "Listener information"
- */
+/// @brief
+/// Publisher events Listener
+///
+/// Since a Publisher is an Entity, it has the ability to have a Listener
+/// associated with it. In this case, the associated Listener should be of type
+/// PublisherListener. This interface must be implemented by the
+/// application. A user-defined class must be provided by the application which must
+/// extend from the PublisherListener class.
+///
+/// <b><i>
+/// All operations for this interface must be implemented in the user-defined class, it is
+/// up to the application whether an operation is empty or contains some functionality.
+/// </i></b>
+///
+/// The PublisherListener provides a generic mechanism (actually a
+/// callback function) for the Data Distribution Service to notify the application of
+/// relevant asynchronous status change events, such as a missed deadline, violation of
+/// a QosPolicy setting, etc. The PublisherListener is related to
+/// changes in communication status StatusConditions.
+///
+/// @code{.cpp}
+/// // Application example listener
+/// class ExampleListener :
+///                public virtual dds::pub::PublisherListener
+/// {
+/// public:
+///     virtual void on_offered_deadline_missed (
+///         dds::pub::AnyDataWriter& writer,
+///         const dds::core::status::OfferedDeadlineMissedStatus& status)
+///     {
+///         std::cout << "on_offered_deadline_missed" << std::endl;
+///     }
+///
+///     virtual void on_offered_incompatible_qos (
+///         dds::pub::AnyDataWriter& writer,
+///         const dds::core::status::OfferedIncompatibleQosStatus& status)
+///     {
+///         std::cout << "on_offered_incompatible_qos" << std::endl;
+///     }
+///
+///     virtual void on_liveliness_lost (
+///         dds::pub::AnyDataWriter& writer,
+///         const dds::core::status::LivelinessLostStatus& status)
+///     {
+///         std::cout << "on_liveliness_lost" << std::endl;
+///     }
+///
+///     virtual void on_publication_matched (
+///         dds::pub::AnyDataWriter& writer,
+///         const dds::core::status::PublicationMatchedStatus& status)
+///     {
+///         std::cout << "on_publication_matched" << std::endl;
+///     }
+/// };
+///
+/// // Create Publisher with the listener
+/// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+/// dds::pub::Publisher publisher(participant,
+///                               participant.default_publisher_qos(),
+///                               new ExampleListener(),
+///                               dds::core::status::StatusMask::all());
+///
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Modules_Publisher "Publisher"
+/// @see for more information: @ref DCPS_Modules_Infrastructure_Listener "Listener information"
 class OMG_DDS_API dds::pub::PublisherListener : public virtual dds::pub::AnyDataWriterListener
 {
 public:
@@ -109,22 +107,20 @@ public:
 };
 
 
-/**
- * @brief
- * Publisher events Listener
- *
- * This listener is just like PublisherListener, except
- * that the application doesn't have to implement all operations.
- *
- * @code{.cpp}
- * class ExampleListener : public virtual dds::pub::NoOpPublisherListener
- * {
- *    // Not necessary to implement any Listener operations.
- * };
- * @endcode
- *
- * @see dds::pub::PublisherListener
- */
+/// @brief
+/// Publisher events Listener
+///
+/// This listener is just like PublisherListener, except
+/// that the application doesn't have to implement all operations.
+///
+/// @code{.cpp}
+/// class ExampleListener : public virtual dds::pub::NoOpPublisherListener
+/// {
+///    // Not necessary to implement any Listener operations.
+/// };
+/// @endcode
+///
+/// @see dds::pub::PublisherListener
 class OMG_DDS_API dds::pub::NoOpPublisherListener :
     public virtual dds::pub::PublisherListener,
     public virtual dds::pub::NoOpAnyDataWriterListener

--- a/src/ddscxx/include/dds/pub/PublisherListener.hpp
+++ b/src/ddscxx/include/dds/pub/PublisherListener.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_PUB_PUBLISHER_LISTENER_HPP_
 #define OMG_DDS_PUB_PUBLISHER_LISTENER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/pub/AnyDataWriterListener.hpp>
 

--- a/src/ddscxx/include/dds/pub/SuspendedPublication.hpp
+++ b/src/ddscxx/include/dds/pub/SuspendedPublication.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_PUB_SUSPENDED_PUBLICATION_HPP_
 #define OMG_DDS_PUB_SUSPENDED_PUBLICATION_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/pub/detail/SuspendedPublication.hpp>
 

--- a/src/ddscxx/include/dds/pub/TAnyDataWriter.hpp
+++ b/src/ddscxx/include/dds/pub/TAnyDataWriter.hpp
@@ -1,22 +1,21 @@
 #ifndef OMG_TDDS_PUB_ANY_DATA_WRITER_HPP_
 #define OMG_TDDS_PUB_ANY_DATA_WRITER_HPP_
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/TEntity.hpp>
 #include <dds/pub/Publisher.hpp>

--- a/src/ddscxx/include/dds/pub/TCoherentSet.hpp
+++ b/src/ddscxx/include/dds/pub/TCoherentSet.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_TDDS_PUB_COHERENT_SET_HPP_
 #define OMG_TDDS_PUB_COHERENT_SET_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/pub/Publisher.hpp>
 

--- a/src/ddscxx/include/dds/pub/TPublisher.hpp
+++ b/src/ddscxx/include/dds/pub/TPublisher.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_TDDS_PUB_PUBLISHER_HPP_
 #define OMG_TDDS_PUB_PUBLISHER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/types.hpp>
 #include <dds/core/TEntity.hpp>

--- a/src/ddscxx/include/dds/pub/TSuspendedPublication.hpp
+++ b/src/ddscxx/include/dds/pub/TSuspendedPublication.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_TDDS_PUB_SUSPENDED_PUBLICATION_HPP_
 #define OMG_TDDS_PUB_SUSPENDED_PUBLICATION_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/pub/Publisher.hpp>
 

--- a/src/ddscxx/include/dds/pub/ddspub.hpp
+++ b/src/ddscxx/include/dds/pub/ddspub.hpp
@@ -1,24 +1,22 @@
 #ifndef OMG_DDS_PUB_PACKAGE_INCLUDE_HPP_
 #define OMG_DDS_PUB_PACKAGE_INCLUDE_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/pub/DataWriter.hpp>
 #include <dds/pub/AnyDataWriter.hpp>

--- a/src/ddscxx/include/dds/pub/detail/AnyDataWriter.hpp
+++ b/src/ddscxx/include/dds/pub/detail/AnyDataWriter.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef OMG_DDS_PUB_DETAIL_ANYDATAWRITER_HPP_
 #define OMG_DDS_PUB_DETAIL_ANYDATAWRITER_HPP_
 

--- a/src/ddscxx/include/dds/pub/detail/CoherentSet.hpp
+++ b/src/ddscxx/include/dds/pub/detail/CoherentSet.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef OMG_DDS_PUB_DETAIL_COHERENT_SET_HPP_
 #define OMG_DDS_PUB_DETAIL_COHERENT_SET_HPP_
 

--- a/src/ddscxx/include/dds/pub/detail/DataWriter.hpp
+++ b/src/ddscxx/include/dds/pub/detail/DataWriter.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_PUB_DETAIL_DATA_WRITER_HPP_
 #define OMG_DDS_PUB_DETAIL_DATA_WRITER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/topic/Topic.hpp>
 #include <dds/pub/AnyDataWriter.hpp>

--- a/src/ddscxx/include/dds/pub/detail/DataWriterImpl.hpp
+++ b/src/ddscxx/include/dds/pub/detail/DataWriterImpl.hpp
@@ -1,26 +1,22 @@
 #ifndef OMG_DDS_PUB_DATA_WRITER_IMPL_HPP_
 #define OMG_DDS_PUB_DATA_WRITER_IMPL_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-
-
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 /***************************************************************************
  *

--- a/src/ddscxx/include/dds/pub/detail/Publisher.hpp
+++ b/src/ddscxx/include/dds/pub/detail/Publisher.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_PUB_DETAIL_PUBLISHER_HPP_
 #define OMG_DDS_PUB_DETAIL_PUBLISHER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/pub/detail/TPublisherImpl.hpp>
 #include <org/eclipse/cyclonedds/pub/PublisherDelegate.hpp>

--- a/src/ddscxx/include/dds/pub/detail/SuspendedPublication.hpp
+++ b/src/ddscxx/include/dds/pub/detail/SuspendedPublication.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef OMG_DDS_PUB_DETAIL_SUSPENDED_PUBLICATION_HPP_
 #define OMG_DDS_PUB_DETAIL_SUSPENDED_PUBLICATION_HPP_
 

--- a/src/ddscxx/include/dds/pub/detail/TAnyDataWriterImpl.hpp
+++ b/src/ddscxx/include/dds/pub/detail/TAnyDataWriterImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef OMG_DDS_PUB_DETAIL_TANYDATAWRITER_HPP_
 #define OMG_DDS_PUB_DETAIL_TANYDATAWRITER_HPP_
 

--- a/src/ddscxx/include/dds/pub/detail/TCoherentSetImpl.hpp
+++ b/src/ddscxx/include/dds/pub/detail/TCoherentSetImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_PUB_TCOHERENTSET_IMPL_HPP_
 #define CYCLONEDDS_DDS_PUB_TCOHERENTSET_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/pub/detail/TPublisherImpl.hpp
+++ b/src/ddscxx/include/dds/pub/detail/TPublisherImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_PUB_TPUBLISHER_IMPL_HPP_
 #define CYCLONEDDS_DDS_PUB_TPUBLISHER_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/pub/detail/TSuspendedPublicationImpl.hpp
+++ b/src/ddscxx/include/dds/pub/detail/TSuspendedPublicationImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_PUB_TSUSPENDEDPUBLICATION_IMPL_HPP_
 #define CYCLONEDDS_DDS_PUB_TSUSPENDEDPUBLICATION_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/pub/detail/ddspub.hpp
+++ b/src/ddscxx/include/dds/pub/detail/ddspub.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef OMG_DDS_PUB_PACKAGE_DETAIL_INCLUDE_HPP_
 #define OMG_DDS_PUB_PACKAGE_DETAIL_INCLUDE_HPP_
 

--- a/src/ddscxx/include/dds/pub/detail/discovery.hpp
+++ b/src/ddscxx/include/dds/pub/detail/discovery.hpp
@@ -1,15 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+//
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/dds/pub/detail/find.hpp
+++ b/src/ddscxx/include/dds/pub/detail/find.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/dds/pub/discovery.hpp
+++ b/src/ddscxx/include/dds/pub/discovery.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_PUB_DISCOVERY_HPP_
 #define OMG_DDS_PUB_DISCOVERY_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/domain/DomainParticipant.hpp>
 #include <dds/pub/DataWriter.hpp>

--- a/src/ddscxx/include/dds/pub/find.hpp
+++ b/src/ddscxx/include/dds/pub/find.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_PUB_FIND_HPP_
 #define OMG_DDS_PUB_FIND_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <string>
 

--- a/src/ddscxx/include/dds/pub/qos/DataWriterQos.hpp
+++ b/src/ddscxx/include/dds/pub/qos/DataWriterQos.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_QOS_DATA_WRITER_QOS_HPP_
 #define OMG_DDS_QOS_DATA_WRITER_QOS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/pub/qos/detail/DataWriterQos.hpp>
 

--- a/src/ddscxx/include/dds/pub/qos/PublisherQos.hpp
+++ b/src/ddscxx/include/dds/pub/qos/PublisherQos.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_QOS_PUBLISER_QOS_HPP_
 #define OMG_DDS_QOS_PUBLISER_QOS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/pub/qos/detail/PublisherQos.hpp>
 

--- a/src/ddscxx/include/dds/pub/qos/detail/DataWriterQos.hpp
+++ b/src/ddscxx/include/dds/pub/qos/detail/DataWriterQos.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_PUB_QOS_DETAIL_DATAWRITER_QOS_HPP_
 #define OMG_DDS_PUB_QOS_DETAIL_DATAWRITER_QOS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/detail/TEntityQosImpl.hpp>
 #include <org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.hpp>

--- a/src/ddscxx/include/dds/pub/qos/detail/DataWriterQos.hpp
+++ b/src/ddscxx/include/dds/pub/qos/detail/DataWriterQos.hpp
@@ -82,62 +82,58 @@ public:
      */
     DataWriterQos(const DataWriterQos& qos);
 
-    /**
-     * Create a DataWriter QoS from a TopicQos.
-     *
-     * This operation will copy the QosPolicy settings from the TopicQos to the
-     * corresponding QosPolicy settings in the DataWriterQos. The related value
-     * in DataWriterQos will be repliced, while the other policies will get the
-     * @ref anchor_dds_pub_datawriter_qos_defaults "default" QoS policies.
-     *
-     * This is a "convenience" operation. It can be used to merge
-     * @ref anchor_dds_pub_datawriter_qos_defaults "default" DataWriter
-     * QosPolicy settings with the corresponding ones on the Topic. The resulting
-     * DataWriterQos can then be used to create a new DataWriter, or set its
-     * DataWriterQos.
-     * @code{.cpp}
-     * dds::topic::qos::TopicQos topicQos = topic.qos();
-     * dds::pub::qos::DataWriterQos writerQos(topicQos);
-     * // Policies of the DataWriterQos that are not present in the TopicQos
-     * // have the default value.
-     * @endcode
-     *
-     * This operation does not check the resulting DataWriterQos for self
-     * consistency. This is because the "merged" DataWriterQos may not be the
-     * final one, as the application can still modify some QosPolicy settings prior to
-     * applying the DataWriterQos to the DataWriter.
-     *
-     * @param qos the QoS to copy policies from.
-     */
+    /// Create a DataWriter QoS from a TopicQos.
+    ///
+    /// This operation will copy the QosPolicy settings from the TopicQos to the
+    /// corresponding QosPolicy settings in the DataWriterQos. The related value
+    /// in DataWriterQos will be repliced, while the other policies will get the
+    /// @ref anchor_dds_pub_datawriter_qos_defaults "default" QoS policies.
+    ///
+    /// This is a "convenience" operation. It can be used to merge
+    /// @ref anchor_dds_pub_datawriter_qos_defaults "default" DataWriter
+    /// QosPolicy settings with the corresponding ones on the Topic. The resulting
+    /// DataWriterQos can then be used to create a new DataWriter, or set its
+    /// DataWriterQos.
+    /// @code{.cpp}
+    /// dds::topic::qos::TopicQos topicQos = topic.qos();
+    /// dds::pub::qos::DataWriterQos writerQos(topicQos);
+    /// // Policies of the DataWriterQos that are not present in the TopicQos
+    /// // have the default value.
+    /// @endcode
+    ///
+    /// This operation does not check the resulting DataWriterQos for self
+    /// consistency. This is because the "merged" DataWriterQos may not be the
+    /// final one, as the application can still modify some QosPolicy settings prior to
+    /// applying the DataWriterQos to the DataWriter.
+    ///
+    /// @param qos the QoS to copy policies from.
     DataWriterQos(const dds::topic::qos::TopicQos& qos);
 
-    /**
-     * Assign dds::topic::qos::TopicQos policies to the DataWriterQos.
-     *
-     * This operation will copy the QosPolicy settings from the TopicQos to the
-     * corresponding QosPolicy settings in the DataWriterQos (replacing the values,
-     * if present).
-     *
-     * This is a "convenience" operation, useful in combination with the operations
-     * Publisher::default_datawriter_qos() and dds::topic::Topic::qos().
-     * This operation can be used to merge the DataWriter
-     * QosPolicy settings with the corresponding ones on the Topic. The resulting
-     * DataWriterQos can then be used to create a new DataWriter, or set its
-     * DataWriterQos.
-     * @code{.cpp}
-     * dds::topic::qos::TopicQos topicQos = topic.qos();
-     * dds::pub::qos::DataWriterQos writerQos = publisher.default_datawriter_qos();
-     * writerQos = topicQos;
-     * // Policies of the DataWriterQos that are not present in the TopicQos are untouched.
-     * @endcode
-     *
-     * This operation does not check the resulting DataWriterQos for self
-     * consistency. This is because the "merged" DataWriterQos may not be the
-     * final one, as the application can still modify some QosPolicy settings prior to
-     * applying the DataWriterQos to the DataWriter.
-     *
-     * @param qos the QoS to copy policies from.
-     */
+    /// Assign dds::topic::qos::TopicQos policies to the DataWriterQos.
+    ///
+    /// This operation will copy the QosPolicy settings from the TopicQos to the
+    /// corresponding QosPolicy settings in the DataWriterQos (replacing the values,
+    /// if present).
+    ///
+    /// This is a "convenience" operation, useful in combination with the operations
+    /// Publisher::default_datawriter_qos() and dds::topic::Topic::qos().
+    /// This operation can be used to merge the DataWriter
+    /// QosPolicy settings with the corresponding ones on the Topic. The resulting
+    /// DataWriterQos can then be used to create a new DataWriter, or set its
+    /// DataWriterQos.
+    /// @code{.cpp}
+    /// dds::topic::qos::TopicQos topicQos = topic.qos();
+    /// dds::pub::qos::DataWriterQos writerQos = publisher.default_datawriter_qos();
+    /// writerQos = topicQos;
+    /// // Policies of the DataWriterQos that are not present in the TopicQos are untouched.
+    /// @endcode
+    ///
+    /// This operation does not check the resulting DataWriterQos for self
+    /// consistency. This is because the "merged" DataWriterQos may not be the
+    /// final one, as the application can still modify some QosPolicy settings prior to
+    /// applying the DataWriterQos to the DataWriter.
+    ///
+    /// @param qos the QoS to copy policies from.
     DataWriterQos& operator= (const dds::topic::qos::TopicQos& other);
 };
 

--- a/src/ddscxx/include/dds/pub/qos/detail/PublisherQos.hpp
+++ b/src/ddscxx/include/dds/pub/qos/detail/PublisherQos.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_PUB_QOS_DETAIL_PUBLISER_QOS_HPP_
 #define OMG_DDS_PUB_QOS_DETAIL_PUBLISER_QOS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/detail/TEntityQosImpl.hpp>
 #include <org/eclipse/cyclonedds/pub/qos/PublisherQosDelegate.hpp>

--- a/src/ddscxx/include/dds/sub/AnyDataReader.hpp
+++ b/src/ddscxx/include/dds/sub/AnyDataReader.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_ANY_DATA_READER_HPP_
 #define OMG_DDS_SUB_ANY_DATA_READER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/sub/detail/AnyDataReader.hpp>
 

--- a/src/ddscxx/include/dds/sub/AnyDataReaderListener.hpp
+++ b/src/ddscxx/include/dds/sub/AnyDataReaderListener.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_ANY_DATA_READER_LISTENER_HPP_
 #define OMG_DDS_SUB_ANY_DATA_READER_LISTENER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/refmacros.hpp>
 #include <dds/core/status/Status.hpp>

--- a/src/ddscxx/include/dds/sub/CoherentAccess.hpp
+++ b/src/ddscxx/include/dds/sub/CoherentAccess.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_COHERENT_ACCESS_HPP_
 #define OMG_DDS_SUB_COHERENT_ACCESS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/sub/detail/CoherentAccess.hpp>
 

--- a/src/ddscxx/include/dds/sub/DataReader.hpp
+++ b/src/ddscxx/include/dds/sub/DataReader.hpp
@@ -1,20 +1,19 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef OMG_DDS_SUB_DATA_READER_HPP_
 #define OMG_DDS_SUB_DATA_READER_HPP_
 

--- a/src/ddscxx/include/dds/sub/DataReaderListener.hpp
+++ b/src/ddscxx/include/dds/sub/DataReaderListener.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_DATA_READER_LISTENER_HPP_
 #define OMG_DDS_SUB_DATA_READER_LISTENER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/status/Status.hpp>
 

--- a/src/ddscxx/include/dds/sub/DataReaderListener.hpp
+++ b/src/ddscxx/include/dds/sub/DataReaderListener.hpp
@@ -32,97 +32,95 @@ class NoOpDataReaderListener;
 }
 }
 
-/**
- * @brief
- * DataReader events Listener
- *
- * Since a DataReader is an Entity, it has the ability to have a Listener
- * associated with it. In this case, the associated Listener should be of type
- * DataReaderListener. This interface must be implemented by the
- * application. A user-defined class must be provided by the application which must
- * extend from the DataReaderListener class.
- *
- * <b><i>
- * All operations for this interface must be implemented in the user-defined class, it is
- * up to the application whether an operation is empty or contains some functionality.
- * </i></b>
- *
- * The DataReaderListener provides a generic mechanism (actually a
- * callback function) for the Data Distribution Service to notify the application of
- * relevant asynchronous status change events, such as a missed deadline, violation of
- * a QosPolicy setting, etc. The DataReaderListener is related to
- * changes in communication status StatusConditions.
- *
- * @code{.cpp}
- * // Application example listener
- * class ExampleListener :
- *                public virtual dds::sub::DataReaderListener<Foo::Bar>
- * {
- * public:
- *     virtual void on_requested_deadline_missed (
- *         dds::sub::DataReader<Foo::Bar>& reader,
- *         const dds::core::status::RequestedDeadlineMissedStatus & status)
- *     {
- *         std::cout << "on_requested_deadline_missed" << std::endl;
- *     }
- *
- *     virtual void on_requested_incompatible_qos (
- *         dds::sub::DataReader<Foo::Bar>& reader,
- *         const dds::core::status::RequestedIncompatibleQosStatus & status)
- *     {
- *         std::cout << "on_requested_incompatible_qos" << std::endl;
- *     }
- *
- *     virtual void on_sample_rejected (
- *         dds::sub::DataReader<Foo::Bar>& reader,
- *         const dds::core::status::SampleRejectedStatus & status)
- *     {
- *         std::cout << "on_sample_rejected" << std::endl;
- *     }
- *
- *     virtual void on_liveliness_changed (
- *         dds::sub::DataReader<Foo::Bar>& reader,
- *         const dds::core::status::LivelinessChangedStatus & status)
- *     {
- *         std::cout << "on_liveliness_changed" << std::endl;
- *     }
- *
- *     virtual void on_data_available (
- *         dds::sub::DataReader<Foo::Bar>& reader)
- *     {
- *         std::cout << "on_data_available" << std::endl;
- *     }
- *
- *     virtual void on_subscription_matched (
- *         dds::sub::DataReader<Foo::Bar>& reader,
- *         const dds::core::status::SubscriptionMatchedStatus & status)
- *     {
- *         std::cout << "on_subscription_matched" << std::endl;
- *     }
- *
- *     virtual void on_sample_lost (
- *         dds::sub::DataReader<Foo::Bar>& reader,
- *         const dds::core::status::SampleLostStatus & status)
- *     {
- *         std::cout << "on_sample_lost" << std::endl;
- *     }
- * };
- *
- * // Create DataReader with the listener
- * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
- * dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
- * dds::sub::Subscriber subscriber(participant);
- * dds::sub::DataReader<Foo::Bar> reader(subscriber,
- *                                       topic,
- *                                       subscriber.default_datareader_qos(),
- *                                       new ExampleListener(),
- *                                       dds::core::status::StatusMask::all());
- *
- * @endcode
- *
- * @see for more information: @ref DCPS_Modules_Subscription_DataReader "Data Reader"
- * @see for more information: @ref DCPS_Modules_Infrastructure_Listener "Listener information"
- */
+/// @brief
+/// DataReader events Listener
+///
+/// Since a DataReader is an Entity, it has the ability to have a Listener
+/// associated with it. In this case, the associated Listener should be of type
+/// DataReaderListener. This interface must be implemented by the
+/// application. A user-defined class must be provided by the application which must
+/// extend from the DataReaderListener class.
+///
+/// <b><i>
+/// All operations for this interface must be implemented in the user-defined class, it is
+/// up to the application whether an operation is empty or contains some functionality.
+/// </i></b>
+///
+/// The DataReaderListener provides a generic mechanism (actually a
+/// callback function) for the Data Distribution Service to notify the application of
+/// relevant asynchronous status change events, such as a missed deadline, violation of
+/// a QosPolicy setting, etc. The DataReaderListener is related to
+/// changes in communication status StatusConditions.
+///
+/// @code{.cpp}
+/// // Application example listener
+/// class ExampleListener :
+///                public virtual dds::sub::DataReaderListener<Foo::Bar>
+/// {
+/// public:
+///     virtual void on_requested_deadline_missed (
+///         dds::sub::DataReader<Foo::Bar>& reader,
+///         const dds::core::status::RequestedDeadlineMissedStatus & status)
+///     {
+///         std::cout << "on_requested_deadline_missed" << std::endl;
+///     }
+///
+///     virtual void on_requested_incompatible_qos (
+///         dds::sub::DataReader<Foo::Bar>& reader,
+///         const dds::core::status::RequestedIncompatibleQosStatus & status)
+///     {
+///         std::cout << "on_requested_incompatible_qos" << std::endl;
+///     }
+///
+///     virtual void on_sample_rejected (
+///         dds::sub::DataReader<Foo::Bar>& reader,
+///         const dds::core::status::SampleRejectedStatus & status)
+///     {
+///         std::cout << "on_sample_rejected" << std::endl;
+///     }
+///
+///     virtual void on_liveliness_changed (
+///         dds::sub::DataReader<Foo::Bar>& reader,
+///         const dds::core::status::LivelinessChangedStatus & status)
+///     {
+///         std::cout << "on_liveliness_changed" << std::endl;
+///     }
+///
+///     virtual void on_data_available (
+///         dds::sub::DataReader<Foo::Bar>& reader)
+///     {
+///         std::cout << "on_data_available" << std::endl;
+///     }
+///
+///     virtual void on_subscription_matched (
+///         dds::sub::DataReader<Foo::Bar>& reader,
+///         const dds::core::status::SubscriptionMatchedStatus & status)
+///     {
+///         std::cout << "on_subscription_matched" << std::endl;
+///     }
+///
+///     virtual void on_sample_lost (
+///         dds::sub::DataReader<Foo::Bar>& reader,
+///         const dds::core::status::SampleLostStatus & status)
+///     {
+///         std::cout << "on_sample_lost" << std::endl;
+///     }
+/// };
+///
+/// // Create DataReader with the listener
+/// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+/// dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
+/// dds::sub::Subscriber subscriber(participant);
+/// dds::sub::DataReader<Foo::Bar> reader(subscriber,
+///                                       topic,
+///                                       subscriber.default_datareader_qos(),
+///                                       new ExampleListener(),
+///                                       dds::core::status::StatusMask::all());
+///
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Modules_Subscription_DataReader "Data Reader"
+/// @see for more information: @ref DCPS_Modules_Infrastructure_Listener "Listener information"
 template <typename T>
 class dds::sub::DataReaderListener
 {
@@ -307,22 +305,20 @@ public:
 };
 
 
-/**
- * @brief
- * DataReader events Listener
- *
- * This listener is just like DataReaderListener, except
- * that the application doesn't have to implement all operations.
- *
- * @code{.cpp}
- * class ExampleListener : public virtual dds::sub::NoOpDataReaderListener<Foo::Bar>
- * {
- *    // Not necessary to implement any Listener operations.
- * };
- * @endcode
- *
- * @see dds::sub::DataReaderListener
- */
+/// @brief
+/// DataReader events Listener
+///
+/// This listener is just like DataReaderListener, except
+/// that the application doesn't have to implement all operations.
+///
+/// @code{.cpp}
+/// class ExampleListener : public virtual dds::sub::NoOpDataReaderListener<Foo::Bar>
+/// {
+///    // Not necessary to implement any Listener operations.
+/// };
+/// @endcode
+///
+/// @see dds::sub::DataReaderListener
 template <typename T>
 class dds::sub::NoOpDataReaderListener : public virtual DataReaderListener<T>
 {

--- a/src/ddscxx/include/dds/sub/GenerationCount.hpp
+++ b/src/ddscxx/include/dds/sub/GenerationCount.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef OMG_DDS_SUB_GENERATION_COUNT_HPP_
 #define OMG_DDS_SUB_GENERATION_COUNT_HPP_
 

--- a/src/ddscxx/include/dds/sub/LoanedSamples.hpp
+++ b/src/ddscxx/include/dds/sub/LoanedSamples.hpp
@@ -41,48 +41,46 @@ template <typename T> typename T::const_iterator cend(const T& t);
 }
 /** @endcond */
 
-/**
- * @brief
- * This class encapsulates and automates the management of loaned samples.
- *
- * It is a container which is used to hold samples which have been read
- * or taken by the DataReader. Samples are effectively "loaned" from the
- * DataReader to avoid the need to copy the data. When the LoanedSamples
- * container goes out of scope the loan is automatically returned.
- *
- * LoanedSamples maintains a ref count so that the loan will only be
- * returned once all copies of the same LoanedSamples have been destroyed.
- *
- * @anchor anchor_dds_sub_loanedsamples_example
- * @code{.cpp}
- * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
- * dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
- * dds::sub::Subscriber subscriber(participant);
- * dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
- *
- * // Assume there is data to read
- * {
- *     dds::sub::LoanedSamples<Foo::Bar> samples = reader.read();
- *     dds::sub::LoanedSamples<Foo::Bar>::const_iterator it;
- *     for (it = samples.begin(); it != samples.end(); ++it) {
- *         const dds::sub::Sample<Foo::Bar>& sample = *it;
- *         const Foo::Bar& data = sample.data();
- *         const dds::sub::SampleInfo& info = sample.info();
- *         // Use sample data and meta information.
- *     }
- *
- *     function(samples);
- * }
- * // LoanedSamples out of scope. Whether the loan is returned, depends what the reference
- * // count of the LoanedSamples is. That again, depends on what the function() did with it.
- * // Maybe function() stored the LoanedSamples, maybe not. Whatever the case, LoanedSamples
- * // takes care of the loan and resource handling.
- * @endcode
- *
- * @see for more information: @ref DCPS_Modules_Subscription_DataSample "DataSample"
- * @see for more information: @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo"
- * @see for more information: @ref DCPS_Modules_Subscription "Subscription"
- */
+/// @brief
+/// This class encapsulates and automates the management of loaned samples.
+///
+/// It is a container which is used to hold samples which have been read
+/// or taken by the DataReader. Samples are effectively "loaned" from the
+/// DataReader to avoid the need to copy the data. When the LoanedSamples
+/// container goes out of scope the loan is automatically returned.
+///
+/// LoanedSamples maintains a ref count so that the loan will only be
+/// returned once all copies of the same LoanedSamples have been destroyed.
+///
+/// @anchor anchor_dds_sub_loanedsamples_example
+/// @code{.cpp}
+/// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+/// dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
+/// dds::sub::Subscriber subscriber(participant);
+/// dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
+///
+/// // Assume there is data to read
+/// {
+///     dds::sub::LoanedSamples<Foo::Bar> samples = reader.read();
+///     dds::sub::LoanedSamples<Foo::Bar>::const_iterator it;
+///     for (it = samples.begin(); it != samples.end(); ++it) {
+///         const dds::sub::Sample<Foo::Bar>& sample = *it;
+///         const Foo::Bar& data = sample.data();
+///         const dds::sub::SampleInfo& info = sample.info();
+///         // Use sample data and meta information.
+///     }
+///
+///     function(samples);
+/// }
+/// // LoanedSamples out of scope. Whether the loan is returned, depends what the reference
+/// // count of the LoanedSamples is. That again, depends on what the function() did with it.
+/// // Maybe function() stored the LoanedSamples, maybe not. Whatever the case, LoanedSamples
+/// // takes care of the loan and resource handling.
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Modules_Subscription_DataSample "DataSample"
+/// @see for more information: @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo"
+/// @see for more information: @ref DCPS_Modules_Subscription "Subscription"
 template <typename T, template <typename Q> class DELEGATE>
 class dds::sub::LoanedSamples
 {

--- a/src/ddscxx/include/dds/sub/LoanedSamples.hpp
+++ b/src/ddscxx/include/dds/sub/LoanedSamples.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef OMG_DDS_SUB_TLOANED_SAMPLES_HPP_
 #define OMG_DDS_SUB_TLOANED_SAMPLES_HPP_
 

--- a/src/ddscxx/include/dds/sub/Query.hpp
+++ b/src/ddscxx/include/dds/sub/Query.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_QUERY_HPP_
 #define OMG_DDS_SUB_QUERY_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/sub/detail/Query.hpp>
 

--- a/src/ddscxx/include/dds/sub/Rank.hpp
+++ b/src/ddscxx/include/dds/sub/Rank.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef OMG_DDS_SUB_RANK_HPP_
 #define OMG_DDS_SUB_RANK_HPP_
 

--- a/src/ddscxx/include/dds/sub/Sample.hpp
+++ b/src/ddscxx/include/dds/sub/Sample.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_SAMPLE_HPP_
 #define OMG_DDS_SUB_SAMPLE_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/sub/detail/Sample.hpp>
 

--- a/src/ddscxx/include/dds/sub/SampleInfo.hpp
+++ b/src/ddscxx/include/dds/sub/SampleInfo.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef OMG_DDS_SUB_SAMPLE_INFO_HPP_
 #define OMG_DDS_SUB_SAMPLE_INFO_HPP_
 

--- a/src/ddscxx/include/dds/sub/SampleRef.hpp
+++ b/src/ddscxx/include/dds/sub/SampleRef.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_SAMPLEREF_HPP_
 #define OMG_DDS_SUB_SAMPLEREF_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/sub/detail/SampleRef.hpp>
 

--- a/src/ddscxx/include/dds/sub/SharedSamples.hpp
+++ b/src/ddscxx/include/dds/sub/SharedSamples.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef OMG_DDS_SUB_SHARED_SAMPLES_HPP_
 #define OMG_DDS_SUB_SHARED_SAMPLES_HPP_
 

--- a/src/ddscxx/include/dds/sub/Subscriber.hpp
+++ b/src/ddscxx/include/dds/sub/Subscriber.hpp
@@ -1,24 +1,22 @@
 #ifndef OMG_DDS_SUB_SUBSCRIBER_HPP_
 #define OMG_DDS_SUB_SUBSCRIBER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/sub/detail/Subscriber.hpp>
 

--- a/src/ddscxx/include/dds/sub/SubscriberListener.hpp
+++ b/src/ddscxx/include/dds/sub/SubscriberListener.hpp
@@ -28,100 +28,98 @@ namespace sub
 
 DDSCXX_WARNING_MSVC_OFF(4250)
 
-/**
- * @brief
- * Subscriber events Listener
- *
- * Since a Subscriber is an Entity, it has the ability to have a Listener
- * associated with it. In this case, the associated Listener should be of type
- * SubscriberListener. This interface must be implemented by the
- * application. A user-defined class must be provided by the application which must
- * extend from the SubscriberListener class.
- *
- * <b><i>
- * All operations for this interface must be implemented in the user-defined class, it is
- * up to the application whether an operation is empty or contains some functionality.
- * </i></b>
- *
- * The SubscriberListener provides a generic mechanism (actually a
- * callback function) for the Data Distribution Service to notify the application of
- * relevant asynchronous status change events, such as a missed deadline, violation of
- * a QosPolicy setting, etc. The SubscriberListener is related to
- * changes in communication status StatusConditions.
- *
- * @code{.cpp}
- * // Application example listener
- * class ExampleListener :
- *                public virtual dds::sub::SubscriberListener
- * {
- * public:
- *     virtual void on_requested_deadline_missed (
- *         dds::sub::AnyDataReader& reader,
- *         const dds::core::status::RequestedDeadlineMissedStatus & status)
- *     {
- *         std::cout << "on_requested_deadline_missed" << std::endl;
- *     }
- *
- *     virtual void on_requested_incompatible_qos (
- *         dds::sub::AnyDataReader& reader,
- *         const dds::core::status::RequestedIncompatibleQosStatus & status)
- *     {
- *         std::cout << "on_requested_incompatible_qos" << std::endl;
- *     }
- *
- *     virtual void on_sample_rejected (
- *         dds::sub::AnyDataReader& reader,
- *         const dds::core::status::SampleRejectedStatus & status)
- *     {
- *         std::cout << "on_sample_rejected" << std::endl;
- *     }
- *
- *     virtual void on_liveliness_changed (
- *         dds::sub::AnyDataReader& reader,
- *         const dds::core::status::LivelinessChangedStatus & status)
- *     {
- *         std::cout << "on_liveliness_changed" << std::endl;
- *     }
- *
- *     virtual void on_data_available (
- *         dds::sub::AnyDataReader& reader)
- *     {
- *         std::cout << "on_data_available" << std::endl;
- *     }
- *
- *     virtual void on_subscription_matched (
- *         dds::sub::AnyDataReader& reader,
- *         const dds::core::status::SubscriptionMatchedStatus & status)
- *     {
- *         std::cout << "on_subscription_matched" << std::endl;
- *     }
- *
- *     virtual void on_sample_lost (
- *         dds::sub::AnyDataReader& reader,
- *         const dds::core::status::SampleLostStatus & status)
- *     {
- *         std::cout << "on_sample_lost" << std::endl;
- *     }
- *
- *     virtual void on_data_on_readers (
- *         dds::sub::Subscriber& subs)
- *     {
- *         std::cout << "on_data_on_readers" << std::endl;
- *     }
- * };
- *
- * // Create Subscriber with the listener
- * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
- * dds::sub::Subscriber subscriber(participant,
- *                                 participant.default_subscriber_qos(),
- *                                 new ExampleListener(),
- *                                 dds::core::status::StatusMask::all());
- *
- * @endcode
- *
- * @see for more information: @ref DCPS_Modules_Subscriber "Subscriber"
- * @see for more information: @ref DCPS_Modules_Infrastructure_Listener "Listener information"
- */
+/// @brief
+/// Subscriber events Listener
+///
+/// Since a Subscriber is an Entity, it has the ability to have a Listener
+/// associated with it. In this case, the associated Listener should be of type
+/// SubscriberListener. This interface must be implemented by the
+/// application. A user-defined class must be provided by the application which must
+/// extend from the SubscriberListener class.
+///
+/// <b><i>
+/// All operations for this interface must be implemented in the user-defined class, it is
+/// up to the application whether an operation is empty or contains some functionality.
+/// </i></b>
+///
+/// The SubscriberListener provides a generic mechanism (actually a
+/// callback function) for the Data Distribution Service to notify the application of
+/// relevant asynchronous status change events, such as a missed deadline, violation of
+/// a QosPolicy setting, etc. The SubscriberListener is related to
+/// changes in communication status StatusConditions.
+///
+/// @code{.cpp}
+/// // Application example listener
+/// class ExampleListener :
+///                public virtual dds::sub::SubscriberListener
+/// {
+/// public:
+///     virtual void on_requested_deadline_missed (
+///         dds::sub::AnyDataReader& reader,
+///         const dds::core::status::RequestedDeadlineMissedStatus & status)
+///     {
+///         std::cout << "on_requested_deadline_missed" << std::endl;
+///     }
+///
+///     virtual void on_requested_incompatible_qos (
+///         dds::sub::AnyDataReader& reader,
+///         const dds::core::status::RequestedIncompatibleQosStatus & status)
+///     {
+///         std::cout << "on_requested_incompatible_qos" << std::endl;
+///     }
+///
+///     virtual void on_sample_rejected (
+///         dds::sub::AnyDataReader& reader,
+///         const dds::core::status::SampleRejectedStatus & status)
+///     {
+///         std::cout << "on_sample_rejected" << std::endl;
+///     }
+///
+///     virtual void on_liveliness_changed (
+///         dds::sub::AnyDataReader& reader,
+///         const dds::core::status::LivelinessChangedStatus & status)
+///     {
+///         std::cout << "on_liveliness_changed" << std::endl;
+///     }
+///
+///     virtual void on_data_available (
+///         dds::sub::AnyDataReader& reader)
+///     {
+///         std::cout << "on_data_available" << std::endl;
+///     }
+///
+///     virtual void on_subscription_matched (
+///         dds::sub::AnyDataReader& reader,
+///         const dds::core::status::SubscriptionMatchedStatus & status)
+///     {
+///         std::cout << "on_subscription_matched" << std::endl;
+///     }
+///
+///     virtual void on_sample_lost (
+///         dds::sub::AnyDataReader& reader,
+///         const dds::core::status::SampleLostStatus & status)
+///     {
+///         std::cout << "on_sample_lost" << std::endl;
+///     }
+///
+///     virtual void on_data_on_readers (
+///         dds::sub::Subscriber& subs)
+///     {
+///         std::cout << "on_data_on_readers" << std::endl;
+///     }
+/// };
+///
+/// // Create Subscriber with the listener
+/// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+/// dds::sub::Subscriber subscriber(participant,
+///                                 participant.default_subscriber_qos(),
+///                                 new ExampleListener(),
+///                                 dds::core::status::StatusMask::all());
+///
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Modules_Subscriber "Subscriber"
+/// @see for more information: @ref DCPS_Modules_Infrastructure_Listener "Listener information"
 class OMG_DDS_API SubscriberListener : public virtual AnyDataReaderListener
 {
 public:
@@ -166,22 +164,20 @@ public:
 };
 
 
-/**
- * @brief
- * Subscriber events Listener
- *
- * This listener is just like SubscriberListener, except
- * that the application doesn't have to implement all operations.
- *
- * @code{.cpp}
- * class ExampleListener : public virtual dds::sub::NoOpSubscriberListener
- * {
- *    // Not necessary to implement any Listener operations.
- * };
- * @endcode
- *
- * @see dds::sub::SubscriberListener
- */
+/// @brief
+/// Subscriber events Listener
+///
+/// This listener is just like SubscriberListener, except
+/// that the application doesn't have to implement all operations.
+///
+/// @code{.cpp}
+/// class ExampleListener : public virtual dds::sub::NoOpSubscriberListener
+/// {
+///    // Not necessary to implement any Listener operations.
+/// };
+/// @endcode
+///
+/// @see dds::sub::SubscriberListener
 class OMG_DDS_API NoOpSubscriberListener :
     public virtual SubscriberListener,
     public virtual NoOpAnyDataReaderListener

--- a/src/ddscxx/include/dds/sub/SubscriberListener.hpp
+++ b/src/ddscxx/include/dds/sub/SubscriberListener.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_SUBSCRIBER_LISTENER_HPP_
 #define OMG_DDS_SUB_SUBSCRIBER_LISTENER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/sub/AnyDataReaderListener.hpp>
 #include <dds/sub/Subscriber.hpp>

--- a/src/ddscxx/include/dds/sub/TAnyDataReader.hpp
+++ b/src/ddscxx/include/dds/sub/TAnyDataReader.hpp
@@ -1,22 +1,21 @@
 #ifndef OMG_TDDS_SUB_ANY_DATA_READER_HPP_
 #define OMG_TDDS_SUB_ANY_DATA_READER_HPP_
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/TEntity.hpp>
 #include <dds/sub/Subscriber.hpp>

--- a/src/ddscxx/include/dds/sub/TCoherentAccess.hpp
+++ b/src/ddscxx/include/dds/sub/TCoherentAccess.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_TCOHERENT_ACCESS_HPP_
 #define OMG_DDS_SUB_TCOHERENT_ACCESS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/Value.hpp>
 

--- a/src/ddscxx/include/dds/sub/TCoherentAccess.hpp
+++ b/src/ddscxx/include/dds/sub/TCoherentAccess.hpp
@@ -30,65 +30,63 @@ class TCoherentAccess;
 }
 }
 
-/**
- * @brief
- * Class for RAII way of beginning/ending coherent access.
- *
- * Coherent access indicates that the application is about to access
- * the data samples in any of the DataReader objects attached to the
- * Subscriber.
- *
- * The application is required to use this operation
- * only if Presentation QosPolicy of the Subscriber to which the
- * DataReader belongs has the access_scope set to "GROUP". In the
- * aforementioned case, the operation must be called
- * prior to calling any of the sample-accessing operations, i.e.
- * read and take on DataReader. Otherwise the sample-accessing
- * operations will throw a PreconditionNotMetError exception.
- *
- * Once the application has finished accessing the data samples
- * it must end the coherent access. It is not required for the
- * application to begin or end access if the Presentation QosPolicy
- * has the access_scope set to something other than GROUP. Beginning
- * or ending access in this case is not considered an error and has
- * no effect. Beginning and ending access may be nested. In that
- * case, the application end access as many times as it began
- * access.
- *
- * @code{.cpp}
- * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
- * dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
- *
- * dds::sub::qos::SubscriberQos sQos sQos = participant.default_subscriber_qos()
- *                                          << dds::core::policy::Presentation::TopicAccessScope(false, true);
- * dds::sub::Subscriber subscriber(participant, sQos);
- *
- * {
- *     std::vector< dds::sub::DataReader<Foo::Bar> > readers;
- *     // Start coherent access.
- *     dds::sub::TCoherentAccess coherentAccess(subscriber);
- *     // Find (previously created with the subscriber) datareaders that now got data.
- *     dds::sub::find< dds::sub::DataReader<Foo::Bar> >(subscriber,
- *                                                      dds::sub::status::DataState::any(),
- *                                                      back_inserter(readers));
- *     // Get data from the readers
- *     for (size_type i = 0; i < rv.size(); i++) {
- *         dds::sub::LoanedSamples<Foo::Bar> samples = readers[i].read()
- *         dds::sub::LoanedSamples<Type1>::const_iterator it;
- *         for (it = samples.begin(); it != samples.end(); iterator++) {
- *             const dds::sub::Sample<Foo::Bar>& sample = *it;
- *             const Foo::Bar& data = sample.data();
- *             const dds::sub::SampleInfo& info = sample.info();
- *             // Use sample data and meta information.
- *         }
- *     }
- * }
- * // CoherentAccess went out of scope: it is ended implicitly
- * @endcode
- *
- * @see for more information: @ref DCPS_Modules_Subscription "Subscription"
- * @see dds::sub::Subscriber
- */
+/// @brief
+/// Class for RAII way of beginning/ending coherent access.
+///
+/// Coherent access indicates that the application is about to access
+/// the data samples in any of the DataReader objects attached to the
+/// Subscriber.
+///
+/// The application is required to use this operation
+/// only if Presentation QosPolicy of the Subscriber to which the
+/// DataReader belongs has the access_scope set to "GROUP". In the
+/// aforementioned case, the operation must be called
+/// prior to calling any of the sample-accessing operations, i.e.
+/// read and take on DataReader. Otherwise the sample-accessing
+/// operations will throw a PreconditionNotMetError exception.
+///
+/// Once the application has finished accessing the data samples
+/// it must end the coherent access. It is not required for the
+/// application to begin or end access if the Presentation QosPolicy
+/// has the access_scope set to something other than GROUP. Beginning
+/// or ending access in this case is not considered an error and has
+/// no effect. Beginning and ending access may be nested. In that
+/// case, the application end access as many times as it began
+/// access.
+///
+/// @code{.cpp}
+/// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+/// dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
+///
+/// dds::sub::qos::SubscriberQos sQos sQos = participant.default_subscriber_qos()
+///                                          << dds::core::policy::Presentation::TopicAccessScope(false, true);
+/// dds::sub::Subscriber subscriber(participant, sQos);
+///
+/// {
+///     std::vector< dds::sub::DataReader<Foo::Bar> > readers;
+///     // Start coherent access.
+///     dds::sub::TCoherentAccess coherentAccess(subscriber);
+///     // Find (previously created with the subscriber) datareaders that now got data.
+///     dds::sub::find< dds::sub::DataReader<Foo::Bar> >(subscriber,
+///                                                      dds::sub::status::DataState::any(),
+///                                                      back_inserter(readers));
+///     // Get data from the readers
+///     for (size_type i = 0; i < rv.size(); i++) {
+///         dds::sub::LoanedSamples<Foo::Bar> samples = readers[i].read()
+///         dds::sub::LoanedSamples<Type1>::const_iterator it;
+///         for (it = samples.begin(); it != samples.end(); iterator++) {
+///             const dds::sub::Sample<Foo::Bar>& sample = *it;
+///             const Foo::Bar& data = sample.data();
+///             const dds::sub::SampleInfo& info = sample.info();
+///             // Use sample data and meta information.
+///         }
+///     }
+/// }
+/// // CoherentAccess went out of scope: it is ended implicitly
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Modules_Subscription "Subscription"
+/// @see dds::sub::Subscriber
 template <typename DELEGATE>
 class dds::sub::TCoherentAccess : public dds::core::Value<DELEGATE>
 {

--- a/src/ddscxx/include/dds/sub/TDataReader.hpp
+++ b/src/ddscxx/include/dds/sub/TDataReader.hpp
@@ -1,23 +1,23 @@
 #ifndef OMG_DDS_SUB_TDATA_READER_HPP_
 #define OMG_DDS_SUB_TDATA_READER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <dds/core/detail/conformance.hpp>
 #include <dds/sub/AnyDataReader.hpp>
 #include <dds/topic/ContentFilteredTopic.hpp>

--- a/src/ddscxx/include/dds/sub/TDataReader.hpp
+++ b/src/ddscxx/include/dds/sub/TDataReader.hpp
@@ -38,69 +38,67 @@ class DataReaderListener;
 }
 }
 
-/**
- * @brief
- * DataReader allows the applicatin to access published sample data.
- *
- * A DataReader allows the application:
- * - to declare the data it wishes to receive (i.e., make a subscription)
- * - to access the data received by the attached Subscriber
- *
- * A DataReader refers to exactly one TopicDescription (either a Topic, a
- * ContentFilteredTopic or a MultiTopic) that identifies the samples to be
- * read. The Topic must exist prior to the DataReader creation.
- *
- * A DataReader is attached to exactly one Subscriber which acts as a factory
- * for it.
- *
- * The DataReader may give access to several instances of the data type, which
- * are distinguished from each other by their key.
- *
- * The pre-processor generates from IDL type descriptions the application
- * DataReader<type> classes. For each application data type that is used as Topic
- * data type, a typed class DataReader<type> is derived from the AnyDataReader
- * class.
- *
- * For instance, for an application, the definitions are located in the Foo.idl file.
- * The pre-processor will generate a ccpp_Foo.h include file.
- *
- * <b>General note:</b> The name ccpp_Foo.h is derived from the IDL file Foo.idl,
- * that defines Foo::Bar, for all relevant DataReader<Foo::Bar> operations.
- *
- * @note Apart from idl files, Google protocol buffers are also supported. For the
- *       API itself, it doesn't matter if the type header files were generated from
- *       idl or protocol buffers. The resulting API usage and includes remain the same.
- *
- * @anchor anchor_dds_sub_datareader_example
- * <b>Example</b>
- * @code{.cpp}
- * // Default creation of a DataReader
- * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
- * dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
- * dds::sub::Subscriber subscriber(participant);
- * dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
- *
- * {
- *     // Default read of a sample on the DataReader
- *     dds::sub::LoanedSamples<Foo::Bar> samples;
- *     samples = reader.read();
- *
- *     // Default way of accessing the loaned samples
- *     dds::sub::LoanedSamples<Foo::Bar>::const_iterator it;
- *     for (it = samples.begin(); it != samples.end(); ++it) {
- *         const dds::sub::Sample<Foo::Bar>& sample = *it;
- *         const Foo::Bar& data = sample.data();
- *         const dds::sub::SampleInfo& info = sample.info();
- *         // Use sample data and meta information.
- *     }
- * }
- * // Like the name says, the read samples are loans from the DataReader. The loan
- * // was automatically returned when the LoanedSamples went out of scope.
- * @endcode
- *
- * @see for more information: @ref DCPS_Modules_Subscription "Subscription concept"
- * @see for more information: @ref DCPS_Modules_Subscription_DataReader "DataReader concept"
- */
+/// @brief
+/// DataReader allows the applicatin to access published sample data.
+///
+/// A DataReader allows the application:
+/// - to declare the data it wishes to receive (i.e., make a subscription)
+/// - to access the data received by the attached Subscriber
+///
+/// A DataReader refers to exactly one TopicDescription (either a Topic, a
+/// ContentFilteredTopic or a MultiTopic) that identifies the samples to be
+/// read. The Topic must exist prior to the DataReader creation.
+///
+/// A DataReader is attached to exactly one Subscriber which acts as a factory
+/// for it.
+///
+/// The DataReader may give access to several instances of the data type, which
+/// are distinguished from each other by their key.
+///
+/// The pre-processor generates from IDL type descriptions the application
+/// DataReader<type> classes. For each application data type that is used as Topic
+/// data type, a typed class DataReader<type> is derived from the AnyDataReader
+/// class.
+///
+/// For instance, for an application, the definitions are located in the Foo.idl file.
+/// The pre-processor will generate a ccpp_Foo.h include file.
+///
+/// <b>General note:</b> The name ccpp_Foo.h is derived from the IDL file Foo.idl,
+/// that defines Foo::Bar, for all relevant DataReader<Foo::Bar> operations.
+///
+/// @note Apart from idl files, Google protocol buffers are also supported. For the
+///       API itself, it doesn't matter if the type header files were generated from
+///       idl or protocol buffers. The resulting API usage and includes remain the same.
+///
+/// @anchor anchor_dds_sub_datareader_example
+/// <b>Example</b>
+/// @code{.cpp}
+/// // Default creation of a DataReader
+/// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+/// dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
+/// dds::sub::Subscriber subscriber(participant);
+/// dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
+///
+/// {
+///     // Default read of a sample on the DataReader
+///     dds::sub::LoanedSamples<Foo::Bar> samples;
+///     samples = reader.read();
+///
+///     // Default way of accessing the loaned samples
+///     dds::sub::LoanedSamples<Foo::Bar>::const_iterator it;
+///     for (it = samples.begin(); it != samples.end(); ++it) {
+///         const dds::sub::Sample<Foo::Bar>& sample = *it;
+///         const Foo::Bar& data = sample.data();
+///         const dds::sub::SampleInfo& info = sample.info();
+///         // Use sample data and meta information.
+///     }
+/// }
+/// // Like the name says, the read samples are loans from the DataReader. The loan
+/// // was automatically returned when the LoanedSamples went out of scope.
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Modules_Subscription "Subscription concept"
+/// @see for more information: @ref DCPS_Modules_Subscription_DataReader "DataReader concept"
 template <typename T, template <typename Q> class DELEGATE>
 class dds::sub::DataReader final : public dds::sub::TAnyDataReader< DELEGATE<T> >
 {
@@ -113,53 +111,51 @@ public:
 
 public:
 
-    /**
-     * The Selector class is used by the DataReader to compose read operations.
-     *
-     * A Selector can perform complex data selections, such as per-instance selection,
-     * content and status filtering, etc, when reading or taking samples. These settings
-     * on a Selector can be concatenated.
-     *
-     * The DataReader has the select() operation, which can be used to aqcuire the Selector
-     * functionality on the reader implicitly.
-     * @code{.cpp}
-     * // Take a maximum of 3 new samples of a certain instance.
-     * samples = reader.select()
-     *                     .max_samples(3)
-     *                     .state(dds::sub::status::DataState::new_data())
-     *                     .instance(someValidInstanceHandle)
-     *                     .take();
-     * @endcode
-     * However, this will create and destroy a Selector for every read, which is not
-     * very performance friendly.
-     *
-     * The performance can be increase by creating a Selector up front and doing the
-     * reading on that Selector directly and re-using it.
-     * @code{.cpp}
-     * // Create a Selector as selective reader up front.
-     * dds::sub::DataReader<Foo::Bar>::Selector selectiveReader(reader);
-     * // Configure it to take a maximum of 3 new samples of a certain instance
-     * selectiveReader.max_samples(3);
-     * selectiveReader.state(dds::sub::status::DataState::new_data());
-     * selectiveReader.instance(someValidInstanceHandle);
-     *
-     * // Use the configured Selector to -take- a maximum of 3 new samples of a
-     * // certain instance (which it was configured to do).
-     * // This can be used in loops for example, reducing the need for creating
-     * // implicit Selectors for every take.
-     * samples = selectiveReader.take();
-     * @endcode
-     *
-     * <i>Defaults</i>
-     * Element         | Default Value
-     * --------------- | --------------------
-     * state           | dds::sub::status::DataState::any
-     * content         | Empty dds::sub::Query
-     * max_samples     | dds::core::LENGTH_UNLIMITED
-     * instance        | dds::core::InstanceHandle nil
-     *
-     * @see for more information: @link dds::sub::DataReader::select() DataReader select() @endlink
-     */
+    /// The Selector class is used by the DataReader to compose read operations.
+    ///
+    /// A Selector can perform complex data selections, such as per-instance selection,
+    /// content and status filtering, etc, when reading or taking samples. These settings
+    /// on a Selector can be concatenated.
+    ///
+    /// The DataReader has the select() operation, which can be used to aqcuire the Selector
+    /// functionality on the reader implicitly.
+    /// @code{.cpp}
+    /// // Take a maximum of 3 new samples of a certain instance.
+    /// samples = reader.select()
+    ///                     .max_samples(3)
+    ///                     .state(dds::sub::status::DataState::new_data())
+    ///                     .instance(someValidInstanceHandle)
+    ///                     .take();
+    /// @endcode
+    /// However, this will create and destroy a Selector for every read, which is not
+    /// very performance friendly.
+    ///
+    /// The performance can be increase by creating a Selector up front and doing the
+    /// reading on that Selector directly and re-using it.
+    /// @code{.cpp}
+    /// // Create a Selector as selective reader up front.
+    /// dds::sub::DataReader<Foo::Bar>::Selector selectiveReader(reader);
+    /// // Configure it to take a maximum of 3 new samples of a certain instance
+    /// selectiveReader.max_samples(3);
+    /// selectiveReader.state(dds::sub::status::DataState::new_data());
+    /// selectiveReader.instance(someValidInstanceHandle);
+    ///
+    /// // Use the configured Selector to -take- a maximum of 3 new samples of a
+    /// // certain instance (which it was configured to do).
+    /// // This can be used in loops for example, reducing the need for creating
+    /// // implicit Selectors for every take.
+    /// samples = selectiveReader.take();
+    /// @endcode
+    ///
+    /// <i>Defaults</i>
+    /// Element         | Default Value
+    /// --------------- | --------------------
+    /// state           | dds::sub::status::DataState::any
+    /// content         | Empty dds::sub::Query
+    /// max_samples     | dds::core::LENGTH_UNLIMITED
+    /// instance        | dds::core::InstanceHandle nil
+    ///
+    /// @see for more information: @link dds::sub::DataReader::select() DataReader select() @endlink
     class Selector
     {
     public:
@@ -170,160 +166,148 @@ public:
          */
         Selector(DataReader& dr);
 
-        /**
-         * Set InstanceHandle to filter with during the read or take.
-         *
-         * <i>Example</i><br>
-         * Read only samples of the given instance.
-         * @code{.cpp}
-         * dds::core::InstanceHandle hdl = someValidInstanceHandle;
-         *
-         * // Implicit use of Selector
-         * samples = reader.select().instance(hdl).read();
-         *
-         * // Explicit use of Selector
-         * dds::sub::DataReader<Foo::Bar>::Selector selectiveReader(reader);
-         * selectiveReader.instance(hdl);
-         * samples = selectiveReader.read();
-         * @endcode
-         * See also @link dds::sub::DataReader::select() DataReader select() @endlink operation.
-         *
-         * @param handle the InstanceHandle to read/take for
-         * @return a Selector to be able to concatenate Selector settings.
-         */
+        /// Set InstanceHandle to filter with during the read or take.
+        ///
+        /// <i>Example</i><br>
+        /// Read only samples of the given instance.
+        /// @code{.cpp}
+        /// dds::core::InstanceHandle hdl = someValidInstanceHandle;
+        ///
+        /// // Implicit use of Selector
+        /// samples = reader.select().instance(hdl).read();
+        ///
+        /// // Explicit use of Selector
+        /// dds::sub::DataReader<Foo::Bar>::Selector selectiveReader(reader);
+        /// selectiveReader.instance(hdl);
+        /// samples = selectiveReader.read();
+        /// @endcode
+        /// See also @link dds::sub::DataReader::select() DataReader select() @endlink operation.
+        ///
+        /// @param handle the InstanceHandle to read/take for
+        /// @return a Selector to be able to concatenate Selector settings.
         Selector& instance(const dds::core::InstanceHandle& handle);
 
-        /**
-         * Set next InstanceHandle to filter with during the read or take.
-         *
-         * <i>Example</i><br>
-         * Read all samples, instance by instance.
-         * @code{.cpp}
-         * // Implicit use of Selector
-         * {
-         *     // Get sample(s) of first instance
-         *     dds::core::InstanceHandle hdl; //nil
-         *     samples = reader.select().next_instance(hdl).read();
-         *     while (samples.length() > 0) {
-         *         // Handle the sample(s) of this instance (just the first one in this case)
-         *         const dds::sub::Sample<Foo::Bar>& sample = *(samples.begin());
-         *         // Get sample(s) of the next instance
-         *         hdl = sample.info().instance_handle();
-         *         samples = reader.select().next_instance(hdl).read();
-         *     }
-         * }
-         *
-         * // Explicit use of Selector
-         * {
-         *     // Get sample(s) of first instance
-         *     dds::sub::DataReader<Foo::Bar>::Selector selectiveReader(reader);
-         *     dds::core::InstanceHandle hdl; //nil
-         *     selectiveReader.next_instance(hdl);
-         *     samples = selectiveReader.read();
-         *     while (samples.length() > 0) {
-         *         // Handle the sample(s) of this instance (just the first one in this case)
-         *         const dds::sub::Sample<Foo::Bar>& sample = *(samples.begin());
-         *         // Get sample(s) of the next instance
-         *         hdl = sample.info().instance_handle();
-         *         selectiveReader.next_instance(hdl);
-         *         samples = selectiveReader.read();
-         *     }
-         * }
-         * @endcode
-         * See also @link dds::sub::DataReader::select() DataReader select() @endlink operation.
-         *
-         * @param handle the 'previous' InstanceHandle associated with new the read/take
-         * @return a Selector to be able to concatenate Selector settings.
-         */
+        /// Set next InstanceHandle to filter with during the read or take.
+        ///
+        /// <i>Example</i><br>
+        /// Read all samples, instance by instance.
+        /// @code{.cpp}
+        /// // Implicit use of Selector
+        /// {
+        ///     // Get sample(s) of first instance
+        ///     dds::core::InstanceHandle hdl; //nil
+        ///     samples = reader.select().next_instance(hdl).read();
+        ///     while (samples.length() > 0) {
+        ///         // Handle the sample(s) of this instance (just the first one in this case)
+        ///         const dds::sub::Sample<Foo::Bar>& sample = *(samples.begin());
+        ///         // Get sample(s) of the next instance
+        ///         hdl = sample.info().instance_handle();
+        ///         samples = reader.select().next_instance(hdl).read();
+        ///     }
+        /// }
+        ///
+        /// // Explicit use of Selector
+        /// {
+        ///     // Get sample(s) of first instance
+        ///     dds::sub::DataReader<Foo::Bar>::Selector selectiveReader(reader);
+        ///     dds::core::InstanceHandle hdl; //nil
+        ///     selectiveReader.next_instance(hdl);
+        ///     samples = selectiveReader.read();
+        ///     while (samples.length() > 0) {
+        ///         // Handle the sample(s) of this instance (just the first one in this case)
+        ///         const dds::sub::Sample<Foo::Bar>& sample = *(samples.begin());
+        ///         // Get sample(s) of the next instance
+        ///         hdl = sample.info().instance_handle();
+        ///         selectiveReader.next_instance(hdl);
+        ///         samples = selectiveReader.read();
+        ///     }
+        /// }
+        /// @endcode
+        /// See also @link dds::sub::DataReader::select() DataReader select() @endlink operation.
+        ///
+        /// @param handle the 'previous' InstanceHandle associated with new the read/take
+        /// @return a Selector to be able to concatenate Selector settings.
         Selector& next_instance(const dds::core::InstanceHandle& handle);
 
-        /**
-         * Set DataState to filter with during the read or take.
-         *
-         * <i>Example</i><br>
-         * Read only new data.
-         * @code{.cpp}
-         * // DataState to filter only new data
-         * dds::sub::status::DataState newData = dds::sub::status::DataState::new_data();
-         *
-         * // Implicit use of Selector
-         * samples = reader.select().state(newData).read();
-         *
-         * // Explicit use of Selector
-         * dds::sub::DataReader<Foo::Bar>::Selector selectiveReader(reader);
-         * selectiveReader.state(newData);
-         * samples = selectiveReader.read();
-         * @endcode
-         * See also @link dds::sub::DataReader::select() DataReader select() @endlink operation.
-         *
-         * @param state the requested DataState of the samples
-         * @return a Selector to be able to concatenate Selector settings.
-         */
+        /// Set DataState to filter with during the read or take.
+        ///
+        /// <i>Example</i><br>
+        /// Read only new data.
+        /// @code{.cpp}
+        /// // DataState to filter only new data
+        /// dds::sub::status::DataState newData = dds::sub::status::DataState::new_data();
+        ///
+        /// // Implicit use of Selector
+        /// samples = reader.select().state(newData).read();
+        ///
+        /// // Explicit use of Selector
+        /// dds::sub::DataReader<Foo::Bar>::Selector selectiveReader(reader);
+        /// selectiveReader.state(newData);
+        /// samples = selectiveReader.read();
+        /// @endcode
+        /// See also @link dds::sub::DataReader::select() DataReader select() @endlink operation.
+        ///
+        /// @param state the requested DataState of the samples
+        /// @return a Selector to be able to concatenate Selector settings.
         Selector& state(const dds::sub::status::DataState& state);
 
-        /**
-         * Set the Query to filter with during the read or take.
-         *
-         * <i>Example</i><br>
-         * Read only samples that will be filtered according to the given dds::sub::Query.
-         * @code{.cpp}
-         * // Assume data type has an element called long_1
-         * dds::sub::Query query(reader, "long_1 > 1 and long_1 < 7");
-         *
-         * // Implicit use of Selector
-         * samples = reader.select().content(query).read();
-         *
-         * // Explicit use of Selector
-         * dds::sub::DataReader<Foo::Bar>::Selector selectiveReader(reader);
-         * selectiveReader.content(query);
-         * samples = selectiveReader.read();
-         * @endcode
-         * See also @link dds::sub::DataReader::select() DataReader select() @endlink operation.
-         *
-         * @param query the Query to apply to the selector
-         * @return a Selector to be able to concatenate Selector settings.
-         */
+        /// Set the Query to filter with during the read or take.
+        ///
+        /// <i>Example</i><br>
+        /// Read only samples that will be filtered according to the given dds::sub::Query.
+        /// @code{.cpp}
+        /// // Assume data type has an element called long_1
+        /// dds::sub::Query query(reader, "long_1 > 1 and long_1 < 7");
+        ///
+        /// // Implicit use of Selector
+        /// samples = reader.select().content(query).read();
+        ///
+        /// // Explicit use of Selector
+        /// dds::sub::DataReader<Foo::Bar>::Selector selectiveReader(reader);
+        /// selectiveReader.content(query);
+        /// samples = selectiveReader.read();
+        /// @endcode
+        /// See also @link dds::sub::DataReader::select() DataReader select() @endlink operation.
+        ///
+        /// @param query the Query to apply to the selector
+        /// @return a Selector to be able to concatenate Selector settings.
         Selector& content(const dds::sub::Query& query);
 
-        /**
-         * Set max_samples to limit the number of sample to get during the read or take.
-         *
-         * <i>Example</i><br>
-         * Read a maximum of three samples.
-         * @code{.cpp}
-         * // Implicit use of Selector
-         * samples = reader.select().max_samples(3).read();
-         *
-         * // Explicit use of Selector
-         * dds::sub::DataReader<Foo::Bar>::Selector selectiveReader(reader);
-         * selectiveReader.max_samples(3);
-         * samples = selectiveReader.read();
-         * @endcode
-         * See also @link dds::sub::DataReader::select() DataReader select() @endlink operation.
-         *
-         * @param maxsamples maximum number of samples to read/take
-         * @return a Selector to be able to concatenate Selector settings.
-         */
+        /// Set max_samples to limit the number of sample to get during the read or take.
+        ///
+        /// <i>Example</i><br>
+        /// Read a maximum of three samples.
+        /// @code{.cpp}
+        /// // Implicit use of Selector
+        /// samples = reader.select().max_samples(3).read();
+        ///
+        /// // Explicit use of Selector
+        /// dds::sub::DataReader<Foo::Bar>::Selector selectiveReader(reader);
+        /// selectiveReader.max_samples(3);
+        /// samples = selectiveReader.read();
+        /// @endcode
+        /// See also @link dds::sub::DataReader::select() DataReader select() @endlink operation.
+        ///
+        /// @param maxsamples maximum number of samples to read/take
+        /// @return a Selector to be able to concatenate Selector settings.
         Selector& max_samples(uint32_t maxsamples);
 
-        /**
-         * This operation works the same as the @link DataReader::read() default
-         * DataReader read() @endlink, except that it is performed on this Selector
-         * with possible filters set.
-         *
-         * @return          The samples in the LoanedSamples container
-         * @throws dds::core::Error
-         *                  An internal error has occurred.
-         * @throws dds::core::NullReferenceError
-         *                  The entity was not properly created and references to dds::core::null.
-         * @throws dds::core::AlreadyClosedError
-         *                  The entity has already been closed.
-         * @throws dds::core::OutOfResourcesError
-         *                  The Data Distribution Service ran out of resources to
-         *                  complete this operation.
-         * @throws dds::core::NotEnabledError
-         *                  The DataReader has not yet been enabled.
-         */
+        /// This operation works the same as the @link DataReader::read() default
+        /// DataReader read() @endlink, except that it is performed on this Selector
+        /// with possible filters set.
+        ///
+        /// @return          The samples in the LoanedSamples container
+        /// @throws dds::core::Error
+        ///                  An internal error has occurred.
+        /// @throws dds::core::NullReferenceError
+        ///                  The entity was not properly created and references to dds::core::null.
+        /// @throws dds::core::AlreadyClosedError
+        ///                  The entity has already been closed.
+        /// @throws dds::core::OutOfResourcesError
+        ///                  The Data Distribution Service ran out of resources to
+        ///                  complete this operation.
+        /// @throws dds::core::NotEnabledError
+        ///                  The DataReader has not yet been enabled.
         dds::sub::LoanedSamples<T> read();
 
         /**
@@ -446,65 +430,63 @@ public:
         typename DELEGATE<T>::Selector impl_;
     };
 
-    /**
-     * The ManipulatorSelector class is used by the DataReader to compose streaming
-     * read operations.
-     *
-     * A ManipulatorSelector can perform complex data selections, such as per-instance
-     * selection, content and status filtering, etc, when reading or taking samples
-     * through the streaming operator.
-     *
-     * <i>Convenience functors</i><br>
-     * The following convenience functors use a ManipulatorSelector implicitly and can be
-     * used in the streaming operator:
-     * - dds::sub::read
-     * - dds::sub::take
-     * - dds::sub::max_samples
-     * - dds::sub::content
-     * - dds::sub::state
-     * - dds::sub::instance
-     * - dds::sub::next_instance
-     *
-     * @code{.cpp}
-     * // Take a maximum of 3 new samples of a certain instance.
-     * reader >> dds::sub::take
-     *        >> dds::sub::max_samples(3)
-     *        >> dds::sub::state(dds::sub::status::DataState::new_data())
-     *        >> dds::sub::instance(someValidInstanceHandle)
-     *        >> samples;
-     * @endcode
-     * However, this will create and destroy ManipulatorSelectors and Functors for
-     * every read, which is not very performance friendly.
-     *
-     * The performance can be increase by creating a ManipulatorSelector up front and
-     * doing the reading on that ManipulatorSelector directly and re-using it.
-     * @code{.cpp}
-     * // Create a ManipulatorSelector as selective reader up front.
-     * dds::sub::DataReader<Foo::Bar>::ManipulatorSelector selectiveReader(reader);
-     * // Configure it to take a maximum of 3 new samples of a certain instance
-     * selectiveReader.max_samples(3);
-     * selectiveReader.state(dds::sub::status::DataState::new_data());
-     * selectiveReader.instance(someValidInstanceHandle);
-     * selectiveReader.read_mode(false); // take
-     *
-     * // Use the configured ManipulatorSelector to -take- a maximum of 3 samples of a
-     * // certain instance (which it was configured to do).
-     * // This can be used in loops for example, reducing the need for creating
-     * // implicit ManipulatorSelectors for every take.
-     * selectiveReader >> samples;
-     * @endcode
-     *
-     * <i>Defaults</i>
-     * Element         | Default Value
-     * --------------- | --------------------
-     * read_mode       | true (read)
-     * state           | dds::sub::status::DataState::any
-     * content         | Empty dds::sub::Query
-     * max_samples     | dds::core::LENGTH_UNLIMITED
-     * instance        | dds::core::InstanceHandle nil
-     *
-     * @see for more information: @link dds::sub::DataReader::operator>>(dds::sub::LoanedSamples<T>& ls) DataReader stream operator>> @endlink
-     */
+    /// The ManipulatorSelector class is used by the DataReader to compose streaming
+    /// read operations.
+    ///
+    /// A ManipulatorSelector can perform complex data selections, such as per-instance
+    /// selection, content and status filtering, etc, when reading or taking samples
+    /// through the streaming operator.
+    ///
+    /// <i>Convenience functors</i><br>
+    /// The following convenience functors use a ManipulatorSelector implicitly and can be
+    /// used in the streaming operator:
+    /// - dds::sub::read
+    /// - dds::sub::take
+    /// - dds::sub::max_samples
+    /// - dds::sub::content
+    /// - dds::sub::state
+    /// - dds::sub::instance
+    /// - dds::sub::next_instance
+    ///
+    /// @code{.cpp}
+    /// // Take a maximum of 3 new samples of a certain instance.
+    /// reader >> dds::sub::take
+    ///        >> dds::sub::max_samples(3)
+    ///        >> dds::sub::state(dds::sub::status::DataState::new_data())
+    ///        >> dds::sub::instance(someValidInstanceHandle)
+    ///        >> samples;
+    /// @endcode
+    /// However, this will create and destroy ManipulatorSelectors and Functors for
+    /// every read, which is not very performance friendly.
+    ///
+    /// The performance can be increase by creating a ManipulatorSelector up front and
+    /// doing the reading on that ManipulatorSelector directly and re-using it.
+    /// @code{.cpp}
+    /// // Create a ManipulatorSelector as selective reader up front.
+    /// dds::sub::DataReader<Foo::Bar>::ManipulatorSelector selectiveReader(reader);
+    /// // Configure it to take a maximum of 3 new samples of a certain instance
+    /// selectiveReader.max_samples(3);
+    /// selectiveReader.state(dds::sub::status::DataState::new_data());
+    /// selectiveReader.instance(someValidInstanceHandle);
+    /// selectiveReader.read_mode(false); // take
+    ///
+    /// // Use the configured ManipulatorSelector to -take- a maximum of 3 samples of a
+    /// // certain instance (which it was configured to do).
+    /// // This can be used in loops for example, reducing the need for creating
+    /// // implicit ManipulatorSelectors for every take.
+    /// selectiveReader >> samples;
+    /// @endcode
+    ///
+    /// <i>Defaults</i>
+    /// Element         | Default Value
+    /// --------------- | --------------------
+    /// read_mode       | true (read)
+    /// state           | dds::sub::status::DataState::any
+    /// content         | Empty dds::sub::Query
+    /// max_samples     | dds::core::LENGTH_UNLIMITED
+    /// instance        | dds::core::InstanceHandle nil
+    ///
+    /// @see for more information: @link dds::sub::DataReader::operator>>(dds::sub::LoanedSamples<T>& ls) DataReader stream operator>> @endlink
     class ManipulatorSelector
     {
     public:
@@ -529,186 +511,174 @@ public:
          */
         bool read_mode();
 
-        /**
-         * Set the read_mode.
-         *
-         * The read_mode specifies if a sample should be read or taken:
-         * - true = read (default)
-         * - false = take
-         *
-         * <i>Convenience Functor:</i> dds::sub::read<br>
-         * <i>Convenience Functor:</i> dds::sub::take
-         *
-         * <i>Example</i><br>
-         * Determine to read or take samples.
-         * @code{.cpp}
-         * // No usage of ManipulatorSelector, means a read iso take as default.
-         * reader >> samples;
-         *
-         * // Implicit use of ManipulatorSelector
-         * reader >> dds::sub::read >> samples;
-         * reader >> dds::sub::take >> samples;
-         *
-         * // Explicit use of ManipulatorSelector
-         * dds::sub::DataReader<Foo::Bar>::ManipulatorSelector readingReader(reader);
-         * readingReader.read_mode(true); // Read, which is already the default.
-         * readingReader >> samples;
-         *
-         * dds::sub::DataReader<Foo::Bar>::ManipulatorSelector takingReader(reader);
-         * takingReader.read_mode(false); // Take.
-         * takingReader >> samples;
-         * @endcode
-         * See also @link dds::sub::DataReader::operator>>(dds::sub::LoanedSamples<T>& ls)
-         * DataReader stream operator>> @endlink
-         *
-         * @param readmode the read mode of the DataReader
-         */
+        /// Set the read_mode.
+        ///
+        /// The read_mode specifies if a sample should be read or taken:
+        /// - true = read (default)
+        /// - false = take
+        ///
+        /// <i>Convenience Functor:</i> dds::sub::read<br>
+        /// <i>Convenience Functor:</i> dds::sub::take
+        ///
+        /// <i>Example</i><br>
+        /// Determine to read or take samples.
+        /// @code{.cpp}
+        /// // No usage of ManipulatorSelector, means a read iso take as default.
+        /// reader >> samples;
+        ///
+        /// // Implicit use of ManipulatorSelector
+        /// reader >> dds::sub::read >> samples;
+        /// reader >> dds::sub::take >> samples;
+        ///
+        /// // Explicit use of ManipulatorSelector
+        /// dds::sub::DataReader<Foo::Bar>::ManipulatorSelector readingReader(reader);
+        /// readingReader.read_mode(true); // Read, which is already the default.
+        /// readingReader >> samples;
+        ///
+        /// dds::sub::DataReader<Foo::Bar>::ManipulatorSelector takingReader(reader);
+        /// takingReader.read_mode(false); // Take.
+        /// takingReader >> samples;
+        /// @endcode
+        /// See also @link dds::sub::DataReader::operator>>(dds::sub::LoanedSamples<T>& ls)
+        /// DataReader stream operator>> @endlink
+        ///
+        /// @param readmode the read mode of the DataReader
         void read_mode(bool readmode);
 
-        /**
-         * Set max_samples to limit the number of sample to get during the read or take.
-         *
-         * <i>Convenience Functor:</i> dds::sub::max_samples
-         *
-         * <i>Example</i><br>
-         * Read a maximum of three samples.
-         * @code{.cpp}
-         * // Implicit use of ManipulatorSelector
-         * reader >> dds::sub::max_samples(3) >> samples;
-         *
-         * // Explicit use of ManipulatorSelector
-         * dds::sub::DataReader<Foo::Bar>::ManipulatorSelector selectiveReader(reader);
-         * selectiveReader.max_samples(3);
-         * selectiveReader >> samples;
-         * @endcode
-         * See also @link dds::sub::DataReader::operator>>(dds::sub::LoanedSamples<T>& ls)
-         * DataReader stream operator>> @endlink
-         *
-         * @param n maximum number of samples
-         */
+        /// Set max_samples to limit the number of sample to get during the read or take.
+        ///
+        /// <i>Convenience Functor:</i> dds::sub::max_samples
+        ///
+        /// <i>Example</i><br>
+        /// Read a maximum of three samples.
+        /// @code{.cpp}
+        /// // Implicit use of ManipulatorSelector
+        /// reader >> dds::sub::max_samples(3) >> samples;
+        ///
+        /// // Explicit use of ManipulatorSelector
+        /// dds::sub::DataReader<Foo::Bar>::ManipulatorSelector selectiveReader(reader);
+        /// selectiveReader.max_samples(3);
+        /// selectiveReader >> samples;
+        /// @endcode
+        /// See also @link dds::sub::DataReader::operator>>(dds::sub::LoanedSamples<T>& ls)
+        /// DataReader stream operator>> @endlink
+        ///
+        /// @param n maximum number of samples
         ManipulatorSelector& max_samples(uint32_t n);
 
-        /**
-         * Set InstanceHandle to filter with during the read or take.
-         *
-         * <i>Convenience Functor:</i> dds::sub::instance
-         *
-         * <i>Example</i><br>
-         * Read only samples of the given instance.
-         * @code{.cpp}
-         * dds::core::InstanceHandle hdl = someValidInstanceHandle;
-         *
-         * // Implicit use of ManipulatorSelector
-         * reader >> dds::sub::instance(hdl) >> samples;
-         *
-         * // Explicit use of ManipulatorSelector
-         * dds::sub::DataReader<Foo::Bar>::ManipulatorSelector selectiveReader(reader);
-         * selectiveReader.instance(hdl);
-         * selectiveReader >> samples;
-         * @endcode
-         * See also @link dds::sub::DataReader::operator>>(dds::sub::LoanedSamples<T>& ls)
-         * DataReader stream operator>> @endlink
-         *
-         * @param handle the InstanceHandle for the read/take
-         */
+        /// Set InstanceHandle to filter with during the read or take.
+        ///
+        /// <i>Convenience Functor:</i> dds::sub::instance
+        ///
+        /// <i>Example</i><br>
+        /// Read only samples of the given instance.
+        /// @code{.cpp}
+        /// dds::core::InstanceHandle hdl = someValidInstanceHandle;
+        ///
+        /// // Implicit use of ManipulatorSelector
+        /// reader >> dds::sub::instance(hdl) >> samples;
+        ///
+        /// // Explicit use of ManipulatorSelector
+        /// dds::sub::DataReader<Foo::Bar>::ManipulatorSelector selectiveReader(reader);
+        /// selectiveReader.instance(hdl);
+        /// selectiveReader >> samples;
+        /// @endcode
+        /// See also @link dds::sub::DataReader::operator>>(dds::sub::LoanedSamples<T>& ls)
+        /// DataReader stream operator>> @endlink
+        ///
+        /// @param handle the InstanceHandle for the read/take
         ManipulatorSelector& instance(const dds::core::InstanceHandle& handle);
 
-        /**
-         * Set next InstanceHandle to filter with during the read or take.
-         *
-         * <i>Convenience Functor:</i> dds::sub::next_instance
-         *
-         * <i>Example</i><br>
-         * Read all samples, instance by instance.
-         * @code{.cpp}
-         * // Implicit use of ManipulatorSelector
-         * {
-         *     // Get sample(s) of first instance
-         *     dds::core::InstanceHandle hdl; //nil
-         *     reader >> dds::sub::next_instance(hdl) >> samples;
-         *     while (samples.length() > 0) {
-         *         // Handle the sample(s) of this instance (just the first one in this case)
-         *         const dds::sub::Sample<Foo::Bar>& sample = *(samples.begin());
-         *         // Get sample(s) of the next instance
-         *         hdl = sample.info().instance_handle();
-         *         reader >> dds::sub::next_instance(hdl) >> samples;
-         *     }
-         * }
-         *
-         * // Explicit use of ManipulatorSelector
-         * {
-         *     // Get sample(s) of first instance
-         *     dds::sub::DataReader<Foo::Bar>::ManipulatorSelector selectiveReader(reader);
-         *     dds::core::InstanceHandle hdl; //nil
-         *     selectiveReader.next_instance(hdl);
-         *     selectiveReader >> samples;
-         *     while (samples.length() > 0) {
-         *         // Handle the sample(s) of this instance (just the first one in this case)
-         *         const dds::sub::Sample<Foo::Bar>& sample = *(samples.begin());
-         *         // Get sample(s) of the next instance
-         *         hdl = sample.info().instance_handle();
-         *         selectiveReader.next_instance(hdl);
-         *         selectiveReader >> samples;
-         *     }
-         * }
-         * @endcode
-         * See also @link dds::sub::DataReader::operator>>(dds::sub::LoanedSamples<T>& ls)
-         * DataReader stream operator>> @endlink
-         *
-         * @param handle the 'previous' InstanceHandle associated with new the read/take
-         */
+        /// Set next InstanceHandle to filter with during the read or take.
+        ///
+        /// <i>Convenience Functor:</i> dds::sub::next_instance
+        ///
+        /// <i>Example</i><br>
+        /// Read all samples, instance by instance.
+        /// @code{.cpp}
+        /// // Implicit use of ManipulatorSelector
+        /// {
+        ///     // Get sample(s) of first instance
+        ///     dds::core::InstanceHandle hdl; //nil
+        ///     reader >> dds::sub::next_instance(hdl) >> samples;
+        ///     while (samples.length() > 0) {
+        ///         // Handle the sample(s) of this instance (just the first one in this case)
+        ///         const dds::sub::Sample<Foo::Bar>& sample = *(samples.begin());
+        ///         // Get sample(s) of the next instance
+        ///         hdl = sample.info().instance_handle();
+        ///         reader >> dds::sub::next_instance(hdl) >> samples;
+        ///     }
+        /// }
+        ///
+        /// // Explicit use of ManipulatorSelector
+        /// {
+        ///     // Get sample(s) of first instance
+        ///     dds::sub::DataReader<Foo::Bar>::ManipulatorSelector selectiveReader(reader);
+        ///     dds::core::InstanceHandle hdl; //nil
+        ///     selectiveReader.next_instance(hdl);
+        ///     selectiveReader >> samples;
+        ///     while (samples.length() > 0) {
+        ///         // Handle the sample(s) of this instance (just the first one in this case)
+        ///         const dds::sub::Sample<Foo::Bar>& sample = *(samples.begin());
+        ///         // Get sample(s) of the next instance
+        ///         hdl = sample.info().instance_handle();
+        ///         selectiveReader.next_instance(hdl);
+        ///         selectiveReader >> samples;
+        ///     }
+        /// }
+        /// @endcode
+        /// See also @link dds::sub::DataReader::operator>>(dds::sub::LoanedSamples<T>& ls)
+        /// DataReader stream operator>> @endlink
+        ///
+        /// @param handle the 'previous' InstanceHandle associated with new the read/take
         ManipulatorSelector& next_instance(const dds::core::InstanceHandle& handle);
 
-        /**
-         * Set DataState to filter with during the read or take.
-         *
-         * <i>Convenience Functor:</i> dds::sub::state
-         *
-         * <i>Example</i><br>
-         * Read only new data.
-         * @code{.cpp}
-         * // DataState to filter only new data
-         * dds::sub::status::DataState newData = dds::sub::status::DataState::new_data();
-         *
-         * // Implicit use of ManipulatorSelector
-         * reader >> dds::sub::state(newData) >> samples;
-         *
-         * // Explicit use of ManipulatorSelector
-         * dds::sub::DataReader<Foo::Bar>::ManipulatorSelector selectiveReader(reader);
-         * selectiveReader.state(newData);
-         * selectiveReader.read() >> samples;
-         * @endcode
-         * See also @link dds::sub::DataReader::operator>>(dds::sub::LoanedSamples<T>& ls)
-         * DataReader stream operator>> @endlink
-         *
-         * @param state the required DataState of the samples
-         */
+        /// Set DataState to filter with during the read or take.
+        ///
+        /// <i>Convenience Functor:</i> dds::sub::state
+        ///
+        /// <i>Example</i><br>
+        /// Read only new data.
+        /// @code{.cpp}
+        /// // DataState to filter only new data
+        /// dds::sub::status::DataState newData = dds::sub::status::DataState::new_data();
+        ///
+        /// // Implicit use of ManipulatorSelector
+        /// reader >> dds::sub::state(newData) >> samples;
+        ///
+        /// // Explicit use of ManipulatorSelector
+        /// dds::sub::DataReader<Foo::Bar>::ManipulatorSelector selectiveReader(reader);
+        /// selectiveReader.state(newData);
+        /// selectiveReader.read() >> samples;
+        /// @endcode
+        /// See also @link dds::sub::DataReader::operator>>(dds::sub::LoanedSamples<T>& ls)
+        /// DataReader stream operator>> @endlink
+        ///
+        /// @param state the required DataState of the samples
         ManipulatorSelector& state(const dds::sub::status::DataState& state);
 
-        /**
-         * Set Query to filter with during the read or take.
-         *
-         * <i>Convenience Functor:</i> dds::sub::content
-         *
-         * <i>Example</i><br>
-         * Read only samples that will be filtered according to the given dds::sub::Query.
-         * @code{.cpp}
-         * // Assume data type has an element called long_1
-         * dds::sub::Query query(reader, "long_1 > 1 and long_1 < 7");
-         *
-         * // Implicit use of ManipulatorSelector
-         * reader >> dds::sub::content(query) >> samples;
-         *
-         * // Explicit use of ManipulatorSelector
-         * dds::sub::DataReader<Foo::Bar>::ManipulatorSelector selectiveReader(reader);
-         * selectiveReader.content(query);
-         * selectiveReader >> read;
-         * @endcode
-         * See also @link dds::sub::DataReader::operator>>(dds::sub::LoanedSamples<T>& ls)
-         * DataReader stream operator>> @endlink
-         *
-         * @param query The Query to apply to a read/take
-         */
+        /// Set Query to filter with during the read or take.
+        ///
+        /// <i>Convenience Functor:</i> dds::sub::content
+        ///
+        /// <i>Example</i><br>
+        /// Read only samples that will be filtered according to the given dds::sub::Query.
+        /// @code{.cpp}
+        /// // Assume data type has an element called long_1
+        /// dds::sub::Query query(reader, "long_1 > 1 and long_1 < 7");
+        ///
+        /// // Implicit use of ManipulatorSelector
+        /// reader >> dds::sub::content(query) >> samples;
+        ///
+        /// // Explicit use of ManipulatorSelector
+        /// dds::sub::DataReader<Foo::Bar>::ManipulatorSelector selectiveReader(reader);
+        /// selectiveReader.content(query);
+        /// selectiveReader >> read;
+        /// @endcode
+        /// See also @link dds::sub::DataReader::operator>>(dds::sub::LoanedSamples<T>& ls)
+        /// DataReader stream operator>> @endlink
+        ///
+        /// @param query The Query to apply to a read/take
         ManipulatorSelector& content(const dds::sub::Query& query);
 
         /**
@@ -804,56 +774,54 @@ public:
     DataReader(const dds::sub::Subscriber& sub,
                const ::dds::topic::Topic<T>& topic);
 
-    /**
-     * Create a new DataReader for the desired Topic, ContentFilteredTopic or MultiTopic,
-     * using the given Subscriber and DataReaderQos and attaches the optionally specified
-     * DataReaderListener to it.
-     *
-     * <i>QoS</i><br>
-     * A possible application pattern to construct the DataReaderQos for the
-     * DataReader is to:
-     * @code{.cpp}
-     * // 1) Retrieve the QosPolicy settings on the associated Topic
-     * dds::topic::qos::TopicQos topicQos = topic.qos();
-     * // 2) Retrieve the default DataReaderQos from the related Subscriber
-     * dds::sub::qos::DataReaderQos readerQos = subscriber.default_datareader_qos();
-     * // 3) Combine those two lists of QosPolicy settings by overwriting DataReaderQos
-     * //    policies that are also present TopicQos
-     * readerQos = topicQos;
-     * // 4) Selectively modify QosPolicy settings as desired.
-     * readerQos << dds::core::policy::Durability::Transient();
-     * // 5) Use the resulting QoS to construct the DataReader.
-     * dds::sub::DataReader<Foo::Bar> reader(subscriber, topic, readerQos);
-     * @endcode
-     *
-     * <i>Listener</i><br>
-     * The following statuses are applicable to the DataReaderListener:
-     *  - dds::core::status::StatusMask::requested_deadline_missed()
-     *  - dds::core::status::StatusMask::requested_incompatible_qos()
-     *  - dds::core::status::StatusMask::sample_lost()
-     *  - dds::core::status::StatusMask::sample_rejected()
-     *  - dds::core::status::StatusMask::data_available()
-     *  - dds::core::status::StatusMask::liveliness_changed()
-     *  - dds::core::status::StatusMask::subscription_matched()
-     *
-     * See @ref DCPS_Modules_Infrastructure_Listener "listener concept",
-     * @ref anchor_dds_sub_datareader_commstatus "communication status" and
-     * @ref anchor_dds_sub_datareader_commpropagation "communication propagation"
-     * for more information.
-     *
-     * @param sub       the Subscriber that will contain this DataReader
-     * @param topic     the Topic, ContentFilteredTopic or MultiTopic associated with this DataReader
-     * @param qos       the DataReader qos.
-     * @param listener  the DataReader listener.
-     * @param mask      the listener event mask.
-     * @throws dds::core::Error
-     *                  An internal error has occurred.
-     * @throws dds::core::OutOfResourcesError
-     *                  The Data Distribution Service ran out of resources to
-     *                  complete this operation.
-     * @throws dds::core::InconsistentPolicyError
-     *                  The parameter qos contains conflicting QosPolicy settings.
-     */
+    /// Create a new DataReader for the desired Topic, ContentFilteredTopic or MultiTopic,
+    /// using the given Subscriber and DataReaderQos and attaches the optionally specified
+    /// DataReaderListener to it.
+    ///
+    /// <i>QoS</i><br>
+    /// A possible application pattern to construct the DataReaderQos for the
+    /// DataReader is to:
+    /// @code{.cpp}
+    /// // 1) Retrieve the QosPolicy settings on the associated Topic
+    /// dds::topic::qos::TopicQos topicQos = topic.qos();
+    /// // 2) Retrieve the default DataReaderQos from the related Subscriber
+    /// dds::sub::qos::DataReaderQos readerQos = subscriber.default_datareader_qos();
+    /// // 3) Combine those two lists of QosPolicy settings by overwriting DataReaderQos
+    /// //    policies that are also present TopicQos
+    /// readerQos = topicQos;
+    /// // 4) Selectively modify QosPolicy settings as desired.
+    /// readerQos << dds::core::policy::Durability::Transient();
+    /// // 5) Use the resulting QoS to construct the DataReader.
+    /// dds::sub::DataReader<Foo::Bar> reader(subscriber, topic, readerQos);
+    /// @endcode
+    ///
+    /// <i>Listener</i><br>
+    /// The following statuses are applicable to the DataReaderListener:
+    ///  - dds::core::status::StatusMask::requested_deadline_missed()
+    ///  - dds::core::status::StatusMask::requested_incompatible_qos()
+    ///  - dds::core::status::StatusMask::sample_lost()
+    ///  - dds::core::status::StatusMask::sample_rejected()
+    ///  - dds::core::status::StatusMask::data_available()
+    ///  - dds::core::status::StatusMask::liveliness_changed()
+    ///  - dds::core::status::StatusMask::subscription_matched()
+    ///
+    /// See @ref DCPS_Modules_Infrastructure_Listener "listener concept",
+    /// @ref anchor_dds_sub_datareader_commstatus "communication status" and
+    /// @ref anchor_dds_sub_datareader_commpropagation "communication propagation"
+    /// for more information.
+    ///
+    /// @param sub       the Subscriber that will contain this DataReader
+    /// @param topic     the Topic, ContentFilteredTopic or MultiTopic associated with this DataReader
+    /// @param qos       the DataReader qos.
+    /// @param listener  the DataReader listener.
+    /// @param mask      the listener event mask.
+    /// @throws dds::core::Error
+    ///                  An internal error has occurred.
+    /// @throws dds::core::OutOfResourcesError
+    ///                  The Data Distribution Service ran out of resources to
+    ///                  complete this operation.
+    /// @throws dds::core::InconsistentPolicyError
+    ///                  The parameter qos contains conflicting QosPolicy settings.
     DataReader(const dds::sub::Subscriber& sub,
                const ::dds::topic::Topic<T>& topic,
                const dds::sub::qos::DataReaderQos& qos,
@@ -919,105 +887,103 @@ public:
 
     //== Streaming read/take
 
-    /**
-     * This operation reads a sequence of typed samples from the DataReader by means
-     * of the shift operator.
-     *
-     * What samples are read depends on what @link dds::sub::DataReader::default_filter_state(const dds::sub::status::DataState& state)
-     * default state filter @endlink has been set (default any).
-     *
-     * This operation reads a sequence of typed samples from the DataReader<type>. The
-     * data is put into a dds::sub::LoanedSamples, which is basically a sequence of samples,
-     * which in turn contains the actual data and meta information.
-     *
-     * The memory used for storing the sample may be loaned by the middleware thus allowing zero
-     * copy operations.
-     *
-     * If the DataReader has no samples that meet the constraints, the resulting
-     * dds::sub::LoanedSamples will be empty.
-     * @code{.cpp}
-     * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
-     * dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
-     * dds::sub::Subscriber subscriber(participant);
-     * dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
-     *
-     * {
-     *     dds::sub::LoanedSamples<Foo::Bar> samples;
-     *     reader >> samples;
-     * }
-     * // The LoanedSamples went out of scope, meaning the loan was returned.
-     * @endcode
-     *
-     * <b><i>Take</i></b><br>
-     * The default behaviour of the DataReader stream operator>> is to read samples. It can be
-     * explicitly stated if the operator should do a read or take.
-     * @code{.cpp}
-     * reader >> dds::sub::read >> samples;
-     * reader >> dds::sub::take >> samples;
-     * @endcode
-     * These are two of the available convenience manipulators (see next paragraph).
-     *
-     * <b><i>Manipulators</i></b><br>
-     * Manipulators are defined externally to make it possible to control which data is read
-     * and whether the streaming operators reads or takes.
-     *
-     * Available convenience stream manipulators:
-     * - dds::sub::read
-     * - dds::sub::take
-     * - dds::sub::max_samples
-     * - dds::sub::content
-     * - dds::sub::state
-     * - dds::sub::instance
-     * - dds::sub::next_instance
-     *
-     * The manipulators can be concatenated:
-     * @code{.cpp}
-     * // Take (iso read) a maximum of 3 new samples of a certain instance.
-     * reader >> dds::sub::take
-     *        >> dds::sub::max_samples(3)
-     *        >> dds::sub::state(dds::sub::status::DataState::new_data())
-     *        >> dds::sub::instance(someValidInstanceHandle)
-     *        >> samples;
-     * @endcode
-     *
-     * <i>Please be aware that using pre-set filters on the DataReader and then
-     * call read() or take() on that reader explicitly will perform better than
-     * having to create Manipulators for every read (which is what essentially
-     * happens in the code example above). Performance can be increase by creating
-     * a manipulator up front and using that multiple times
-     * (see dds::sub::DataReader::ManipulatorSelector).</i>
-     *
-     * <b><i>Invalid Data</i></b><br>
-     * Some elements in the returned sequence may not have valid data: the valid_data
-     * field in the SampleInfo indicates whether the corresponding data value contains
-     * any meaningful data. If not, the data value is just a ‘dummy’ sample for which only
-     * the keyfields have been assigned. It is used to accompany the SampleInfo that
-     * communicates a change in the instance_state of an instance for which there is
-     * no ‘real’ sample available.
-     *
-     * For example, when an application always ‘takes’ all available samples of a
-     * particular instance, there is no sample available to report the disposal of that
-     * instance. In such a case the DataReader will insert a dummy sample into the
-     * data_values sequence to accompany the SampleInfo element in the info_seq
-     * sequence that communicates the disposal of the instance.
-     *
-     * The act of reading a sample sets its sample_state to READ_SAMPLE_STATE. If
-     * the sample belongs to the most recent generation of the instance, it also sets the
-     * view_state of the instance to NOT_NEW_VIEW_STATE. It does not affect the
-     * instance_state of the instance.
-     *
-     * @throws dds::core::Error
-     *                  An internal error has occurred.
-     * @throws dds::core::NullReferenceError
-     *                  The entity was not properly created and references to dds::core::null.
-     * @throws dds::core::AlreadyClosedError
-     *                  The entity has already been closed.
-     * @throws dds::core::OutOfResourcesError
-     *                  The Data Distribution Service ran out of resources to
-     *                  complete this operation.
-     * @throws dds::core::NotEnabledError
-     *                  The DataReader has not yet been enabled.
-     */
+    /// This operation reads a sequence of typed samples from the DataReader by means
+    /// of the shift operator.
+    ///
+    /// What samples are read depends on what @link dds::sub::DataReader::default_filter_state(const dds::sub::status::DataState& state)
+    /// default state filter @endlink has been set (default any).
+    ///
+    /// This operation reads a sequence of typed samples from the DataReader<type>. The
+    /// data is put into a dds::sub::LoanedSamples, which is basically a sequence of samples,
+    /// which in turn contains the actual data and meta information.
+    ///
+    /// The memory used for storing the sample may be loaned by the middleware thus allowing zero
+    /// copy operations.
+    ///
+    /// If the DataReader has no samples that meet the constraints, the resulting
+    /// dds::sub::LoanedSamples will be empty.
+    /// @code{.cpp}
+    /// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+    /// dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
+    /// dds::sub::Subscriber subscriber(participant);
+    /// dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
+    ///
+    /// {
+    ///     dds::sub::LoanedSamples<Foo::Bar> samples;
+    ///     reader >> samples;
+    /// }
+    /// // The LoanedSamples went out of scope, meaning the loan was returned.
+    /// @endcode
+    ///
+    /// <b><i>Take</i></b><br>
+    /// The default behaviour of the DataReader stream operator>> is to read samples. It can be
+    /// explicitly stated if the operator should do a read or take.
+    /// @code{.cpp}
+    /// reader >> dds::sub::read >> samples;
+    /// reader >> dds::sub::take >> samples;
+    /// @endcode
+    /// These are two of the available convenience manipulators (see next paragraph).
+    ///
+    /// <b><i>Manipulators</i></b><br>
+    /// Manipulators are defined externally to make it possible to control which data is read
+    /// and whether the streaming operators reads or takes.
+    ///
+    /// Available convenience stream manipulators:
+    /// - dds::sub::read
+    /// - dds::sub::take
+    /// - dds::sub::max_samples
+    /// - dds::sub::content
+    /// - dds::sub::state
+    /// - dds::sub::instance
+    /// - dds::sub::next_instance
+    ///
+    /// The manipulators can be concatenated:
+    /// @code{.cpp}
+    /// // Take (iso read) a maximum of 3 new samples of a certain instance.
+    /// reader >> dds::sub::take
+    ///        >> dds::sub::max_samples(3)
+    ///        >> dds::sub::state(dds::sub::status::DataState::new_data())
+    ///        >> dds::sub::instance(someValidInstanceHandle)
+    ///        >> samples;
+    /// @endcode
+    ///
+    /// <i>Please be aware that using pre-set filters on the DataReader and then
+    /// call read() or take() on that reader explicitly will perform better than
+    /// having to create Manipulators for every read (which is what essentially
+    /// happens in the code example above). Performance can be increase by creating
+    /// a manipulator up front and using that multiple times
+    /// (see dds::sub::DataReader::ManipulatorSelector).</i>
+    ///
+    /// <b><i>Invalid Data</i></b><br>
+    /// Some elements in the returned sequence may not have valid data: the valid_data
+    /// field in the SampleInfo indicates whether the corresponding data value contains
+    /// any meaningful data. If not, the data value is just a ‘dummy’ sample for which only
+    /// the keyfields have been assigned. It is used to accompany the SampleInfo that
+    /// communicates a change in the instance_state of an instance for which there is
+    /// no ‘real’ sample available.
+    ///
+    /// For example, when an application always ‘takes’ all available samples of a
+    /// particular instance, there is no sample available to report the disposal of that
+    /// instance. In such a case the DataReader will insert a dummy sample into the
+    /// data_values sequence to accompany the SampleInfo element in the info_seq
+    /// sequence that communicates the disposal of the instance.
+    ///
+    /// The act of reading a sample sets its sample_state to READ_SAMPLE_STATE. If
+    /// the sample belongs to the most recent generation of the instance, it also sets the
+    /// view_state of the instance to NOT_NEW_VIEW_STATE. It does not affect the
+    /// instance_state of the instance.
+    ///
+    /// @throws dds::core::Error
+    ///                  An internal error has occurred.
+    /// @throws dds::core::NullReferenceError
+    ///                  The entity was not properly created and references to dds::core::null.
+    /// @throws dds::core::AlreadyClosedError
+    ///                  The entity has already been closed.
+    /// @throws dds::core::OutOfResourcesError
+    ///                  The Data Distribution Service ran out of resources to
+    ///                  complete this operation.
+    /// @throws dds::core::NotEnabledError
+    ///                  The DataReader has not yet been enabled.
     DataReader& operator>>(dds::sub::LoanedSamples<T>& ls);
 
     /** @copydoc dds::sub::DataReader::operator>>(dds::sub::LoanedSamples<T>& ls) */
@@ -1034,272 +1000,264 @@ public:
 public:
     //== Loan Read/Take API ==================================================
 
-    /**
-     * This operation reads a sequence of typed samples from the DataReader.
-     *
-     * What samples are read depends on what @link dds::sub::DataReader::default_filter_state(const dds::sub::status::DataState& state)
-     * default state filter @endlink has been set (default any).
-     *
-     * This operation reads a sequence of typed samples from the DataReader<type>. The
-     * data is put into a dds::sub::LoanedSamples, which is basically a sequence of samples,
-     * which in turn contains the actual data and meta information.
-     *
-     * The memory used for storing the sample may be loaned by the middleware thus allowing zero
-     * copy operations.
-     *
-     * If the DataReader has no samples that meet the constraints, the resulting
-     * dds::sub::LoanedSamples will be empty.
-     * @code{.cpp}
-     * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
-     * dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
-     * dds::sub::Subscriber subscriber(participant);
-     * dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
-     *
-     * {
-     *     // Read the available samples.
-     *     dds::sub::LoanedSamples<Foo::Bar> samples;
-     *     samples = reader.read();
-     *
-     *     // Access the information.
-     *     dds::sub::LoanedSamples<Foo::Bar>::const_iterator it;
-     *     for (it = samples.begin(); it != samples.end(); ++it) {
-     *         const dds::sub::Sample<Foo::Bar>& sample = *it;
-     *     }
-     * }
-     * // The LoanedSamples went out of scope, meaning the loan resources were taken care of.
-     * @endcode
-     *
-     * <b><i>Selectors</i></b><br>
-     * What data is read already depends on the
-     * @ref anchor_dds_sub_datareader_defaultstatefilter "default state filter".
-     * But it can be manipulated even more when using dds::sub::DataReader::select()
-     * operation.
-     *
-     * @anchor anchor_dds_sub_datareader_invalidsamples
-     * <b><i>Invalid Data</i></b><br>
-     * Some elements in the returned sequence may not have valid data: the valid_data
-     * field in the SampleInfo indicates whether the corresponding data value contains
-     * any meaningful data. If not, the data value is just a ‘dummy’ sample for which only
-     * the keyfields have been assigned. It is used to accompany the SampleInfo that
-     * communicates a change in the instance_state of an instance for which there is
-     * no ‘real’ sample available.
-     *
-     * For example, when an application always ‘takes’ all available samples of a
-     * particular instance, there is no sample available to report the disposal of that
-     * instance. In such a case the DataReader will insert a dummy sample into the
-     * data_values sequence to accompany the SampleInfo element in the info_seq
-     * sequence that communicates the disposal of the instance.
-     *
-     * The act of reading a sample sets its sample_state to READ_SAMPLE_STATE. If
-     * the sample belongs to the most recent generation of the instance, it also sets the
-     * view_state of the instance to NOT_NEW_VIEW_STATE. It does not affect the
-     * instance_state of the instance.
-     *
-     * @return          The samples in the LoanedSamples container
-     * @throws dds::core::Error
-     *                  An internal error has occurred.
-     * @throws dds::core::NullReferenceError
-     *                  The entity was not properly created and references to dds::core::null.
-     * @throws dds::core::AlreadyClosedError
-     *                  The entity has already been closed.
-     * @throws dds::core::OutOfResourcesError
-     *                  The Data Distribution Service ran out of resources to
-     *                  complete this operation.
-     * @throws dds::core::NotEnabledError
-     *                  The DataReader has not yet been enabled.
-     */
+    /// This operation reads a sequence of typed samples from the DataReader.
+    ///
+    /// What samples are read depends on what @link dds::sub::DataReader::default_filter_state(const dds::sub::status::DataState& state)
+    /// default state filter @endlink has been set (default any).
+    ///
+    /// This operation reads a sequence of typed samples from the DataReader<type>. The
+    /// data is put into a dds::sub::LoanedSamples, which is basically a sequence of samples,
+    /// which in turn contains the actual data and meta information.
+    ///
+    /// The memory used for storing the sample may be loaned by the middleware thus allowing zero
+    /// copy operations.
+    ///
+    /// If the DataReader has no samples that meet the constraints, the resulting
+    /// dds::sub::LoanedSamples will be empty.
+    /// @code{.cpp}
+    /// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+    /// dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
+    /// dds::sub::Subscriber subscriber(participant);
+    /// dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
+    ///
+    /// {
+    ///     // Read the available samples.
+    ///     dds::sub::LoanedSamples<Foo::Bar> samples;
+    ///     samples = reader.read();
+    ///
+    ///     // Access the information.
+    ///     dds::sub::LoanedSamples<Foo::Bar>::const_iterator it;
+    ///     for (it = samples.begin(); it != samples.end(); ++it) {
+    ///         const dds::sub::Sample<Foo::Bar>& sample = *it;
+    ///     }
+    /// }
+    /// // The LoanedSamples went out of scope, meaning the loan resources were taken care of.
+    /// @endcode
+    ///
+    /// <b><i>Selectors</i></b><br>
+    /// What data is read already depends on the
+    /// @ref anchor_dds_sub_datareader_defaultstatefilter "default state filter".
+    /// But it can be manipulated even more when using dds::sub::DataReader::select()
+    /// operation.
+    ///
+    /// @anchor anchor_dds_sub_datareader_invalidsamples
+    /// <b><i>Invalid Data</i></b><br>
+    /// Some elements in the returned sequence may not have valid data: the valid_data
+    /// field in the SampleInfo indicates whether the corresponding data value contains
+    /// any meaningful data. If not, the data value is just a ‘dummy’ sample for which only
+    /// the keyfields have been assigned. It is used to accompany the SampleInfo that
+    /// communicates a change in the instance_state of an instance for which there is
+    /// no ‘real’ sample available.
+    ///
+    /// For example, when an application always ‘takes’ all available samples of a
+    /// particular instance, there is no sample available to report the disposal of that
+    /// instance. In such a case the DataReader will insert a dummy sample into the
+    /// data_values sequence to accompany the SampleInfo element in the info_seq
+    /// sequence that communicates the disposal of the instance.
+    ///
+    /// The act of reading a sample sets its sample_state to READ_SAMPLE_STATE. If
+    /// the sample belongs to the most recent generation of the instance, it also sets the
+    /// view_state of the instance to NOT_NEW_VIEW_STATE. It does not affect the
+    /// instance_state of the instance.
+    ///
+    /// @return          The samples in the LoanedSamples container
+    /// @throws dds::core::Error
+    ///                  An internal error has occurred.
+    /// @throws dds::core::NullReferenceError
+    ///                  The entity was not properly created and references to dds::core::null.
+    /// @throws dds::core::AlreadyClosedError
+    ///                  The entity has already been closed.
+    /// @throws dds::core::OutOfResourcesError
+    ///                  The Data Distribution Service ran out of resources to
+    ///                  complete this operation.
+    /// @throws dds::core::NotEnabledError
+    ///                  The DataReader has not yet been enabled.
     LoanedSamples<T> read();
 
-    /**
-     * This operation takes a sequence of typed samples from the DataReader.
-     *
-     * The behaviour is identical to read except for that the samples are removed
-     * from the DataReader.
-     *
-     * What samples are taken depends on what @link dds::sub::DataReader::default_filter_state(const dds::sub::status::DataState& state)
-     * default state filter @endlink has been set (default any).
-     *
-     * This operation takes a sequence of typed samples from the DataReader<type>. The
-     * data is put into a dds::sub::LoanedSamples, which is basically a sequence of samples,
-     * which in turn contains the actual data and meta information.
-     *
-     * The memory used for storing the sample may be loaned by the middleware thus allowing zero
-     * copy operations.
-     *
-     * If the DataReader has no samples that meet the constraints, the resulting
-     * dds::sub::LoanedSamples will be empty.
-     * @code{.cpp}
-     * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
-     * dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
-     * dds::sub::Subscriber subscriber(participant);
-     * dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
-     *
-     * {
-     *     // Take the available samples.
-     *     dds::sub::LoanedSamples<Foo::Bar> samples;
-     *     samples = reader.take();
-     *
-     *     // Access the information.
-     *     dds::sub::LoanedSamples<Foo::Bar>::const_iterator it;
-     *     for (it = samples.begin(); it != samples.end(); ++it) {
-     *         const dds::sub::Sample<Foo::Bar>& sample = *it;
-     *     }
-     * }
-     * // The LoanedSamples went out of scope, meaning the loan resources were taken care of.
-     * @endcode
-     *
-     * <b><i>Selectors</i></b><br>
-     * What data is taken, already depends on the
-     * @ref anchor_dds_sub_datareader_defaultstatefilter "default state filter".
-     * But it can be manipulated even more when using dds::sub::DataReader::select()
-     * operation.
-     *
-     * <b><i>Invalid Data</i></b><br>
-     * Some elements in the returned sequence may not have valid data: the valid_data
-     * field in the SampleInfo indicates whether the corresponding data value contains
-     * any meaningful data.<br>
-     * Look @ref anchor_dds_sub_datareader_invalidsamples "here" for more information.
-     *
-     * @return          The samples in the LoanedSamples container
-     * @throws dds::core::Error
-     *                  An internal error has occurred.
-     * @throws dds::core::NullReferenceError
-     *                  The entity was not properly created and references to dds::core::null.
-     * @throws dds::core::AlreadyClosedError
-     *                  The entity has already been closed.
-     * @throws dds::core::OutOfResourcesError
-     *                  The Data Distribution Service ran out of resources to
-     *                  complete this operation.
-     * @throws dds::core::NotEnabledError
-     *                  The DataReader has not yet been enabled.
-     */
+    /// This operation takes a sequence of typed samples from the DataReader.
+    ///
+    /// The behaviour is identical to read except for that the samples are removed
+    /// from the DataReader.
+    ///
+    /// What samples are taken depends on what @link dds::sub::DataReader::default_filter_state(const dds::sub::status::DataState& state)
+    /// default state filter @endlink has been set (default any).
+    ///
+    /// This operation takes a sequence of typed samples from the DataReader<type>. The
+    /// data is put into a dds::sub::LoanedSamples, which is basically a sequence of samples,
+    /// which in turn contains the actual data and meta information.
+    ///
+    /// The memory used for storing the sample may be loaned by the middleware thus allowing zero
+    /// copy operations.
+    ///
+    /// If the DataReader has no samples that meet the constraints, the resulting
+    /// dds::sub::LoanedSamples will be empty.
+    /// @code{.cpp}
+    /// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+    /// dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
+    /// dds::sub::Subscriber subscriber(participant);
+    /// dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
+    ///
+    /// {
+    ///     // Take the available samples.
+    ///     dds::sub::LoanedSamples<Foo::Bar> samples;
+    ///     samples = reader.take();
+    ///
+    ///     // Access the information.
+    ///     dds::sub::LoanedSamples<Foo::Bar>::const_iterator it;
+    ///     for (it = samples.begin(); it != samples.end(); ++it) {
+    ///         const dds::sub::Sample<Foo::Bar>& sample = *it;
+    ///     }
+    /// }
+    /// // The LoanedSamples went out of scope, meaning the loan resources were taken care of.
+    /// @endcode
+    ///
+    /// <b><i>Selectors</i></b><br>
+    /// What data is taken, already depends on the
+    /// @ref anchor_dds_sub_datareader_defaultstatefilter "default state filter".
+    /// But it can be manipulated even more when using dds::sub::DataReader::select()
+    /// operation.
+    ///
+    /// <b><i>Invalid Data</i></b><br>
+    /// Some elements in the returned sequence may not have valid data: the valid_data
+    /// field in the SampleInfo indicates whether the corresponding data value contains
+    /// any meaningful data.<br>
+    /// Look @ref anchor_dds_sub_datareader_invalidsamples "here" for more information.
+    ///
+    /// @return          The samples in the LoanedSamples container
+    /// @throws dds::core::Error
+    ///                  An internal error has occurred.
+    /// @throws dds::core::NullReferenceError
+    ///                  The entity was not properly created and references to dds::core::null.
+    /// @throws dds::core::AlreadyClosedError
+    ///                  The entity has already been closed.
+    /// @throws dds::core::OutOfResourcesError
+    ///                  The Data Distribution Service ran out of resources to
+    ///                  complete this operation.
+    /// @throws dds::core::NotEnabledError
+    ///                  The DataReader has not yet been enabled.
     LoanedSamples<T> take();
 
     //== Copy Read/Take API ==================================================
 
     // --- Forward Iterators: --- //
 
-    /**
-     * This operation reads a sequence of typed samples from the DataReader.
-     *
-     * What samples are read depends on what @link dds::sub::DataReader::default_filter_state(const dds::sub::status::DataState& state)
-     * default state filter @endlink has been set (default any).
-     *
-     * The samples are copied into the application provided container using the
-     * forward iterator parameter.
-     *
-     * If the DataReader has no samples that meet the constraints, the resulting
-     * dds::sub::LoanedSamples will be empty.
-     * @code{.cpp}
-     * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
-     * dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
-     * dds::sub::Subscriber subscriber(participant);
-     * dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
-     *
-     * // Prepare container to store samples in
-     * const uint32_t MAX_SAMPLES (3)
-     * std::vector<dds::sub::Sample<Foo::Bar> > samples(MAX_SAMPLES);
-     * std::vector<dds::sub::Sample<Foo::Bar> >::iterator iter = samples.begin();
-     *
-     * // Read and copy the available samples into the vector by means of the iterator
-     * uint32_t len =  reader.read(iter, MAX_SAMPLES);
-     *
-     * // Access the information.
-     * for (iter = samples.begin(); iter != samples.end(); ++iter) {
-     *     const dds::sub::Sample<Foo::Bar>& sample = *iter;
-     * }
-     * @endcode
-     *
-     * <b><i>Selectors</i></b><br>
-     * What data is read already depends on the
-     * @ref anchor_dds_sub_datareader_defaultstatefilter "default state filter".
-     * But it can be manipulated even more when using dds::sub::DataReader::select()
-     * operation.
-     *
-     * <b><i>Invalid Data</i></b><br>
-     * Some elements in the returned sequence may not have valid data: the valid_data
-     * field in the SampleInfo indicates whether the corresponding data value contains
-     * any meaningful data.<br>
-     * Look @ref anchor_dds_sub_datareader_invalidsamples "here" for more information.
-     *
-     * @param  sfit     Forward-inserting container iterator
-     * @param  max_samples Maximum samples to read and copy into the given container
-     * @return          The number of samples in the LoanedSamples container
-     * @throws dds::core::Error
-     *                  An internal error has occurred.
-     * @throws dds::core::NullReferenceError
-     *                  The entity was not properly created and references to dds::core::null.
-     * @throws dds::core::AlreadyClosedError
-     *                  The entity has already been closed.
-     * @throws dds::core::OutOfResourcesError
-     *                  The Data Distribution Service ran out of resources to
-     *                  complete this operation.
-     * @throws dds::core::NotEnabledError
-     *                  The DataReader has not yet been enabled.
-     */
+    /// This operation reads a sequence of typed samples from the DataReader.
+    ///
+    /// What samples are read depends on what @link dds::sub::DataReader::default_filter_state(const dds::sub::status::DataState& state)
+    /// default state filter @endlink has been set (default any).
+    ///
+    /// The samples are copied into the application provided container using the
+    /// forward iterator parameter.
+    ///
+    /// If the DataReader has no samples that meet the constraints, the resulting
+    /// dds::sub::LoanedSamples will be empty.
+    /// @code{.cpp}
+    /// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+    /// dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
+    /// dds::sub::Subscriber subscriber(participant);
+    /// dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
+    ///
+    /// // Prepare container to store samples in
+    /// const uint32_t MAX_SAMPLES (3)
+    /// std::vector<dds::sub::Sample<Foo::Bar> > samples(MAX_SAMPLES);
+    /// std::vector<dds::sub::Sample<Foo::Bar> >::iterator iter = samples.begin();
+    ///
+    /// // Read and copy the available samples into the vector by means of the iterator
+    /// uint32_t len =  reader.read(iter, MAX_SAMPLES);
+    ///
+    /// // Access the information.
+    /// for (iter = samples.begin(); iter != samples.end(); ++iter) {
+    ///     const dds::sub::Sample<Foo::Bar>& sample = *iter;
+    /// }
+    /// @endcode
+    ///
+    /// <b><i>Selectors</i></b><br>
+    /// What data is read already depends on the
+    /// @ref anchor_dds_sub_datareader_defaultstatefilter "default state filter".
+    /// But it can be manipulated even more when using dds::sub::DataReader::select()
+    /// operation.
+    ///
+    /// <b><i>Invalid Data</i></b><br>
+    /// Some elements in the returned sequence may not have valid data: the valid_data
+    /// field in the SampleInfo indicates whether the corresponding data value contains
+    /// any meaningful data.<br>
+    /// Look @ref anchor_dds_sub_datareader_invalidsamples "here" for more information.
+    ///
+    /// @param  sfit     Forward-inserting container iterator
+    /// @param  max_samples Maximum samples to read and copy into the given container
+    /// @return          The number of samples in the LoanedSamples container
+    /// @throws dds::core::Error
+    ///                  An internal error has occurred.
+    /// @throws dds::core::NullReferenceError
+    ///                  The entity was not properly created and references to dds::core::null.
+    /// @throws dds::core::AlreadyClosedError
+    ///                  The entity has already been closed.
+    /// @throws dds::core::OutOfResourcesError
+    ///                  The Data Distribution Service ran out of resources to
+    ///                  complete this operation.
+    /// @throws dds::core::NotEnabledError
+    ///                  The DataReader has not yet been enabled.
     template <typename SamplesFWIterator>
     uint32_t
     read(SamplesFWIterator sfit,
          uint32_t max_samples);
 
-    /**
-     * This operation takes a sequence of typed samples from the DataReader.
-     *
-     * What samples are take depends on what @link dds::sub::DataReader::default_filter_state(const dds::sub::status::DataState& state)
-     * default state filter @endlink has been set (default any).
-     *
-     * The samples are copied into the application provided container using the
-     * forward iterator parameter.
-     *
-     * If the DataReader has no samples that meet the constraints, the resulting
-     * dds::sub::LoanedSamples will be empty.
-     * @code{.cpp}
-     * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
-     * dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
-     * dds::sub::Subscriber subscriber(participant);
-     * dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
-     *
-     * // Prepare container to store samples in
-     * const uint32_t MAX_SAMPLES (3)
-     * std::vector<dds::sub::Sample<Foo::Bar> > samples(MAX_SAMPLES);
-     * std::vector<dds::sub::Sample<Foo::Bar> >::iterator iter = samples.begin();
-     *
-     * // Take and copy the available samples into the vector by means of the iterator
-     * uint32_t len =  reader.take(iter, MAX_SAMPLES);
-     *
-     * // Access the information.
-     * for (iter = samples.begin(); iter != samples.end(); ++iter) {
-     *     const dds::sub::Sample<Foo::Bar>& sample = *iter;
-     * }
-     * @endcode
-     *
-     * <b><i>Selectors</i></b><br>
-     * What data is taken, already depends on the
-     * @ref anchor_dds_sub_datareader_defaultstatefilter "default state filter".
-     * But it can be manipulated even more when using dds::sub::DataReader::select()
-     * operation.
-     *
-     * <b><i>Invalid Data</i></b><br>
-     * Some elements in the returned sequence may not have valid data: the valid_data
-     * field in the SampleInfo indicates whether the corresponding data value contains
-     * any meaningful data.<br>
-     * Look @ref anchor_dds_sub_datareader_invalidsamples "here" for more information.
-     *
-     * @param  sfit     Forward-inserting container iterator
-     * @param  max_samples Maximum samples to take and copy into the given container
-     * @return          The number of samples in the given container
-     * @throws dds::core::Error
-     *                  An internal error has occurred.
-     * @throws dds::core::NullReferenceError
-     *                  The entity was not properly created and references to dds::core::null.
-     * @throws dds::core::AlreadyClosedError
-     *                  The entity has already been closed.
-     * @throws dds::core::OutOfResourcesError
-     *                  The Data Distribution Service ran out of resources to
-     *                  complete this operation.
-     * @throws dds::core::NotEnabledError
-     *                  The DataReader has not yet been enabled.
-     */
+    /// This operation takes a sequence of typed samples from the DataReader.
+    ///
+    /// What samples are take depends on what @link dds::sub::DataReader::default_filter_state(const dds::sub::status::DataState& state)
+    /// default state filter @endlink has been set (default any).
+    ///
+    /// The samples are copied into the application provided container using the
+    /// forward iterator parameter.
+    ///
+    /// If the DataReader has no samples that meet the constraints, the resulting
+    /// dds::sub::LoanedSamples will be empty.
+    /// @code{.cpp}
+    /// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+    /// dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
+    /// dds::sub::Subscriber subscriber(participant);
+    /// dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
+    ///
+    /// // Prepare container to store samples in
+    /// const uint32_t MAX_SAMPLES (3)
+    /// std::vector<dds::sub::Sample<Foo::Bar> > samples(MAX_SAMPLES);
+    /// std::vector<dds::sub::Sample<Foo::Bar> >::iterator iter = samples.begin();
+    ///
+    /// // Take and copy the available samples into the vector by means of the iterator
+    /// uint32_t len =  reader.take(iter, MAX_SAMPLES);
+    ///
+    /// // Access the information.
+    /// for (iter = samples.begin(); iter != samples.end(); ++iter) {
+    ///     const dds::sub::Sample<Foo::Bar>& sample = *iter;
+    /// }
+    /// @endcode
+    ///
+    /// <b><i>Selectors</i></b><br>
+    /// What data is taken, already depends on the
+    /// @ref anchor_dds_sub_datareader_defaultstatefilter "default state filter".
+    /// But it can be manipulated even more when using dds::sub::DataReader::select()
+    /// operation.
+    ///
+    /// <b><i>Invalid Data</i></b><br>
+    /// Some elements in the returned sequence may not have valid data: the valid_data
+    /// field in the SampleInfo indicates whether the corresponding data value contains
+    /// any meaningful data.<br>
+    /// Look @ref anchor_dds_sub_datareader_invalidsamples "here" for more information.
+    ///
+    /// @param  sfit     Forward-inserting container iterator
+    /// @param  max_samples Maximum samples to take and copy into the given container
+    /// @return          The number of samples in the given container
+    /// @throws dds::core::Error
+    ///                  An internal error has occurred.
+    /// @throws dds::core::NullReferenceError
+    ///                  The entity was not properly created and references to dds::core::null.
+    /// @throws dds::core::AlreadyClosedError
+    ///                  The entity has already been closed.
+    /// @throws dds::core::OutOfResourcesError
+    ///                  The Data Distribution Service ran out of resources to
+    ///                  complete this operation.
+    /// @throws dds::core::NotEnabledError
+    ///                  The DataReader has not yet been enabled.
     template <typename SamplesFWIterator>
     uint32_t
     take(SamplesFWIterator sfit,
@@ -1308,126 +1266,122 @@ public:
 
     // --- Back-Inserting Iterators: --- //
 
-    /**
-     * This operation reads a sequence of typed samples from the DataReader.
-     *
-     * What samples are read depends on what @link dds::sub::DataReader::default_filter_state(const dds::sub::status::DataState& state)
-     * default state filter @endlink has been set (default any).
-     *
-     * The samples are copied into the application provided container using a
-     * back-inserting iterator. Notice that as a consequence of using a back-inserting
-     * iterator, this operation may allocate memory to resize the underlying container.
-     *
-     * If the DataReader has no samples that meet the constraints, the resulting
-     * dds::sub::LoanedSamples will be empty.
-     * @code{.cpp}
-     * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
-     * dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
-     * dds::sub::Subscriber subscriber(participant);
-     * dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
-     *
-     * // Prepare container to store samples in
-     * std::vector<dds::sub::Sample<Foo::Bar> > samples;
-     * std::back_insert_iterator< std::vector<dds::sub::Sample<Foo::Bar> > > bi(samples);
-     *
-     * // Read and copy the available samples into the vector by means of the iterator
-     * uint32_t len =  reader.read(bi);
-     *
-     * // Access the information.
-     * std::vector<dds::sub::Sample<Space::Type1> >::iterator iter = samples.begin();
-     * for (iter = samples.begin(); iter != samples.end(); ++iter) {
-     *     const dds::sub::Sample<Foo::Bar>& sample = *iter;
-     * }
-     * @endcode
-     *
-     * <b><i>Selectors</i></b><br>
-     * What data is read already depends on the
-     * @ref anchor_dds_sub_datareader_defaultstatefilter "default state filter".
-     * But it can be manipulated even more when using dds::sub::DataReader::select()
-     * operation.
-     *
-     * <b><i>Invalid Data</i></b><br>
-     * Some elements in the returned sequence may not have valid data: the valid_data
-     * field in the SampleInfo indicates whether the corresponding data value contains
-     * any meaningful data.<br>
-     * Look @ref anchor_dds_sub_datareader_invalidsamples "here" for more information.
-     *
-     * @param  sbit     Back-inserting container iterator
-     * @return          The number of samples in the given container
-     * @throws dds::core::Error
-     *                  An internal error has occurred.
-     * @throws dds::core::NullReferenceError
-     *                  The entity was not properly created and references to dds::core::null.
-     * @throws dds::core::AlreadyClosedError
-     *                  The entity has already been closed.
-     * @throws dds::core::OutOfResourcesError
-     *                  The Data Distribution Service ran out of resources to
-     *                  complete this operation.
-     * @throws dds::core::NotEnabledError
-     *                  The DataReader has not yet been enabled.
-     */
+    /// This operation reads a sequence of typed samples from the DataReader.
+    ///
+    /// What samples are read depends on what @link dds::sub::DataReader::default_filter_state(const dds::sub::status::DataState& state)
+    /// default state filter @endlink has been set (default any).
+    ///
+    /// The samples are copied into the application provided container using a
+    /// back-inserting iterator. Notice that as a consequence of using a back-inserting
+    /// iterator, this operation may allocate memory to resize the underlying container.
+    ///
+    /// If the DataReader has no samples that meet the constraints, the resulting
+    /// dds::sub::LoanedSamples will be empty.
+    /// @code{.cpp}
+    /// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+    /// dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
+    /// dds::sub::Subscriber subscriber(participant);
+    /// dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
+    ///
+    /// // Prepare container to store samples in
+    /// std::vector<dds::sub::Sample<Foo::Bar> > samples;
+    /// std::back_insert_iterator< std::vector<dds::sub::Sample<Foo::Bar> > > bi(samples);
+    ///
+    /// // Read and copy the available samples into the vector by means of the iterator
+    /// uint32_t len =  reader.read(bi);
+    ///
+    /// // Access the information.
+    /// std::vector<dds::sub::Sample<Space::Type1> >::iterator iter = samples.begin();
+    /// for (iter = samples.begin(); iter != samples.end(); ++iter) {
+    ///     const dds::sub::Sample<Foo::Bar>& sample = *iter;
+    /// }
+    /// @endcode
+    ///
+    /// <b><i>Selectors</i></b><br>
+    /// What data is read already depends on the
+    /// @ref anchor_dds_sub_datareader_defaultstatefilter "default state filter".
+    /// But it can be manipulated even more when using dds::sub::DataReader::select()
+    /// operation.
+    ///
+    /// <b><i>Invalid Data</i></b><br>
+    /// Some elements in the returned sequence may not have valid data: the valid_data
+    /// field in the SampleInfo indicates whether the corresponding data value contains
+    /// any meaningful data.<br>
+    /// Look @ref anchor_dds_sub_datareader_invalidsamples "here" for more information.
+    ///
+    /// @param  sbit     Back-inserting container iterator
+    /// @return          The number of samples in the given container
+    /// @throws dds::core::Error
+    ///                  An internal error has occurred.
+    /// @throws dds::core::NullReferenceError
+    ///                  The entity was not properly created and references to dds::core::null.
+    /// @throws dds::core::AlreadyClosedError
+    ///                  The entity has already been closed.
+    /// @throws dds::core::OutOfResourcesError
+    ///                  The Data Distribution Service ran out of resources to
+    ///                  complete this operation.
+    /// @throws dds::core::NotEnabledError
+    ///                  The DataReader has not yet been enabled.
     template <typename SamplesBIIterator>
     uint32_t
     read(SamplesBIIterator sbit);
 
-    /**
-     * This operation takes a sequence of typed samples from the DataReader.
-     *
-     * What samples are take depends on what @link dds::sub::DataReader::default_filter_state(const dds::sub::status::DataState& state)
-     * default state filter @endlink has been set (default any).
-     *
-     * The samples are copied into the application provided container using a
-     * back-inserting iterator. Notice that as a consequence of using a back-inserting
-     * iterator, this operation may allocate memory to resize the underlying container.
-     *
-     * If the DataReader has no samples that meet the constraints, the resulting
-     * dds::sub::LoanedSamples will be empty.
-     * @code{.cpp}
-     * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
-     * dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
-     * dds::sub::Subscriber subscriber(participant);
-     * dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
-     *
-     * // Prepare container to store samples in
-     * std::vector<dds::sub::Sample<Foo::Bar> > samples;
-     * std::back_insert_iterator< std::vector<dds::sub::Sample<Foo::Bar> > > bi(samples);
-     *
-     * // Take and copy the available samples into the vector by means of the iterator
-     * uint32_t len =  reader.take(bi);
-     *
-     * // Access the information.
-     * std::vector<dds::sub::Sample<Space::Type1> >::iterator iter = samples.begin();
-     * for (iter = samples.begin(); iter != samples.end(); ++iter) {
-     *     const dds::sub::Sample<Foo::Bar>& sample = *iter;
-     * }
-     * @endcode
-     *
-     * <b><i>Selectors</i></b><br>
-     * What data is taken, already depends on the
-     * @ref anchor_dds_sub_datareader_defaultstatefilter "default state filter".
-     * But it can be manipulated even more when using dds::sub::DataReader::select()
-     * operation.
-     *
-     * <b><i>Invalid Data</i></b><br>
-     * Some elements in the returned sequence may not have valid data: the valid_data
-     * field in the SampleInfo indicates whether the corresponding data value contains
-     * any meaningful data.<br>
-     * Look @ref anchor_dds_sub_datareader_invalidsamples "here" for more information.
-     *
-     * @param  sbit     Back-inserting container iterator
-     * @return          The number of samples in the given container
-     * @throws dds::core::Error
-     *                  An internal error has occurred.
-     * @throws dds::core::NullReferenceError
-     *                  The entity was not properly created and references to dds::core::null.
-     * @throws dds::core::AlreadyClosedError
-     *                  The entity has already been closed.
-     * @throws dds::core::OutOfResourcesError
-     *                  The Data Distribution Service ran out of resources to
-     *                  complete this operation.
-     * @throws dds::core::NotEnabledError
-     *                  The DataReader has not yet been enabled.
-     */
+    /// This operation takes a sequence of typed samples from the DataReader.
+    ///
+    /// What samples are take depends on what @link dds::sub::DataReader::default_filter_state(const dds::sub::status::DataState& state)
+    /// default state filter @endlink has been set (default any).
+    ///
+    /// The samples are copied into the application provided container using a
+    /// back-inserting iterator. Notice that as a consequence of using a back-inserting
+    /// iterator, this operation may allocate memory to resize the underlying container.
+    ///
+    /// If the DataReader has no samples that meet the constraints, the resulting
+    /// dds::sub::LoanedSamples will be empty.
+    /// @code{.cpp}
+    /// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+    /// dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
+    /// dds::sub::Subscriber subscriber(participant);
+    /// dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
+    ///
+    /// // Prepare container to store samples in
+    /// std::vector<dds::sub::Sample<Foo::Bar> > samples;
+    /// std::back_insert_iterator< std::vector<dds::sub::Sample<Foo::Bar> > > bi(samples);
+    ///
+    /// // Take and copy the available samples into the vector by means of the iterator
+    /// uint32_t len =  reader.take(bi);
+    ///
+    /// // Access the information.
+    /// std::vector<dds::sub::Sample<Space::Type1> >::iterator iter = samples.begin();
+    /// for (iter = samples.begin(); iter != samples.end(); ++iter) {
+    ///     const dds::sub::Sample<Foo::Bar>& sample = *iter;
+    /// }
+    /// @endcode
+    ///
+    /// <b><i>Selectors</i></b><br>
+    /// What data is taken, already depends on the
+    /// @ref anchor_dds_sub_datareader_defaultstatefilter "default state filter".
+    /// But it can be manipulated even more when using dds::sub::DataReader::select()
+    /// operation.
+    ///
+    /// <b><i>Invalid Data</i></b><br>
+    /// Some elements in the returned sequence may not have valid data: the valid_data
+    /// field in the SampleInfo indicates whether the corresponding data value contains
+    /// any meaningful data.<br>
+    /// Look @ref anchor_dds_sub_datareader_invalidsamples "here" for more information.
+    ///
+    /// @param  sbit     Back-inserting container iterator
+    /// @return          The number of samples in the given container
+    /// @throws dds::core::Error
+    ///                  An internal error has occurred.
+    /// @throws dds::core::NullReferenceError
+    ///                  The entity was not properly created and references to dds::core::null.
+    /// @throws dds::core::AlreadyClosedError
+    ///                  The entity has already been closed.
+    /// @throws dds::core::OutOfResourcesError
+    ///                  The Data Distribution Service ran out of resources to
+    ///                  complete this operation.
+    /// @throws dds::core::NotEnabledError
+    ///                  The DataReader has not yet been enabled.
     template <typename SamplesBIIterator>
     uint32_t
     take(SamplesBIIterator sbit);
@@ -1435,56 +1389,54 @@ public:
     //========================================================================
     //== DSL Method for dealing with instances, content and status filters.
 
-    /**
-     * Get a dds::sub::DataReader::Selector instance that acts on this DataReader.
-     *
-     * The DataReader::read and DataReader::take read all samples that are
-     * available within the DataReader (provided that the
-     * @ref anchor_dds_sub_datareader_defaultstatefilter "default state filter"
-     * hasn't been changed).
-     *
-     * <b><i>Selectors</i></b><br>
-     * A Selector can perform complex data selections, such as per-instance selection,
-     * content and status filtering, etc when reading or taking. Such a selector is
-     * returned by this operation. Setting filters on the Selector can be concatenated,
-     * resulting in the following example code.
-     * @code{.cpp}
-     * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
-     * dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
-     * dds::sub::Subscriber subscriber(participant);
-     * dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
-     *
-     * // Take a maximum of 3 new samples of a certain instance.
-     * {
-     *     dds::sub::LoanedSamples<Foo::Bar> samples;
-     *     samples = reader.select()
-     *                         .max_samples(3)
-     *                         .state(dds::sub::status::DataState::new_data())
-     *                         .instance(someValidInstanceHandle)
-     *                         .take();
-     * }
-     * @endcode
-     *
-     * <i>Please be aware that using pre-set filters on the DataReader and then
-     * call read() or take() on that reader explicitly will perform better than
-     * having to create Selectors for every read (which is what essentially
-     * happens in the code example above). Performance can be increase by creating
-     * a selector up front and using that multiple times
-     * (see dds::sub::DataReader::Selector).</i>
-     *
-     * @return          A Selector that acts on the DataReader
-     * @throws dds::core::Error
-     *                  An internal error has occurred.
-     * @throws dds::core::NullReferenceError
-     *                  The entity was not properly created and references to dds::core::null.
-     * @throws dds::core::AlreadyClosedError
-     *                  The entity has already been closed.
-     * @throws dds::core::OutOfResourcesError
-     *                  The Data Distribution Service ran out of resources to
-     *                  complete this operation.
-     * @throws dds::core::NotEnabledError
-     *                  The DataReader has not yet been enabled.
-     */
+    /// Get a dds::sub::DataReader::Selector instance that acts on this DataReader.
+    ///
+    /// The DataReader::read and DataReader::take read all samples that are
+    /// available within the DataReader (provided that the
+    /// @ref anchor_dds_sub_datareader_defaultstatefilter "default state filter"
+    /// hasn't been changed).
+    ///
+    /// <b><i>Selectors</i></b><br>
+    /// A Selector can perform complex data selections, such as per-instance selection,
+    /// content and status filtering, etc when reading or taking. Such a selector is
+    /// returned by this operation. Setting filters on the Selector can be concatenated,
+    /// resulting in the following example code.
+    /// @code{.cpp}
+    /// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+    /// dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
+    /// dds::sub::Subscriber subscriber(participant);
+    /// dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
+    ///
+    /// // Take a maximum of 3 new samples of a certain instance.
+    /// {
+    ///     dds::sub::LoanedSamples<Foo::Bar> samples;
+    ///     samples = reader.select()
+    ///                         .max_samples(3)
+    ///                         .state(dds::sub::status::DataState::new_data())
+    ///                         .instance(someValidInstanceHandle)
+    ///                         .take();
+    /// }
+    /// @endcode
+    ///
+    /// <i>Please be aware that using pre-set filters on the DataReader and then
+    /// call read() or take() on that reader explicitly will perform better than
+    /// having to create Selectors for every read (which is what essentially
+    /// happens in the code example above). Performance can be increase by creating
+    /// a selector up front and using that multiple times
+    /// (see dds::sub::DataReader::Selector).</i>
+    ///
+    /// @return          A Selector that acts on the DataReader
+    /// @throws dds::core::Error
+    ///                  An internal error has occurred.
+    /// @throws dds::core::NullReferenceError
+    ///                  The entity was not properly created and references to dds::core::null.
+    /// @throws dds::core::AlreadyClosedError
+    ///                  The entity has already been closed.
+    /// @throws dds::core::OutOfResourcesError
+    ///                  The Data Distribution Service ran out of resources to
+    ///                  complete this operation.
+    /// @throws dds::core::NotEnabledError
+    ///                  The DataReader has not yet been enabled.
     Selector select();
 
     //========================================================================

--- a/src/ddscxx/include/dds/sub/TGenerationCount.hpp
+++ b/src/ddscxx/include/dds/sub/TGenerationCount.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef OMG_DDS_SUB_T_GENERATION_COUNT_HPP_
 #define OMG_DDS_SUB_T_GENERATION_COUNT_HPP_
 

--- a/src/ddscxx/include/dds/sub/TQuery.hpp
+++ b/src/ddscxx/include/dds/sub/TQuery.hpp
@@ -1,23 +1,22 @@
 #ifndef DDS_CORE_TQUERY_HPP_
 #define DDS_CORE_TQUERY_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/types.hpp>
 #include <dds/core/Reference.hpp>

--- a/src/ddscxx/include/dds/sub/TRank.hpp
+++ b/src/ddscxx/include/dds/sub/TRank.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef OMG_DDS_SUB_TRANK_HPP_
 #define OMG_DDS_SUB_TRANK_HPP_
 

--- a/src/ddscxx/include/dds/sub/TSample.hpp
+++ b/src/ddscxx/include/dds/sub/TSample.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_TSAMPLE_HPP_
 #define OMG_DDS_SUB_TSAMPLE_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/Value.hpp>
 #include <dds/sub/SampleInfo.hpp>

--- a/src/ddscxx/include/dds/sub/TSample.hpp
+++ b/src/ddscxx/include/dds/sub/TSample.hpp
@@ -30,37 +30,35 @@ class Sample;
 }
 }
 
-/**
- * @brief
- * This class encapsulates the data and info meta-data associated with
- * DDS samples.
- *
- * It is normally used with dds::sub::LoanedSamples:
- * @code{.cpp}
- * dds::sub::LoanedSamples<Foo::Bar> samples = reader.read();
- * dds::sub::LoanedSamples<Foo::Bar>::const_iterator it;
- * for (it = samples.begin(); it != samples.end(); ++it) {
- *     const dds::sub::Sample<Foo::Bar>& sample = *it;
- *     const Foo::Bar& data = sample.data();
- *     const dds::sub::SampleInfo& info = sample.info();
- *     // Use sample data and meta information.
- * }
- * @endcode
- * Or more implicitly:
- * @code{.cpp}
- * dds::sub::LoanedSamples<Foo::Bar> samples = reader.read();
- * dds::sub::LoanedSamples<Foo::Bar>::const_iterator it;
- * for (it = samples.begin(); it != samples.end(); ++it) {
- *     const Foo::Bar& data = it->data();
- *     const dds::sub::SampleInfo& info = it->info();
- *     // Use sample data and meta information.
- * }
- * @endcode
- *
- * @see for more information: @ref DCPS_Modules_Subscription_DataSample "DataSample"
- * @see for more information: @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo"
- * @see for more information: @ref DCPS_Modules_Subscription "Subscription"
- */
+/// @brief
+/// This class encapsulates the data and info meta-data associated with
+/// DDS samples.
+///
+/// It is normally used with dds::sub::LoanedSamples:
+/// @code{.cpp}
+/// dds::sub::LoanedSamples<Foo::Bar> samples = reader.read();
+/// dds::sub::LoanedSamples<Foo::Bar>::const_iterator it;
+/// for (it = samples.begin(); it != samples.end(); ++it) {
+///     const dds::sub::Sample<Foo::Bar>& sample = *it;
+///     const Foo::Bar& data = sample.data();
+///     const dds::sub::SampleInfo& info = sample.info();
+///     // Use sample data and meta information.
+/// }
+/// @endcode
+/// Or more implicitly:
+/// @code{.cpp}
+/// dds::sub::LoanedSamples<Foo::Bar> samples = reader.read();
+/// dds::sub::LoanedSamples<Foo::Bar>::const_iterator it;
+/// for (it = samples.begin(); it != samples.end(); ++it) {
+///     const Foo::Bar& data = it->data();
+///     const dds::sub::SampleInfo& info = it->info();
+///     // Use sample data and meta information.
+/// }
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Modules_Subscription_DataSample "DataSample"
+/// @see for more information: @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo"
+/// @see for more information: @ref DCPS_Modules_Subscription "Subscription"
 template <typename T, template <typename Q> class DELEGATE>
 class dds::sub::Sample : public dds::core::Value< DELEGATE<T> >
 {

--- a/src/ddscxx/include/dds/sub/TSampleInfo.hpp
+++ b/src/ddscxx/include/dds/sub/TSampleInfo.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef OMG_DDS_SUB_TSAMPLE_INFO_HPP_
 #define OMG_DDS_SUB_TSAMPLE_INFO_HPP_
 

--- a/src/ddscxx/include/dds/sub/TSampleRef.hpp
+++ b/src/ddscxx/include/dds/sub/TSampleRef.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_TSAMPLEREF_HPP_
 #define OMG_DDS_SUB_TSAMPLEREF_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/Value.hpp>
 #include <dds/sub/SampleInfo.hpp>

--- a/src/ddscxx/include/dds/sub/TSampleRef.hpp
+++ b/src/ddscxx/include/dds/sub/TSampleRef.hpp
@@ -30,37 +30,35 @@ class SampleRef;
 }
 }
 
-/**
- * @brief
- * This class encapsulates a reference to the data and info meta-data
- * associated with DDS samples.
- *
- * It is normally used with dds::sub::LoanedSamples:
- * @code{.cpp}
- * dds::sub::LoanedSamples<Foo::Bar> samples = reader.read();
- * dds::sub::LoanedSamples<Foo::Bar>::const_iterator it;
- * for (it = samples.begin(); it != samples.end(); ++it) {
- *     const dds::sub::Sample<Foo::Bar>& sample = *it;
- *     const Foo::Bar& data = sample.data();
- *     const dds::sub::SampleInfo& info = sample.info();
- *     // Use sample data and meta information.
- * }
- * @endcode
- * Or more implicitly:
- * @code{.cpp}
- * dds::sub::LoanedSamples<Foo::Bar> samples = reader.read();
- * dds::sub::LoanedSamples<Foo::Bar>::const_iterator it;
- * for (it = samples.begin(); it != samples.end(); ++it) {
- *     const Foo::Bar& data = it->data();
- *     const dds::sub::SampleInfo& info = it->info();
- *     // Use sample data and meta information.
- * }
- * @endcode
- *
- * @see for more information: @ref DCPS_Modules_Subscription_DataSample "DataSample"
- * @see for more information: @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo"
- * @see for more information: @ref DCPS_Modules_Subscription "Subscription"
- */
+/// @brief
+/// This class encapsulates a reference to the data and info meta-data
+/// associated with DDS samples.
+///
+/// It is normally used with dds::sub::LoanedSamples:
+/// @code{.cpp}
+/// dds::sub::LoanedSamples<Foo::Bar> samples = reader.read();
+/// dds::sub::LoanedSamples<Foo::Bar>::const_iterator it;
+/// for (it = samples.begin(); it != samples.end(); ++it) {
+///     const dds::sub::Sample<Foo::Bar>& sample = *it;
+///     const Foo::Bar& data = sample.data();
+///     const dds::sub::SampleInfo& info = sample.info();
+///     // Use sample data and meta information.
+/// }
+/// @endcode
+/// Or more implicitly:
+/// @code{.cpp}
+/// dds::sub::LoanedSamples<Foo::Bar> samples = reader.read();
+/// dds::sub::LoanedSamples<Foo::Bar>::const_iterator it;
+/// for (it = samples.begin(); it != samples.end(); ++it) {
+///     const Foo::Bar& data = it->data();
+///     const dds::sub::SampleInfo& info = it->info();
+///     // Use sample data and meta information.
+/// }
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Modules_Subscription_DataSample "DataSample"
+/// @see for more information: @ref DCPS_Modules_Subscription_SampleInfo "SampleInfo"
+/// @see for more information: @ref DCPS_Modules_Subscription "Subscription"
 template <typename T, template <typename Q> class DELEGATE>
 class dds::sub::SampleRef : public dds::core::Value< DELEGATE<T> >
 {

--- a/src/ddscxx/include/dds/sub/TSubscriber.hpp
+++ b/src/ddscxx/include/dds/sub/TSubscriber.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_TDDS_SUB_SUBSCRIBER_HPP_
 #define OMG_TDDS_SUB_SUBSCRIBER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/TEntity.hpp>
 #include <dds/domain/DomainParticipant.hpp>

--- a/src/ddscxx/include/dds/sub/cond/QueryCondition.hpp
+++ b/src/ddscxx/include/dds/sub/cond/QueryCondition.hpp
@@ -2,23 +2,22 @@
 #define OMG_DDS_SUB_COND_QUERY_CONDITION_HPP_
 
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/sub/cond/detail/QueryCondition.hpp>
 #include <dds/sub/Query.hpp>

--- a/src/ddscxx/include/dds/sub/cond/ReadCondition.hpp
+++ b/src/ddscxx/include/dds/sub/cond/ReadCondition.hpp
@@ -2,23 +2,22 @@
 #define OMG_DDS_SUB_COND_READ_CONDITION_HPP_
 
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/sub/cond/detail/ReadCondition.hpp>
 #include <dds/sub/cond/detail/TReadConditionImpl.hpp>

--- a/src/ddscxx/include/dds/sub/cond/TQueryCondition.hpp
+++ b/src/ddscxx/include/dds/sub/cond/TQueryCondition.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_TQUERY_CONDITION_HPP_
 #define OMG_DDS_SUB_TQUERY_CONDITION_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/detail/conformance.hpp>
 #include <dds/sub/cond/detail/QueryCondition.hpp>

--- a/src/ddscxx/include/dds/sub/cond/TReadCondition.hpp
+++ b/src/ddscxx/include/dds/sub/cond/TReadCondition.hpp
@@ -2,23 +2,22 @@
 #define OMG_DDS_SUB_TCOND_READ_CONDITION_HPP_
 
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/cond/TCondition.hpp>
 #include <dds/sub/DataReader.hpp>

--- a/src/ddscxx/include/dds/sub/cond/detail/QueryCondition.hpp
+++ b/src/ddscxx/include/dds/sub/cond/detail/QueryCondition.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_DETAIL_QUERY_CONDITION_HPP_
 #define OMG_DDS_SUB_DETAIL_QUERY_CONDITION_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace org
 {

--- a/src/ddscxx/include/dds/sub/cond/detail/ReadCondition.hpp
+++ b/src/ddscxx/include/dds/sub/cond/detail/ReadCondition.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef OMG_DDS_SUB_DETAIL_READ_CONDITION_HPP_
 #define OMG_DDS_SUB_DETAIL_READ_CONDITION_HPP_
 

--- a/src/ddscxx/include/dds/sub/cond/detail/TQueryConditionImpl.hpp
+++ b/src/ddscxx/include/dds/sub/cond/detail/TQueryConditionImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_SUB_COND_TQUERYCONDITION_IMPL_HPP_
 #define CYCLONEDDS_DDS_SUB_COND_TQUERYCONDITION_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/sub/cond/detail/TReadConditionImpl.hpp
+++ b/src/ddscxx/include/dds/sub/cond/detail/TReadConditionImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_CORE_COND_TREADCONDITION_IMPL_HPP_
 #define CYCLONEDDS_DDS_CORE_COND_TREADCONDITION_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/sub/ddssub.hpp
+++ b/src/ddscxx/include/dds/sub/ddssub.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_PACKAGE_INCLUDE_HPP_
 #define OMG_DDS_SUB_PACKAGE_INCLUDE_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/detail/conformance.hpp>
 

--- a/src/ddscxx/include/dds/sub/detail/AnyDataReader.hpp
+++ b/src/ddscxx/include/dds/sub/detail/AnyDataReader.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_SUB_DETAIL_ANYDATAREADER_HPP_
 #define CYCLONEDDS_DDS_SUB_DETAIL_ANYDATAREADER_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/CoherentAccess.hpp
+++ b/src/ddscxx/include/dds/sub/detail/CoherentAccess.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef OMG_DDS_SUB_DETAIL_COHERENT_ACCESS_HPP_
 #define OMG_DDS_SUB_DETAIL_COHERENT_ACCESS_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/DataReader.hpp
+++ b/src/ddscxx/include/dds/sub/detail/DataReader.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef OMG_DDS_SUB_DETAIL_DATA_READER_HPP_
 #define OMG_DDS_SUB_DETAIL_DATA_READER_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/GenerationCount.hpp
+++ b/src/ddscxx/include/dds/sub/detail/GenerationCount.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef OMG_DDS_SUB_DETAIL_GENERATION_COUNT_HPP_
 #define OMG_DDS_SUB_DETAIL_GENERATION_COUNT_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/LoanedSamples.hpp
+++ b/src/ddscxx/include/dds/sub/detail/LoanedSamples.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef OMG_SUB_DETAIL_LOANED_SAMPLES_IMPL_HPP_
 #define OMG_SUB_DETAIL_LOANED_SAMPLES_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/LoanedSamplesImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/LoanedSamplesImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_SUB_DETAIL_LOANED_SAMPLES_IMPL_HPP_
 #define CYCLONEDDS_DDS_SUB_DETAIL_LOANED_SAMPLES_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/Manipulators.hpp
+++ b/src/ddscxx/include/dds/sub/detail/Manipulators.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_SUB_DETAIL_MANIPULATOR_HPP_
 #define CYCLONEDDS_DDS_SUB_DETAIL_MANIPULATOR_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/Query.hpp
+++ b/src/ddscxx/include/dds/sub/detail/Query.hpp
@@ -1,14 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 #ifndef DDS_SUB_DETAIL_QUERY_HPP_
 #define DDS_SUB_DETAIL_QUERY_HPP_

--- a/src/ddscxx/include/dds/sub/detail/Rank.hpp
+++ b/src/ddscxx/include/dds/sub/detail/Rank.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef OMG_DDS_SUB_DETAIL_RANK_HPP
 #define OMG_DDS_SUB_DETAIL_RANK_HPP
 

--- a/src/ddscxx/include/dds/sub/detail/Sample.hpp
+++ b/src/ddscxx/include/dds/sub/detail/Sample.hpp
@@ -1,24 +1,22 @@
 #ifndef OMG_DDS_PUB_DETAIL_SAMPLE_HPP_
 #define OMG_DDS_PUB_DETAIL_SAMPLE_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace dds
 {

--- a/src/ddscxx/include/dds/sub/detail/SampleInfo.hpp
+++ b/src/ddscxx/include/dds/sub/detail/SampleInfo.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef OMG_DDS_SUB_DETAIL_SAMPLE_INFO_HPP_
 #define OMG_DDS_SUB_DETAIL_SAMPLE_INFO_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/SampleRef.hpp
+++ b/src/ddscxx/include/dds/sub/detail/SampleRef.hpp
@@ -1,24 +1,22 @@
 #ifndef OMG_DDS_PUB_DETAIL_SAMPLEREF_HPP_
 #define OMG_DDS_PUB_DETAIL_SAMPLEREF_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace dds
 {

--- a/src/ddscxx/include/dds/sub/detail/SamplesHolder.hpp
+++ b/src/ddscxx/include/dds/sub/detail/SamplesHolder.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_SUB_DETAIL_SAMPLES_HOLDER_HPP_
 #define CYCLONEDDS_DDS_SUB_DETAIL_SAMPLES_HOLDER_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/SharedSamples.hpp
+++ b/src/ddscxx/include/dds/sub/detail/SharedSamples.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_SUB_DETAIL_SHARED_SAMPLES_HPP_
 #define CYCLONEDDS_DDS_SUB_DETAIL_SHARED_SAMPLES_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/SharedSamplesImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/SharedSamplesImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_SUB_SHARED_SAMPLES_IMPL_HPP_
 #define CYCLONEDDS_DDS_SUB_SHARED_SAMPLES_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/Subscriber.hpp
+++ b/src/ddscxx/include/dds/sub/detail/Subscriber.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_DETAIL_SUBSCRIBER_HPP_
 #define OMG_DDS_SUB_DETAIL_SUBSCRIBER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/sub/detail/TSubscriberImpl.hpp>
 #include <org/eclipse/cyclonedds/sub/SubscriberDelegate.hpp>

--- a/src/ddscxx/include/dds/sub/detail/TAnyDataReaderImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TAnyDataReaderImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef OMG_DDS_SUB_DETAIL_TANYDATAREADER_HPP_
 #define OMG_DDS_SUB_DETAIL_TANYDATAREADER_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/TCoherentAccessImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TCoherentAccessImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_SUB_TCOHERENTACCESS_IMPL_HPP_
 #define CYCLONEDDS_DDS_SUB_TCOHERENTACCESS_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_SUB_TDATAREADER_IMPL_HPP_
 #define CYCLONEDDS_DDS_SUB_TDATAREADER_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/TGenerationCountImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TGenerationCountImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_SUB_DETAIL_TGENERATIONCOUNT_IMPL_HPP_
 #define CYCLONEDDS_DDS_SUB_DETAIL_TGENERATIONCOUNT_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/TQueryImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TQueryImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_SUB_DETAIL_QUERY_IMPL_HPP_
 #define CYCLONEDDS_DDS_SUB_DETAIL_QUERY_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/TRankImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TRankImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_SUB_DETAIL_TRANK_IMPL_HPP_
 #define CYCLONEDDS_DDS_SUB_DETAIL_TRANK_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/TSampleImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TSampleImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_SUB_TSAMPLE_HPP_
 #define CYCLONEDDS_DDS_SUB_TSAMPLE_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/TSampleInfoImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TSampleInfoImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_SUB_DETAIL_TSAMPLEINFO_IMPL_HPP_
 #define CYCLONEDDS_DDS_SUB_DETAIL_TSAMPLEINFO_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/TSampleRefImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TSampleRefImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_SUB_TSAMPLEREF_HPP_
 #define CYCLONEDDS_DDS_SUB_TSAMPLEREF_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/TSubscriberImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TSubscriberImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_SUB_TSUBSCRIBER_IMPL_HPP_
 #define CYCLONEDDS_DDS_SUB_TSUBSCRIBER_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/ddssub.hpp
+++ b/src/ddscxx/include/dds/sub/detail/ddssub.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef OMG_DDS_SUB_PACKAGE_DETAIL_INCLUDE_HPP_
 #define OMG_DDS_SUB_PACKAGE_DETAIL_INCLUDE_HPP_
 

--- a/src/ddscxx/include/dds/sub/detail/discovery.hpp
+++ b/src/ddscxx/include/dds/sub/detail/discovery.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/dds/sub/detail/find.hpp
+++ b/src/ddscxx/include/dds/sub/detail/find.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_SUB_DETAIL_FIND_HPP_
 #define CYCLONEDDS_DDS_SUB_DETAIL_FIND_HPP_
 

--- a/src/ddscxx/include/dds/sub/discovery.hpp
+++ b/src/ddscxx/include/dds/sub/discovery.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_DISCOVERY_HPP_
 #define OMG_DDS_SUB_DISCOVERY_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/domain/DomainParticipant.hpp>
 #include <dds/sub/DataReader.hpp>

--- a/src/ddscxx/include/dds/sub/find.hpp
+++ b/src/ddscxx/include/dds/sub/find.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_FIND_HPP_
 #define OMG_DDS_SUB_FIND_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <string>
 

--- a/src/ddscxx/include/dds/sub/qos/DataReaderQos.hpp
+++ b/src/ddscxx/include/dds/sub/qos/DataReaderQos.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef OMG_DDS_SUB_QOS_DATA_READER_QOS_HPP_
 #define OMG_DDS_SUB_QOS_DATA_READER_QOS_HPP_
 

--- a/src/ddscxx/include/dds/sub/qos/SubscriberQos.hpp
+++ b/src/ddscxx/include/dds/sub/qos/SubscriberQos.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_QOS_SUBSCRIBER_QOS_HPP_
 #define OMG_DDS_SUB_QOS_SUBSCRIBER_QOS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/sub/qos/detail/SubscriberQos.hpp>
 

--- a/src/ddscxx/include/dds/sub/qos/detail/DataReaderQos.hpp
+++ b/src/ddscxx/include/dds/sub/qos/detail/DataReaderQos.hpp
@@ -79,62 +79,58 @@ public:
      */
     DataReaderQos(const DataReaderQos& qos);
 
-    /**
-     * Create a DataReader QoS from a TopicQos.
-     *
-     * This operation will copy the QosPolicy settings from the TopicQos to the
-     * corresponding QosPolicy settings in the DataReaderQos. The related value
-     * in DataReaderQos will be repliced, while the other policies will get the
-     * @ref anchor_dds_sub_datareader_qos_defaults "default" QoS policies.
-     *
-     * This is a "convenience" operation. It can be used to merge
-     * @ref anchor_dds_sub_datareader_qos_defaults "default" DataReader
-     * QosPolicy settings with the corresponding ones on the Topic. The resulting
-     * DataReaderQos can then be used to create a new DataReader, or set its
-     * DataReaderQos.
-     * @code{.cpp}
-     * dds::topic::qos::TopicQos topicQos = topic.qos();
-     * dds::sub::qos::DataReaderQos readerQos(topicQos);
-     * // Policies of the DataReaderQos that are not present in the TopicQos
-     * // have the default value.
-     * @endcode
-     *
-     * This operation does not check the resulting DataReaderQos for self
-     * consistency. This is because the "merged" DataReaderQos may not be the
-     * final one, as the application can still modify some QosPolicy settings prior to
-     * applying the DataReaderQos to the DataReader.
-     *
-     * @param qos the QoS to copy policies from.
-     */
+    /// Create a DataReader QoS from a TopicQos.
+    ///
+    /// This operation will copy the QosPolicy settings from the TopicQos to the
+    /// corresponding QosPolicy settings in the DataReaderQos. The related value
+    /// in DataReaderQos will be repliced, while the other policies will get the
+    /// @ref anchor_dds_sub_datareader_qos_defaults "default" QoS policies.
+    ///
+    /// This is a "convenience" operation. It can be used to merge
+    /// @ref anchor_dds_sub_datareader_qos_defaults "default" DataReader
+    /// QosPolicy settings with the corresponding ones on the Topic. The resulting
+    /// DataReaderQos can then be used to create a new DataReader, or set its
+    /// DataReaderQos.
+    /// @code{.cpp}
+    /// dds::topic::qos::TopicQos topicQos = topic.qos();
+    /// dds::sub::qos::DataReaderQos readerQos(topicQos);
+    /// // Policies of the DataReaderQos that are not present in the TopicQos
+    /// // have the default value.
+    /// @endcode
+    ///
+    /// This operation does not check the resulting DataReaderQos for self
+    /// consistency. This is because the "merged" DataReaderQos may not be the
+    /// final one, as the application can still modify some QosPolicy settings prior to
+    /// applying the DataReaderQos to the DataReader.
+    ///
+    /// @param qos the QoS to copy policies from.
     DataReaderQos(const dds::topic::qos::TopicQos& qos);
 
-    /**
-     * Assign dds::topic::qos::TopicQos policies to the DataReaderQos.
-     *
-     * This operation will copy the QosPolicy settings from the TopicQos to the
-     * corresponding QosPolicy settings in the DataReaderQos (replacing the values,
-     * if present).
-     *
-     * This is a "convenience" operation, useful in combination with the operations
-     * Subscriber::default_datareader_qos() and dds::topic::Topic::qos().
-     * This operation can be used to merge the DataReader
-     * QosPolicy settings with the corresponding ones on the Topic. The resulting
-     * DataReaderQos can then be used to create a new DataReader, or set its
-     * DataReaderQos.
-     * @code{.cpp}
-     * dds::topic::qos::TopicQos topicQos = topic.qos();
-     * dds::sub::qos::DataReaderQos readerQos = subscriber.default_datareader_qos();
-     * readerQos = topicQos;
-     * // Policies of the DataReaderQos that are not present in the TopicQos are untouched.
-     * @endcode
-     *
-     * This operation does not check the resulting DataReaderQos for self
-     * consistency. This is because the "merged" DataReaderQos may not be the
-     * final one, as the application can still modify some QosPolicy settings prior to
-     * applying the DataReaderQos to the DataReader.
-     *
-     * @param qos the QoS to copy policies from.
-     */
+    /// Assign dds::topic::qos::TopicQos policies to the DataReaderQos.
+    ///
+    /// This operation will copy the QosPolicy settings from the TopicQos to the
+    /// corresponding QosPolicy settings in the DataReaderQos (replacing the values,
+    /// if present).
+    ///
+    /// This is a "convenience" operation, useful in combination with the operations
+    /// Subscriber::default_datareader_qos() and dds::topic::Topic::qos().
+    /// This operation can be used to merge the DataReader
+    /// QosPolicy settings with the corresponding ones on the Topic. The resulting
+    /// DataReaderQos can then be used to create a new DataReader, or set its
+    /// DataReaderQos.
+    /// @code{.cpp}
+    /// dds::topic::qos::TopicQos topicQos = topic.qos();
+    /// dds::sub::qos::DataReaderQos readerQos = subscriber.default_datareader_qos();
+    /// readerQos = topicQos;
+    /// // Policies of the DataReaderQos that are not present in the TopicQos are untouched.
+    /// @endcode
+    ///
+    /// This operation does not check the resulting DataReaderQos for self
+    /// consistency. This is because the "merged" DataReaderQos may not be the
+    /// final one, as the application can still modify some QosPolicy settings prior to
+    /// applying the DataReaderQos to the DataReader.
+    ///
+    /// @param qos the QoS to copy policies from.
     DataReaderQos& operator= (const dds::topic::qos::TopicQos& other);
 };
 

--- a/src/ddscxx/include/dds/sub/qos/detail/DataReaderQos.hpp
+++ b/src/ddscxx/include/dds/sub/qos/detail/DataReaderQos.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_QOS_DETAIL_DATA_READER_QOS_HPP_
 #define OMG_DDS_SUB_QOS_DETAIL_DATA_READER_QOS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/detail/TEntityQosImpl.hpp>
 #include <org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.hpp>

--- a/src/ddscxx/include/dds/sub/qos/detail/SubscriberQos.hpp
+++ b/src/ddscxx/include/dds/sub/qos/detail/SubscriberQos.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_QOS_DETAIL_SUBSCRIBER_QOS_HPP_
 #define OMG_DDS_SUB_QOS_DETAIL_SUBSCRIBER_QOS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/detail/TEntityQosImpl.hpp>
 #include <org/eclipse/cyclonedds/sub/qos/SubscriberQosDelegate.hpp>

--- a/src/ddscxx/include/dds/sub/status/DataState.hpp
+++ b/src/ddscxx/include/dds/sub/status/DataState.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_SUB_DATA_STATE_HPP_
 #define OMG_DDS_SUB_DATA_STATE_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <bitset>
 

--- a/src/ddscxx/include/dds/sub/status/detail/DataStateImpl.hpp
+++ b/src/ddscxx/include/dds/sub/status/detail/DataStateImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_SUB_STATUS_DATASTATE_IMPL_HPP_
 #define CYCLONEDDS_DDS_SUB_STATUS_DATASTATE_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/topic/AnyTopic.hpp
+++ b/src/ddscxx/include/dds/topic/AnyTopic.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TOPIC_ANY_TOPIC_HPP_
 #define OMG_DDS_TOPIC_ANY_TOPIC_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Inc.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Inc.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/topic/detail/AnyTopic.hpp>
 

--- a/src/ddscxx/include/dds/topic/AnyTopicListener.hpp
+++ b/src/ddscxx/include/dds/topic/AnyTopicListener.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TOPIC_ANY_TOPIC_LISTENER_HPP_
 #define OMG_DDS_TOPIC_ANY_TOPIC_LISTENER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/topic/AnyTopic.hpp>
 

--- a/src/ddscxx/include/dds/topic/BuiltinTopic.hpp
+++ b/src/ddscxx/include/dds/topic/BuiltinTopic.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TOPIC_BUILTIN_TOPIC_HPP_
 #define OMG_DDS_TOPIC_BUILTIN_TOPIC_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/topic/detail/BuiltinTopic.hpp>
 

--- a/src/ddscxx/include/dds/topic/BuiltinTopicKey.hpp
+++ b/src/ddscxx/include/dds/topic/BuiltinTopicKey.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TOPIC_BUILTIN_TOPIC_KEY_HPP_
 #define OMG_DDS_TOPIC_BUILTIN_TOPIC_KEY_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/topic/detail/BuiltinTopicKey.hpp>
 

--- a/src/ddscxx/include/dds/topic/ContentFilteredTopic.hpp
+++ b/src/ddscxx/include/dds/topic/ContentFilteredTopic.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TOPIC_CONTENT_FILTERED_TOPIC_HPP_
 #define OMG_DDS_TOPIC_CONTENT_FILTERED_TOPIC_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Inc.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Inc.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/topic/detail/ContentFilteredTopic.hpp>
 

--- a/src/ddscxx/include/dds/topic/Filter.hpp
+++ b/src/ddscxx/include/dds/topic/Filter.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+ 
 /*
  * Filter.hpp
  *

--- a/src/ddscxx/include/dds/topic/TAnyTopic.hpp
+++ b/src/ddscxx/include/dds/topic/TAnyTopic.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TOPIC_TANYTOPIC_HPP_
 #define OMG_DDS_TOPIC_TANYTOPIC_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/conformance.hpp>
 #include <dds/core/types.hpp>

--- a/src/ddscxx/include/dds/topic/TBuiltinTopic.hpp
+++ b/src/ddscxx/include/dds/topic/TBuiltinTopic.hpp
@@ -41,41 +41,39 @@ class TSubscriptionBuiltinTopicData;
 }
 }
 
-/**
- * @brief
- * Class that contains information about available DomainParticipants within
- * the system.
- *
- * The DCPSParticipant topic communicates the existence of DomainParticipants
- * by means of the ParticipantBuiltinTopicData datatype. Each
- * ParticipantBuiltinTopicData sample in a Domain represents a DomainParticipant
- * that participates in that Domain: a new ParticipantBuiltinTopicData instance
- * is created when a newly-added DomainParticipant is enabled, and it is disposed
- * when that DomainParticipant is deleted. An updated ParticipantBuiltinTopicData
- * sample is written each time the DomainParticipant modifies its UserDataQosPolicy.
- *
- * @code{.cpp}
- * // Get builtin subscriber
- * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
- * dds::sub::Subscriber builtinSubscriber = dds::sub::builtin_subscriber(participant);
- *
- * // Get DCPSParticipant builtin reader (happy flow)
- * string name = "DCPSParticipant";
- * vector<dds::sub::DataReader<dds::topic::ParticipantBuiltinTopicData> > readersVector;
- * dds::sub::find<dds::sub::DataReader<dds::topic::ParticipantBuiltinTopicData>,
- *                       back_insert_iterator<vector<dds::sub::DataReader<dds::topic::ParticipantBuiltinTopicData> > > >(
- *           builtinSubscriber,
- *           name,
- *           back_inserter<vector<dds::sub::DataReader<dds::topic::ParticipantBuiltinTopicData> > >(readersVector));
- * dds::sub::DataReader<dds::topic::ParticipantBuiltinTopicData> builtinReader = readersVector[0];
- *
- * // The builtinReader can now be used just as a normal dds::sub::DataReader to get
- * // dds::topic::ParticipantBuiltinTopicData samples.
- * @endcode
- *
- * @see for more information: @ref DCPS_Builtin_Topics
- * @see for more information: @ref DCPS_Builtin_Topics_ParticipantData
- */
+/// @brief
+/// Class that contains information about available DomainParticipants within
+/// the system.
+///
+/// The DCPSParticipant topic communicates the existence of DomainParticipants
+/// by means of the ParticipantBuiltinTopicData datatype. Each
+/// ParticipantBuiltinTopicData sample in a Domain represents a DomainParticipant
+/// that participates in that Domain: a new ParticipantBuiltinTopicData instance
+/// is created when a newly-added DomainParticipant is enabled, and it is disposed
+/// when that DomainParticipant is deleted. An updated ParticipantBuiltinTopicData
+/// sample is written each time the DomainParticipant modifies its UserDataQosPolicy.
+///
+/// @code{.cpp}
+/// // Get builtin subscriber
+/// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+/// dds::sub::Subscriber builtinSubscriber = dds::sub::builtin_subscriber(participant);
+///
+/// // Get DCPSParticipant builtin reader (happy flow)
+/// string name = "DCPSParticipant";
+/// vector<dds::sub::DataReader<dds::topic::ParticipantBuiltinTopicData> > readersVector;
+/// dds::sub::find<dds::sub::DataReader<dds::topic::ParticipantBuiltinTopicData>,
+///                       back_insert_iterator<vector<dds::sub::DataReader<dds::topic::ParticipantBuiltinTopicData> > > >(
+///           builtinSubscriber,
+///           name,
+///           back_inserter<vector<dds::sub::DataReader<dds::topic::ParticipantBuiltinTopicData> > >(readersVector));
+/// dds::sub::DataReader<dds::topic::ParticipantBuiltinTopicData> builtinReader = readersVector[0];
+///
+/// // The builtinReader can now be used just as a normal dds::sub::DataReader to get
+/// // dds::topic::ParticipantBuiltinTopicData samples.
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Builtin_Topics
+/// @see for more information: @ref DCPS_Builtin_Topics_ParticipantData
 template <typename D>
 class dds::topic::TParticipantBuiltinTopicData : public ::dds::core::Value<D>
 {
@@ -91,42 +89,40 @@ public:
     const ::dds::core::policy::UserData& user_data() const;
 };
 
-/**
- * @brief
- * Class that contains information about available Topics within
- * the system.
- *
- * The DCPSTopic topic communicates the existence of topics by means of the
- * TopicBuiltinTopicData datatype. Each TopicBuiltinTopicData sample in
- * a Domain represents a Topic in that Domain: a new TopicBuiltinTopicData
- * instance is created when a newly-added Topic is enabled. However, the instance is
- * not disposed when a Topic is deleted by its participant because a topic lifecycle
- * is tied to the lifecycle of a Domain, not to the lifecycle of an individual
- * participant. An updated TopicBuiltinTopicData sample is written each time a
- * Topic modifies one or more of its QosPolicy values.
- *
- * @code{.cpp}
- * // Get builtin subscriber
- * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
- * dds::sub::Subscriber builtinSubscriber = dds::sub::builtin_subscriber(participant);
- *
- * // Get DCPSTopic builtin reader (happy flow)
- * string name = "DCPSTopic";
- * vector<dds::sub::DataReader<dds::topic::TopicBuiltinTopicData> > readersVector;
- * dds::sub::find<dds::sub::DataReader<dds::topic::TopicBuiltinTopicData>,
- *                       back_insert_iterator<vector<dds::sub::DataReader<dds::topic::TopicBuiltinTopicData> > > >(
- *           builtinSubscriber,
- *           name,
- *           back_inserter<vector<dds::sub::DataReader<dds::topic::TopicBuiltinTopicData> > >(readersVector));
- * dds::sub::DataReader<dds::topic::TopicBuiltinTopicData> builtinReader = readersVector[0];
- *
- * // The builtinReader can now be used just as a normal dds::sub::DataReader to get
- * // dds::topic::TopicBuiltinTopicData samples.
- * @endcode
- *
- * @see for more information: @ref DCPS_Builtin_Topics
- * @see for more information: @ref DCPS_Builtin_Topics_TopicData
- */
+/// @brief
+/// Class that contains information about available Topics within
+/// the system.
+///
+/// The DCPSTopic topic communicates the existence of topics by means of the
+/// TopicBuiltinTopicData datatype. Each TopicBuiltinTopicData sample in
+/// a Domain represents a Topic in that Domain: a new TopicBuiltinTopicData
+/// instance is created when a newly-added Topic is enabled. However, the instance is
+/// not disposed when a Topic is deleted by its participant because a topic lifecycle
+/// is tied to the lifecycle of a Domain, not to the lifecycle of an individual
+/// participant. An updated TopicBuiltinTopicData sample is written each time a
+/// Topic modifies one or more of its QosPolicy values.
+///
+/// @code{.cpp}
+/// // Get builtin subscriber
+/// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+/// dds::sub::Subscriber builtinSubscriber = dds::sub::builtin_subscriber(participant);
+///
+/// // Get DCPSTopic builtin reader (happy flow)
+/// string name = "DCPSTopic";
+/// vector<dds::sub::DataReader<dds::topic::TopicBuiltinTopicData> > readersVector;
+/// dds::sub::find<dds::sub::DataReader<dds::topic::TopicBuiltinTopicData>,
+///                       back_insert_iterator<vector<dds::sub::DataReader<dds::topic::TopicBuiltinTopicData> > > >(
+///           builtinSubscriber,
+///           name,
+///           back_inserter<vector<dds::sub::DataReader<dds::topic::TopicBuiltinTopicData> > >(readersVector));
+/// dds::sub::DataReader<dds::topic::TopicBuiltinTopicData> builtinReader = readersVector[0];
+///
+/// // The builtinReader can now be used just as a normal dds::sub::DataReader to get
+/// // dds::topic::TopicBuiltinTopicData samples.
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Builtin_Topics
+/// @see for more information: @ref DCPS_Builtin_Topics_TopicData
 template <typename D>
 class dds::topic::TTopicBuiltinTopicData : public ::dds::core::Value<D>
 {
@@ -214,43 +210,41 @@ public:
     const ::dds::core::policy::TopicData&          topic_data() const;
 };
 
-/**
- * @brief
- * Class that contains information about available DataWriters within
- * the system.
- *
- * The DCPSPublication topic communicates the existence of datawriters by means
- * of the PublicationBuiltinTopicData datatype. Each PublicationBuiltinTopicData
- * sample in a Domain represents a datawriter in that Domain: a new
- * PublicationBuiltinTopicData instance is created when a newly-added DataWriter
- * is enabled, and it is disposed when that DataWriter is deleted. An updated
- * PublicationBuiltinTopicData sample is written each time the DataWriter (or
- * the Publisher to which it belongs) modifies a QosPolicy that applies to the
- * entities connected to it. Also will it be updated when the writer looses or
- * regains its liveliness.
- *
- * @code{.cpp}
- * // Get builtin subscriber
- * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
- * dds::sub::Subscriber builtinSubscriber = dds::sub::builtin_subscriber(participant);
- *
- * // Get DCPSPublication builtin reader (happy flow)
- * string name = "DCPSPublication";
- * vector<dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData> > readersVector;
- * dds::sub::find<dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData>,
- *                       back_insert_iterator<vector<dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData> > > >(
- *           builtinSubscriber,
- *           name,
- *           back_inserter<vector<dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData> > >(readersVector));
- * dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData> builtinReader = readersVector[0];
- *
- * // The builtinReader can now be used just as a normal dds::sub::DataReader to get
- * // dds::topic::PublicationBuiltinTopicData samples.
- * @endcode
- *
- * @see for more information: @ref DCPS_Builtin_Topics
- * @see for more information: @ref DCPS_Builtin_Topics_PublicationData
- */
+/// @brief
+/// Class that contains information about available DataWriters within
+/// the system.
+///
+/// The DCPSPublication topic communicates the existence of datawriters by means
+/// of the PublicationBuiltinTopicData datatype. Each PublicationBuiltinTopicData
+/// sample in a Domain represents a datawriter in that Domain: a new
+/// PublicationBuiltinTopicData instance is created when a newly-added DataWriter
+/// is enabled, and it is disposed when that DataWriter is deleted. An updated
+/// PublicationBuiltinTopicData sample is written each time the DataWriter (or
+/// the Publisher to which it belongs) modifies a QosPolicy that applies to the
+/// entities connected to it. Also will it be updated when the writer looses or
+/// regains its liveliness.
+///
+/// @code{.cpp}
+/// // Get builtin subscriber
+/// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+/// dds::sub::Subscriber builtinSubscriber = dds::sub::builtin_subscriber(participant);
+///
+/// // Get DCPSPublication builtin reader (happy flow)
+/// string name = "DCPSPublication";
+/// vector<dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData> > readersVector;
+/// dds::sub::find<dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData>,
+///                       back_insert_iterator<vector<dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData> > > >(
+///           builtinSubscriber,
+///           name,
+///           back_inserter<vector<dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData> > >(readersVector));
+/// dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData> builtinReader = readersVector[0];
+///
+/// // The builtinReader can now be used just as a normal dds::sub::DataReader to get
+/// // dds::topic::PublicationBuiltinTopicData samples.
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Builtin_Topics
+/// @see for more information: @ref DCPS_Builtin_Topics_PublicationData
 template <typename D>
 class dds::topic::TPublicationBuiltinTopicData  : public ::dds::core::Value<D>
 {
@@ -356,42 +350,40 @@ public:
 
 };
 
-/**
- * @brief
- * Class that contains information about available DataReaders within
- * the system.
- *
- * The DCPSSubscription topic communicates the existence of datareaders by
- * means of the SubscriptionBuiltinTopicData datatype. Each
- * SubscriptionBuiltinTopicData sample in a Domain represents a datareader
- * in that Domain: a new SubscriptionBuiltinTopicData instance is created
- * when a newly-added DataReader is enabled, and it is disposed when that
- * DataReader is deleted. An updated SubscriptionBuiltinTopicData sample is
- * written each time the DataReader (or the Subscriber to which it belongs)
- * modifies a QosPolicy that applies to the entities connected to it.
- *
- * @code{.cpp}
- * // Get builtin subscriber
- * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
- * dds::sub::Subscriber builtinSubscriber = dds::sub::builtin_subscriber(participant);
- *
- * // Get DCPSSubscription builtin reader (happy flow)
- * string name = "DCPSSubscription";
- * vector<dds::sub::DataReader<dds::topic::SubscriptionBuiltinTopicData> > readersVector;
- * dds::sub::find<dds::sub::DataReader<dds::topic::SubscriptionBuiltinTopicData>,
- *                       back_insert_iterator<vector<dds::sub::DataReader<dds::topic::SubscriptionBuiltinTopicData> > > >(
- *           builtinSubscriber,
- *           name,
- *           back_inserter<vector<dds::sub::DataReader<dds::topic::SubscriptionBuiltinTopicData> > >(readersVector));
- * dds::sub::DataReader<dds::topic::SubscriptionBuiltinTopicData> builtinReader = readersVector[0];
- *
- * // The builtinReader can now be used just as a normal dds::sub::DataReader to get
- * // dds::topic::SubscriptionBuiltinTopicData samples.
- * @endcode
- *
- * @see for more information: @ref DCPS_Builtin_Topics
- * @see for more information: @ref DCPS_Builtin_Topics_SubscriptionData
- */
+/// @brief
+/// Class that contains information about available DataReaders within
+/// the system.
+///
+/// The DCPSSubscription topic communicates the existence of datareaders by
+/// means of the SubscriptionBuiltinTopicData datatype. Each
+/// SubscriptionBuiltinTopicData sample in a Domain represents a datareader
+/// in that Domain: a new SubscriptionBuiltinTopicData instance is created
+/// when a newly-added DataReader is enabled, and it is disposed when that
+/// DataReader is deleted. An updated SubscriptionBuiltinTopicData sample is
+/// written each time the DataReader (or the Subscriber to which it belongs)
+/// modifies a QosPolicy that applies to the entities connected to it.
+///
+/// @code{.cpp}
+/// // Get builtin subscriber
+/// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+/// dds::sub::Subscriber builtinSubscriber = dds::sub::builtin_subscriber(participant);
+///
+/// // Get DCPSSubscription builtin reader (happy flow)
+/// string name = "DCPSSubscription";
+/// vector<dds::sub::DataReader<dds::topic::SubscriptionBuiltinTopicData> > readersVector;
+/// dds::sub::find<dds::sub::DataReader<dds::topic::SubscriptionBuiltinTopicData>,
+///                       back_insert_iterator<vector<dds::sub::DataReader<dds::topic::SubscriptionBuiltinTopicData> > > >(
+///           builtinSubscriber,
+///           name,
+///           back_inserter<vector<dds::sub::DataReader<dds::topic::SubscriptionBuiltinTopicData> > >(readersVector));
+/// dds::sub::DataReader<dds::topic::SubscriptionBuiltinTopicData> builtinReader = readersVector[0];
+///
+/// // The builtinReader can now be used just as a normal dds::sub::DataReader to get
+/// // dds::topic::SubscriptionBuiltinTopicData samples.
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Builtin_Topics
+/// @see for more information: @ref DCPS_Builtin_Topics_SubscriptionData
 template <typename D>
 class dds::topic::TSubscriptionBuiltinTopicData  : public ::dds::core::Value<D>
 {

--- a/src/ddscxx/include/dds/topic/TBuiltinTopic.hpp
+++ b/src/ddscxx/include/dds/topic/TBuiltinTopic.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_TDDS_TOPIC_BUILT_IN_TOPIC_HPP_
 #define OMG_TDDS_TOPIC_BUILT_IN_TOPIC_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/detail/conformance.hpp>
 #include <dds/core/Value.hpp>

--- a/src/ddscxx/include/dds/topic/TBuiltinTopicKey.hpp
+++ b/src/ddscxx/include/dds/topic/TBuiltinTopicKey.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TOPIC_TBUILTIN_TOPIC_KEY_HPP_
 #define OMG_DDS_TOPIC_TBUILTIN_TOPIC_KEY_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 #include <dds/core/Value.hpp>

--- a/src/ddscxx/include/dds/topic/TContentFilteredTopic.hpp
+++ b/src/ddscxx/include/dds/topic/TContentFilteredTopic.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_T_TOPIC_CONTENT_FILTERED_TOPIC_HPP_
 #define OMG_DDS_T_TOPIC_CONTENT_FILTERED_TOPIC_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Inc.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Inc.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <vector>
 

--- a/src/ddscxx/include/dds/topic/TContentFilteredTopic.hpp
+++ b/src/ddscxx/include/dds/topic/TContentFilteredTopic.hpp
@@ -37,41 +37,39 @@ class ContentFilteredTopic;
 }
 
 
-/**
- * @brief
- * ContentFilteredTopic is a specialization of TopicDescription that allows
- * for content-based subscriptions.
- *
- * ContentFilteredTopic describes a more sophisticated subscription which
- * indicates that the Subscriber does not necessarily want to see all values of each
- * instance published under the Topic. Rather, it only wants to see the values whose
- * contents satisfy certain criteria. Therefore this class must be used to request
- * content-based subscriptions.
- *
- * The selection of the content is done using the SQL based filter with parameters to
- * adapt the filter clause.
- *
- * <b><i>Example</i></b>
- * @code{.cpp}
- * // Default creation of a Topic
- * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
- * dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
- *
- * // Creation of a ContentFilteredTopic (assume Foo::Bar contains long_1 element).
- * std::vector<std::string> params;
- * params.push_back("1");
- * dds::topic::Filter filter("long_1=%0", params);
- * dds::topic::ContentFilteredTopic<Foo::Bar> cfTopic(topic,
- *                                                    "ContentFilteredTopicName",
- *                                                    filter);
- *
- * // The ContentFilteredTopic can be used to create readers
- * dds::sub::Subscriber subscriber(participant);
- * dds::sub::DataReader<Foo::Bar> reader(subscriber, cfTopic);
- * @endcode
- *
- * @see for more information: @ref DCPS_Modules_TopicDefinition "Topic Definition"
- */
+/// @brief
+/// ContentFilteredTopic is a specialization of TopicDescription that allows
+/// for content-based subscriptions.
+///
+/// ContentFilteredTopic describes a more sophisticated subscription which
+/// indicates that the Subscriber does not necessarily want to see all values of each
+/// instance published under the Topic. Rather, it only wants to see the values whose
+/// contents satisfy certain criteria. Therefore this class must be used to request
+/// content-based subscriptions.
+///
+/// The selection of the content is done using the SQL based filter with parameters to
+/// adapt the filter clause.
+///
+/// <b><i>Example</i></b>
+/// @code{.cpp}
+/// // Default creation of a Topic
+/// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+/// dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
+///
+/// // Creation of a ContentFilteredTopic (assume Foo::Bar contains long_1 element).
+/// std::vector<std::string> params;
+/// params.push_back("1");
+/// dds::topic::Filter filter("long_1=%0", params);
+/// dds::topic::ContentFilteredTopic<Foo::Bar> cfTopic(topic,
+///                                                    "ContentFilteredTopicName",
+///                                                    filter);
+///
+/// // The ContentFilteredTopic can be used to create readers
+/// dds::sub::Subscriber subscriber(participant);
+/// dds::sub::DataReader<Foo::Bar> reader(subscriber, cfTopic);
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Modules_TopicDefinition "Topic Definition"
 template <typename T, template <typename Q> class DELEGATE>
 class dds::topic::ContentFilteredTopic final : public dds::topic::TTopicDescription< DELEGATE<T> >
 {

--- a/src/ddscxx/include/dds/topic/TFilter.hpp
+++ b/src/ddscxx/include/dds/topic/TFilter.hpp
@@ -1,23 +1,22 @@
 #ifndef DDS_TOPIC_TFILTER__HPP_
 #define DDS_TOPIC_TFILTER__HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/types.hpp>
 #include <dds/core/Value.hpp>

--- a/src/ddscxx/include/dds/topic/TTopic.hpp
+++ b/src/ddscxx/include/dds/topic/TTopic.hpp
@@ -40,36 +40,34 @@ class TopicListener;
 }
 
 
-/**
- * @brief
- * Topic is the most basic description of the data to be published and
- * subscribed.
- *
- * A Topic is identified by its name, which must be unique in the whole Domain.
- * In addition (by virtue of extending TopicDescription) it fully specifies the
- * type of the data that can be communicated when publishing or subscribing to
- * the Topic.
- *
- * Topic is the only TopicDescription that can be used for publications and
- * therefore associated with a DataWriter.
- *
- * <b><i>Example</i></b>
- * @code{.cpp}
- * // Default creation of a Topic
- * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
- * dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
- *
- * // The Topic can be used to create readers and writers
- * // DataReader
- * dds::sub::Subscriber subscriber(participant);
- * dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
- * // DataWriter
- * dds::pub::Publisher publisher(participant);
- * dds::pub::DataWriter<Foo::Bar> writer(publisher, topic);
- * @endcode
- *
- * @see for more information: @ref DCPS_Modules_TopicDefinition "Topic Definition"
- */
+/// @brief
+/// Topic is the most basic description of the data to be published and
+/// subscribed.
+///
+/// A Topic is identified by its name, which must be unique in the whole Domain.
+/// In addition (by virtue of extending TopicDescription) it fully specifies the
+/// type of the data that can be communicated when publishing or subscribing to
+/// the Topic.
+///
+/// Topic is the only TopicDescription that can be used for publications and
+/// therefore associated with a DataWriter.
+///
+/// <b><i>Example</i></b>
+/// @code{.cpp}
+/// // Default creation of a Topic
+/// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+/// dds::topic::Topic<Foo::Bar> topic(participant, "TopicName");
+///
+/// // The Topic can be used to create readers and writers
+/// // DataReader
+/// dds::sub::Subscriber subscriber(participant);
+/// dds::sub::DataReader<Foo::Bar> reader(subscriber, topic);
+/// // DataWriter
+/// dds::pub::Publisher publisher(participant);
+/// dds::pub::DataWriter<Foo::Bar> writer(publisher, topic);
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Modules_TopicDefinition "Topic Definition"
 template <typename T, template <typename Q> class DELEGATE>
 class dds::topic::Topic final : public dds::topic::TAnyTopic< DELEGATE<T> >
 {
@@ -173,123 +171,119 @@ public:
           const std::string& topic_name,
           const std::string& type_name);
 
-    /**
-     * Create a new Topic.
-     *
-     * This operation creates a reference to a new or existing Topic under the given name,
-     * for a specific data type.
-     *
-     * <i>QoS</i><br>
-     * A possible application pattern to construct the TopicQos for the
-     * Topic is to:
-     * @code{.cpp}
-     * // 1) Retrieve the QosPolicy settings on the associated DomainParticipant
-     * dds::topic::qos::TopicQos topicQos = participant.default_datareader_qos();
-     * // 2) Selectively modify QosPolicy settings as desired.
-     * topicQos << dds::core::policy::Durability::Transient();
-     * // 3) Use the resulting QoS to construct the DataReader.
-     * dds::topic::Topic<Foo::Bar> topic(participant, "TopicName", topicQos);
-     * @endcode
-     *
-     * <i>Existing Topic Name</i><br>
-     * Before creating a new Topic, this operation performs a
-     * lookup_topicdescription for the specified topic_name. When a Topic is
-     * found with the same name in the current domain, the QoS and type_name of the
-     * found Topic are matched against the parameters qos and type_name. When they
-     * are the same, no Topic is created but a new proxy of the existing Topic is returned.
-     * When they are not exactly the same, no Topic is created and dds::core::Error is thrown.
-     *
-     * <i>Local Proxy</i><br>
-     * Since a Topic is a global concept in the system, access is provided through a local
-     * proxy. In other words, the reference returned is actually not a reference to a Topic
-     * but to a locally created proxy. The Data Distribution Service propagates Topics
-     * and makes remotely created Topics locally available through this proxy. The deletion
-     * of a Topic object will not delete the Topic from the domain, just the local proxy is
-     * deleted.
-     *
-     * <i>Listener</i><br>
-     * The following statuses are applicable to the TopicListener:
-     *  - dds::core::status::StatusMask::inconsistent_topic()
-     *
-     * See @ref DCPS_Modules_Infrastructure_Listener "listener concept",
-     * @ref anchor_dds_topic_listener_commstatus "communication status" and
-     * @ref anchor_dds_topic_listener_commpropagation "communication propagation"
-     * for more information.
-     *
-     * @param dp the domain participant on which the topic will be defined
-     * @param topic_name the topic's name
-     * @param qos the topic listener
-     * @param listener the topic listener
-     * @param mask the listener event mask
-     * @throws dds::core::Error
-     *                  A other Topic with the same name but different type or QoS was
-     *                  detected in the current domain or another internal error has occurred.
-     * @throws dds::core::OutOfResourcesError
-     *                  The Data Distribution Service ran out of resources to
-     *                  complete this operation.
-     */
+    /// Create a new Topic.
+    ///
+    /// This operation creates a reference to a new or existing Topic under the given name,
+    /// for a specific data type.
+    ///
+    /// <i>QoS</i><br>
+    /// A possible application pattern to construct the TopicQos for the
+    /// Topic is to:
+    /// @code{.cpp}
+    /// // 1) Retrieve the QosPolicy settings on the associated DomainParticipant
+    /// dds::topic::qos::TopicQos topicQos = participant.default_datareader_qos();
+    /// // 2) Selectively modify QosPolicy settings as desired.
+    /// topicQos << dds::core::policy::Durability::Transient();
+    /// // 3) Use the resulting QoS to construct the DataReader.
+    /// dds::topic::Topic<Foo::Bar> topic(participant, "TopicName", topicQos);
+    /// @endcode
+    ///
+    /// <i>Existing Topic Name</i><br>
+    /// Before creating a new Topic, this operation performs a
+    /// lookup_topicdescription for the specified topic_name. When a Topic is
+    /// found with the same name in the current domain, the QoS and type_name of the
+    /// found Topic are matched against the parameters qos and type_name. When they
+    /// are the same, no Topic is created but a new proxy of the existing Topic is returned.
+    /// When they are not exactly the same, no Topic is created and dds::core::Error is thrown.
+    ///
+    /// <i>Local Proxy</i><br>
+    /// Since a Topic is a global concept in the system, access is provided through a local
+    /// proxy. In other words, the reference returned is actually not a reference to a Topic
+    /// but to a locally created proxy. The Data Distribution Service propagates Topics
+    /// and makes remotely created Topics locally available through this proxy. The deletion
+    /// of a Topic object will not delete the Topic from the domain, just the local proxy is
+    /// deleted.
+    ///
+    /// <i>Listener</i><br>
+    /// The following statuses are applicable to the TopicListener:
+    ///  - dds::core::status::StatusMask::inconsistent_topic()
+    ///
+    /// See @ref DCPS_Modules_Infrastructure_Listener "listener concept",
+    /// @ref anchor_dds_topic_listener_commstatus "communication status" and
+    /// @ref anchor_dds_topic_listener_commpropagation "communication propagation"
+    /// for more information.
+    ///
+    /// @param dp the domain participant on which the topic will be defined
+    /// @param topic_name the topic's name
+    /// @param qos the topic listener
+    /// @param listener the topic listener
+    /// @param mask the listener event mask
+    /// @throws dds::core::Error
+    ///                  A other Topic with the same name but different type or QoS was
+    ///                  detected in the current domain or another internal error has occurred.
+    /// @throws dds::core::OutOfResourcesError
+    ///                  The Data Distribution Service ran out of resources to
+    ///                  complete this operation.
     Topic(const dds::domain::DomainParticipant& dp,
           const std::string& topic_name,
           const dds::topic::qos::TopicQos& qos,
           dds::topic::TopicListener<T>* listener = NULL,
           const dds::core::status::StatusMask& mask = dds::core::status::StatusMask::none());
 
-    /**
-     * Create a new Topic.
-     *
-     * This operation creates a reference to a new or existing Topic under the given name,
-     * for a specific data type and type_name.
-     *
-     * <i>QoS</i><br>
-     * A possible application pattern to construct the TopicQos for the
-     * Topic is to:
-     * @code{.cpp}
-     * // 1) Retrieve the QosPolicy settings on the associated DomainParticipant
-     * dds::topic::qos::TopicQos topicQos = participant.default_datareader_qos();
-     * // 2) Selectively modify QosPolicy settings as desired.
-     * topicQos << dds::core::policy::Durability::Transient();
-     * // 3) Use the resulting QoS to construct the DataReader.
-     * dds::topic::Topic<Foo::Bar> topic(participant, "TopicName", "TypeName", topicQos);
-     * @endcode
-     *
-     * <i>Existing Topic Name</i><br>
-     * Before creating a new Topic, this operation performs a
-     * lookup_topicdescription for the specified topic_name. When a Topic is
-     * found with the same name in the current domain, the QoS and type_name of the
-     * found Topic are matched against the parameters qos and type_name. When they
-     * are the same, no Topic is created but a new proxy of the existing Topic is returned.
-     * When they are not exactly the same, no Topic is created and dds::core::Error is thrown.
-     *
-     * <i>Local Proxy</i><br>
-     * Since a Topic is a global concept in the system, access is provided through a local
-     * proxy. In other words, the reference returned is actually not a reference to a Topic
-     * but to a locally created proxy. The Data Distribution Service propagates Topics
-     * and makes remotely created Topics locally available through this proxy. The deletion
-     * of a Topic object will not delete the Topic from the domain, just the local proxy is
-     * deleted.
-     *
-     * <i>Listener</i><br>
-     * The following statuses are applicable to the TopicListener:
-     *  - dds::core::status::StatusMask::inconsistent_topic()
-     *
-     * See @ref DCPS_Modules_Infrastructure_Listener "listener concept",
-     * @ref anchor_dds_topic_listener_commstatus "communication status" and
-     * @ref anchor_dds_topic_listener_commpropagation "communication propagation"
-     * for more information.
-     *
-     * @param dp the domain participant on which the topic will be defined
-     * @param topic_name the topic's name
-     * @param type_name a local alias of the data type
-     * @param qos the topic listener
-     * @param listener the topic listener
-     * @param mask the listener event mask
-     * @throws dds::core::Error
-     *                  A other Topic with the same name but different type or QoS was
-     *                  detected in the current domain or another internal error has occurred.
-     * @throws dds::core::OutOfResourcesError
-     *                  The Data Distribution Service ran out of resources to
-     *                  complete this operation.
-     */
+    /// Create a new Topic.
+    ///
+    /// This operation creates a reference to a new or existing Topic under the given name,
+    /// for a specific data type and type_name.
+    ///
+    /// <i>QoS</i><br>
+    /// A possible application pattern to construct the TopicQos for the
+    /// Topic is to:
+    /// @code{.cpp}
+    /// // 1) Retrieve the QosPolicy settings on the associated DomainParticipant
+    /// dds::topic::qos::TopicQos topicQos = participant.default_datareader_qos();
+    /// // 2) Selectively modify QosPolicy settings as desired.
+    /// topicQos << dds::core::policy::Durability::Transient();
+    /// // 3) Use the resulting QoS to construct the DataReader.
+    /// dds::topic::Topic<Foo::Bar> topic(participant, "TopicName", "TypeName", topicQos);
+    /// @endcode
+    ///
+    /// <i>Existing Topic Name</i><br>
+    /// Before creating a new Topic, this operation performs a
+    /// lookup_topicdescription for the specified topic_name. When a Topic is
+    /// found with the same name in the current domain, the QoS and type_name of the
+    /// found Topic are matched against the parameters qos and type_name. When they
+    /// are the same, no Topic is created but a new proxy of the existing Topic is returned.
+    /// When they are not exactly the same, no Topic is created and dds::core::Error is thrown.
+    ///
+    /// <i>Local Proxy</i><br>
+    /// Since a Topic is a global concept in the system, access is provided through a local
+    /// proxy. In other words, the reference returned is actually not a reference to a Topic
+    /// but to a locally created proxy. The Data Distribution Service propagates Topics
+    /// and makes remotely created Topics locally available through this proxy. The deletion
+    /// of a Topic object will not delete the Topic from the domain, just the local proxy is
+    /// deleted.
+    ///
+    /// <i>Listener</i><br>
+    /// The following statuses are applicable to the TopicListener:
+    ///  - dds::core::status::StatusMask::inconsistent_topic()
+    ///
+    /// See @ref DCPS_Modules_Infrastructure_Listener "listener concept",
+    /// @ref anchor_dds_topic_listener_commstatus "communication status" and
+    /// @ref anchor_dds_topic_listener_commpropagation "communication propagation"
+    /// for more information.
+    ///
+    /// @param dp the domain participant on which the topic will be defined
+    /// @param topic_name the topic's name
+    /// @param type_name a local alias of the data type
+    /// @param qos the topic listener
+    /// @param listener the topic listener
+    /// @param mask the listener event mask
+    /// @throws dds::core::Error
+    ///                  A other Topic with the same name but different type or QoS was
+    ///                  detected in the current domain or another internal error has occurred.
+    /// @throws dds::core::OutOfResourcesError
+    ///                  The Data Distribution Service ran out of resources to
+    ///                  complete this operation.
     Topic(const dds::domain::DomainParticipant& dp,
           const std::string& topic_name,
           const std::string& type_name,

--- a/src/ddscxx/include/dds/topic/TTopic.hpp
+++ b/src/ddscxx/include/dds/topic/TTopic.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TTOPIC_TOPIC_HPP_
 #define OMG_DDS_TTOPIC_TOPIC_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/conformance.hpp>
 #include <dds/core/types.hpp>

--- a/src/ddscxx/include/dds/topic/TTopicDescription.hpp
+++ b/src/ddscxx/include/dds/topic/TTopicDescription.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_T_TOPIC_TOPIC_DESCRIPTION_HPP_
 #define OMG_DDS_T_TOPIC_TOPIC_DESCRIPTION_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/TEntity.hpp>
 #include <dds/topic/TopicTraits.hpp>

--- a/src/ddscxx/include/dds/topic/Topic.hpp
+++ b/src/ddscxx/include/dds/topic/Topic.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef OMG_DDS_TOPIC_TOPIC_HPP_
 #define OMG_DDS_TOPIC_TOPIC_HPP_
 

--- a/src/ddscxx/include/dds/topic/TopicDescription.hpp
+++ b/src/ddscxx/include/dds/topic/TopicDescription.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TOPIC_TOPIC_DESCRIPTION_HPP_
 #define OMG_DDS_TOPIC_TOPIC_DESCRIPTION_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Inc.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Inc.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/topic/detail/TopicDescription.hpp>
 

--- a/src/ddscxx/include/dds/topic/TopicInstance.hpp
+++ b/src/ddscxx/include/dds/topic/TopicInstance.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TOPIC_TOPIC_INSTANCE_HPP_
 #define OMG_DDS_TOPIC_TOPIC_INSTANCE_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/Time.hpp>
 #include <dds/core/InstanceHandle.hpp>

--- a/src/ddscxx/include/dds/topic/TopicListener.hpp
+++ b/src/ddscxx/include/dds/topic/TopicListener.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TOPIC_TOPIC_LISTENER_HPP_
 #define OMG_DDS_TOPIC_TOPIC_LISTENER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "dds/topic/Topic.hpp"
 

--- a/src/ddscxx/include/dds/topic/TopicListener.hpp
+++ b/src/ddscxx/include/dds/topic/TopicListener.hpp
@@ -25,54 +25,52 @@ namespace dds
 namespace topic
 {
 
-/**
- * @brief
- * Topic events Listener
- *
- * Since a Topic is an Entity, it has the ability to have a Listener
- * associated with it. In this case, the associated Listener should be of type
- * TopicListener. This interface must be implemented by the
- * application. A user-defined class must be provided by the application which must
- * extend from the TopicListener class.
- *
- * <b><i>
- * All operations for this interface must be implemented in the user-defined class, it is
- * up to the application whether an operation is empty or contains some functionality.
- * </i></b>
- *
- * The TopicListener provides a generic mechanism (actually a
- * callback function) for the Data Distribution Service to notify the application of
- * relevant asynchronous status change events, such as a missed deadline, violation of
- * a QosPolicy setting, etc. The TopicListener is related to
- * changes in communication status StatusConditions.
- *
- * @code{.cpp}
- * // Application example listener
- * class ExampleListener :
- *                public virtual dds::topic::TopicListener<Foo::Bar>
- * {
- * public:
- *     virtual void on_inconsistent_topic (
- *         dds::topic::Topic<Foo::Bar>& topic,
- *         const dds::core::status::InconsistentTopicStatus& status)
- *     {
- *         std::cout << "on_inconsistent_topic" << std::endl;
- *     }
- * };
- *
- * // Create Topic with the listener
- * dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
- * dds::topic::Topic<Foo::Bar> topic(participant,
- *                                   "TopicName",
- *                                   participant.default_topic_qos(),
- *                                   new ExampleListener(),
- *                                   dds::core::status::StatusMask::all());
- *
- * @endcode
- *
- * @see for more information: @ref DCPS_Modules_Topic "Topic"
- * @see for more information: @ref DCPS_Modules_Infrastructure_Listener "Listener information"
- */
+/// @brief
+/// Topic events Listener
+///
+/// Since a Topic is an Entity, it has the ability to have a Listener
+/// associated with it. In this case, the associated Listener should be of type
+/// TopicListener. This interface must be implemented by the
+/// application. A user-defined class must be provided by the application which must
+/// extend from the TopicListener class.
+///
+/// <b><i>
+/// All operations for this interface must be implemented in the user-defined class, it is
+/// up to the application whether an operation is empty or contains some functionality.
+/// </i></b>
+///
+/// The TopicListener provides a generic mechanism (actually a
+/// callback function) for the Data Distribution Service to notify the application of
+/// relevant asynchronous status change events, such as a missed deadline, violation of
+/// a QosPolicy setting, etc. The TopicListener is related to
+/// changes in communication status StatusConditions.
+///
+/// @code{.cpp}
+/// // Application example listener
+/// class ExampleListener :
+///                public virtual dds::topic::TopicListener<Foo::Bar>
+/// {
+/// public:
+///     virtual void on_inconsistent_topic (
+///         dds::topic::Topic<Foo::Bar>& topic,
+///         const dds::core::status::InconsistentTopicStatus& status)
+///     {
+///         std::cout << "on_inconsistent_topic" << std::endl;
+///     }
+/// };
+///
+/// // Create Topic with the listener
+/// dds::domain::DomainParticipant participant(org::eclipse::cyclonedds::domain::default_id());
+/// dds::topic::Topic<Foo::Bar> topic(participant,
+///                                   "TopicName",
+///                                   participant.default_topic_qos(),
+///                                   new ExampleListener(),
+///                                   dds::core::status::StatusMask::all());
+///
+/// @endcode
+///
+/// @see for more information: @ref DCPS_Modules_Topic "Topic"
+/// @see for more information: @ref DCPS_Modules_Infrastructure_Listener "Listener information"
 template <typename T>
 class TopicListener
 {
@@ -104,22 +102,20 @@ public:
 };
 
 
-/**
- * @brief
- * Topic events Listener
- *
- * This listener is just like TopicListener, except
- * that the application doesn't have to implement all operations.
- *
- * @code{.cpp}
- * class ExampleListener : public virtual dds::topic::NoOpTopicListener<Foo::Bar>
- * {
- *    // Not necessary to implement any Listener operations.
- * };
- * @endcode
- *
- * @see dds::topic::TopicListener
- */
+/// @brief
+/// Topic events Listener
+///
+/// This listener is just like TopicListener, except
+/// that the application doesn't have to implement all operations.
+///
+/// @code{.cpp}
+/// class ExampleListener : public virtual dds::topic::NoOpTopicListener<Foo::Bar>
+/// {
+///    // Not necessary to implement any Listener operations.
+/// };
+/// @endcode
+///
+/// @see dds::topic::TopicListener
 template <typename T>
 class NoOpTopicListener : public virtual TopicListener<T>
 {

--- a/src/ddscxx/include/dds/topic/TopicTraits.hpp
+++ b/src/ddscxx/include/dds/topic/TopicTraits.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TOPIC_TOPIC_TRAITS_HPP_
 #define OMG_DDS_TOPIC_TOPIC_TRAITS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <string>
 

--- a/src/ddscxx/include/dds/topic/TopicTraits.hpp
+++ b/src/ddscxx/include/dds/topic/TopicTraits.hpp
@@ -54,18 +54,16 @@ struct topic_type_name
 }
 
 //==============================================================================
-/**
- * @brief
- * Support functionality to check if a given object type is a Topic.
- *
- * @code{.cpp}
- * if (dds::topic::is_topic_type<Foo::Bar>::value) {
- *     // Foo::Bar type is considered a Topic
- * } else {
- *     // Foo::Bar type is NOT considered a Topic
- * }
- * @endcode
- */
+/// @brief
+/// Support functionality to check if a given object type is a Topic.
+///
+/// @code{.cpp}
+/// if (dds::topic::is_topic_type<Foo::Bar>::value) {
+///     // Foo::Bar type is considered a Topic
+/// } else {
+///     // Foo::Bar type is NOT considered a Topic
+/// }
+/// @endcode
 template <typename T>
 struct dds::topic::is_topic_type
 {

--- a/src/ddscxx/include/dds/topic/ddstopic.hpp
+++ b/src/ddscxx/include/dds/topic/ddstopic.hpp
@@ -1,20 +1,20 @@
-/* Copyright 2010, Object Management Group, Inc.
-* Copyright 2010, PrismTech, Corp.
-* Copyright 2010, Real-Time Innovations, Inc.
-* All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef OMG_DDS_TOPIC_PACKAGE_INCLUDE_HPP_
 #define OMG_DDS_TOPIC_PACKAGE_INCLUDE_HPP_
 

--- a/src/ddscxx/include/dds/topic/detail/AnyTopic.hpp
+++ b/src/ddscxx/include/dds/topic/detail/AnyTopic.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef OMG_DDS_TOPIC_DETAIL_ANY_TOPIC_HPP_
 #define OMG_DDS_TOPIC_DETAIL_ANY_TOPIC_HPP_
 

--- a/src/ddscxx/include/dds/topic/detail/BuiltinTopic.hpp
+++ b/src/ddscxx/include/dds/topic/detail/BuiltinTopic.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TOPIC_DETAIL_BUILTIN_TOPIC_HPP_
 #define OMG_DDS_TOPIC_DETAIL_BUILTIN_TOPIC_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/topic/Topic.hpp>
 #include <dds/topic/detail/TTopicImpl.hpp>

--- a/src/ddscxx/include/dds/topic/detail/BuiltinTopicKey.hpp
+++ b/src/ddscxx/include/dds/topic/detail/BuiltinTopicKey.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TOPIC_DETAIL_BUILTIN_TOPIC_KEY_HPP_
 #define OMG_DDS_TOPIC_DETAIL_BUILTIN_TOPIC_KEY_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <org/eclipse/cyclonedds/topic/BuiltinTopicKeyDelegate.hpp>
 #include <dds/topic/detail/TBuiltinTopicKeyImpl.hpp>

--- a/src/ddscxx/include/dds/topic/detail/ContentFilteredTopic.hpp
+++ b/src/ddscxx/include/dds/topic/detail/ContentFilteredTopic.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TOPIC_DETAIL_CONTENTFILTEREDTOPIC_HPP_
 #define OMG_DDS_TOPIC_DETAIL_CONTENTFILTEREDTOPIC_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Inc.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Inc.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <string>
 #include <vector>

--- a/src/ddscxx/include/dds/topic/detail/Filter.hpp
+++ b/src/ddscxx/include/dds/topic/detail/Filter.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef DDS_TOPIC_DETAIL_QUERY_HPP_
 #define DDS_TOPIC_DETAIL_QUERY_HPP_
 

--- a/src/ddscxx/include/dds/topic/detail/TAnyTopicImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TAnyTopicImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_TOPIC_TANYTOPIC_IMPL_HPP_
 #define CYCLONEDDS_DDS_TOPIC_TANYTOPIC_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/topic/detail/TBuiltinTopicImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TBuiltinTopicImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_TOPIC_TBUILTINTOPIC_IMPL_HPP_
 #define CYCLONEDDS_DDS_TOPIC_TBUILTINTOPIC_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/topic/detail/TBuiltinTopicKeyImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TBuiltinTopicKeyImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_TOPIC_DETAIL_TBUILTINTOPICKEY_IMPL_HPP_
 #define CYCLONEDDS_DDS_TOPIC_DETAIL_TBUILTINTOPICKEY_IMPL_HPP_
 

--- a/src/ddscxx/include/dds/topic/detail/TContentFilteredTopicImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TContentFilteredTopicImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_TOPIC_TCONTENTFILTEREDTOPIC_HPP_
 #define CYCLONEDDS_DDS_TOPIC_TCONTENTFILTEREDTOPIC_HPP_
 

--- a/src/ddscxx/include/dds/topic/detail/TFilterImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TFilterImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_TOPIC_TFILTER_HPP_
 #define CYCLONEDDS_DDS_TOPIC_TFILTER_HPP_
 

--- a/src/ddscxx/include/dds/topic/detail/TTopicDescriptionImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TTopicDescriptionImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_TOPIC_TTOPICDESCRIPTION_HPP_
 #define CYCLONEDDS_DDS_TOPIC_TTOPICDESCRIPTION_HPP_
 

--- a/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_TOPIC_TTOPIC_HPP_
 #define CYCLONEDDS_DDS_TOPIC_TTOPIC_HPP_
 

--- a/src/ddscxx/include/dds/topic/detail/Topic.hpp
+++ b/src/ddscxx/include/dds/topic/detail/Topic.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_TOPIC_DETAIL_TOPIC_HPP_
 #define CYCLONEDDS_DDS_TOPIC_DETAIL_TOPIC_HPP_
 

--- a/src/ddscxx/include/dds/topic/detail/TopicDescription.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TopicDescription.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_DDS_TOPIC_DETAIL_TOPICDESCRIPTION_HPP_
 #define CYCLONEDDS_DDS_TOPIC_DETAIL_TOPICDESCRIPTION_HPP_
 

--- a/src/ddscxx/include/dds/topic/detail/TopicInstanceImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TopicInstanceImpl.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_TOPIC_TOPICINSTANCE_HPP_
 #define CYCLONEDDS_DDS_TOPIC_TOPICINSTANCE_HPP_
 

--- a/src/ddscxx/include/dds/topic/detail/ddstopic.hpp
+++ b/src/ddscxx/include/dds/topic/detail/ddstopic.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef OMG_DDS_TOPIC_PACKAGE_DETAIL_INCLUDE_HPP_
 #define OMG_DDS_TOPIC_PACKAGE_DETAIL_INCLUDE_HPP_
 

--- a/src/ddscxx/include/dds/topic/detail/discovery.hpp
+++ b/src/ddscxx/include/dds/topic/detail/discovery.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/dds/topic/detail/find.hpp
+++ b/src/ddscxx/include/dds/topic/detail/find.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/dds/topic/discovery.hpp
+++ b/src/ddscxx/include/dds/topic/discovery.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TOPIC_DISCOVER_HPP_
 #define OMG_DDS_TOPIC_DISCOVER_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Inc.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Inc.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/domain/DomainParticipant.hpp>
 

--- a/src/ddscxx/include/dds/topic/find.hpp
+++ b/src/ddscxx/include/dds/topic/find.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TOPIC_FIND_HPP_
 #define OMG_DDS_TOPIC_FIND_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Inc.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Inc.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <string>
 

--- a/src/ddscxx/include/dds/topic/qos/TopicQos.hpp
+++ b/src/ddscxx/include/dds/topic/qos/TopicQos.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TOPIC_QOS_TOPIC_QOS_HPP_
 #define OMG_DDS_TOPIC_QOS_TOPIC_QOS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/topic/qos/detail/TopicQos.hpp>
 

--- a/src/ddscxx/include/dds/topic/qos/detail/TopicQos.hpp
+++ b/src/ddscxx/include/dds/topic/qos/detail/TopicQos.hpp
@@ -1,23 +1,22 @@
 #ifndef OMG_DDS_TOPIC_QOS_DETAIL_TOPIC_QOS_HPP_
 #define OMG_DDS_TOPIC_QOS_DETAIL_TOPIC_QOS_HPP_
 
-/* Copyright 2010, Object Management Group, Inc.
- * Copyright 2010, PrismTech, Corp.
- * Copyright 2010, Real-Time Innovations, Inc.
- * All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2010, Object Management Group, Inc.
+// Copyright 2010, PrismTech, Corp.
+// Copyright 2010, Real-Time Innovations, Inc.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <dds/core/detail/TEntityQosImpl.hpp>
 #include <org/eclipse/cyclonedds/topic/qos/TopicQosDelegate.hpp>

--- a/src/ddscxx/include/org/eclipse/cyclonedds/ForwardDeclarations.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/ForwardDeclarations.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/DDScObjectDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/DDScObjectDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/EntityDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/EntityDelegate.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/EntityRegistry.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/EntityRegistry.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/EntitySet.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/EntitySet.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/InstanceHandleDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/InstanceHandleDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/ListenerDispatcher.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/ListenerDispatcher.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_CORE_LISTENERDISPATCHER_H_
 #define CYCLONEDDS_CORE_LISTENERDISPATCHER_H_
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/MiscUtils.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/MiscUtils.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/Mutex.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/Mutex.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/ObjectDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/ObjectDelegate.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/ObjectSet.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/ObjectSet.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/QosProviderDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/QosProviderDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/ReportUtils.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/ReportUtils.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/ScopedLock.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/ScopedLock.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/TimeHelper.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/TimeHelper.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/WeakReferenceSet.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/WeakReferenceSet.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2021 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2021 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef BASIC_CDR_SERIALIZATION_HPP_
 #define BASIC_CDR_SERIALIZATION_HPP_
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_enums.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_enums.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2021 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2021 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CDR_ENUMS_HPP_
 #define CDR_ENUMS_HPP_
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2021 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2021 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CDR_STREAM_HPP_
 #define CDR_STREAM_HPP_
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2021 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2021 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef ENTITY_PROPERTIES_HPP_
 #define ENTITY_PROPERTIES_HPP_
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2021 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2021 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef EXTENDED_CDR_SERIALIZATION_V1_HPP_
 #define EXTENDED_CDR_SERIALIZATION_V1_HPP_
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2021 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2021 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef EXTENDED_CDR_SERIALIZATION_V2_HPP_
 #define EXTENDED_CDR_SERIALIZATION_V2_HPP_
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/fragchain.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/fragchain.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2022 ZettaScale Technology
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CDR_SERIALIZATION_FRAGCHAIN_HPP_
 #define CDR_SERIALIZATION_FRAGCHAIN_HPP_
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/ConditionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/ConditionDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/FunctorHolder.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/FunctorHolder.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/GuardConditionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/GuardConditionDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/StatusConditionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/StatusConditionDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/WaitSetDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cond/WaitSetDelegate.hpp
@@ -1,14 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/config.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/config.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/Policy.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/Policy.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/PolicyDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/PolicyDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/ProprietaryPolicyKind.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/ProprietaryPolicyKind.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/QosPolicyCountDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/QosPolicyCountDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/TPolicy.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/TPolicy.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/status/StatusDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/status/StatusDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/type_helpers.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/type_helpers.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
  /**
   * @file
   */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/domain/Domain.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/domain/Domain.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainParticipantListener.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainParticipantListener.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainParticipantRegistry.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainParticipantRegistry.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainWrap.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/domain/DomainWrap.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/domain/qos/DomainParticipantQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/domain/qos/DomainParticipantQosDelegate.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.hpp
@@ -1,15 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+//
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/CoherentSetDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/CoherentSetDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/PublisherDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/PublisherDelegate.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/SuspendedPublicationDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/SuspendedPublicationDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/qos/PublisherQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/qos/PublisherQosDelegate.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/BuiltinSubscriberDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/BuiltinSubscriberDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/CoherentAccessDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/CoherentAccessDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/GenerationCountImpl.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/GenerationCountImpl.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/QueryDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/QueryDelegate.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_SUB_QUERY_DELEGATE_HPP_
 #define CYCLONEDDS_SUB_QUERY_DELEGATE_HPP_
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/RankImpl.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/RankImpl.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/SampleInfoImpl.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/SampleInfoImpl.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/SubscriberDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/SubscriberDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/SubscriberDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/SubscriberDelegate.hpp
@@ -76,7 +76,7 @@ public:
     const dds::domain::DomainParticipant& participant() const;
 
     /** @internal @todo OSPL-1944 Subscriber Listener should return list of affected DataReaders (on_data_on_readers) **/
-    //dds::sub::AnyDataReader get_datareaders(); /* TODO: OSPL-1944? */
+    // dds::sub::AnyDataReader get_datareaders(); // TODO: OSPL-1944?
 
     bool contains_entity(
             const ::dds::core::InstanceHandle& handle);

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/cond/QueryConditionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/cond/QueryConditionDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/cond/ReadConditionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/cond/ReadConditionDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/qos/SubscriberQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/qos/SubscriberQosDelegate.hpp
@@ -1,15 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+//
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/AnyTopicDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/AnyTopicDelegate.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/AnyTopicListener.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/AnyTopicListener.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 #ifndef CYCLONEDDS_TOPIC_ANY_TOPIC_LISTENER_HPP_
 #define CYCLONEDDS_TOPIC_ANY_TOPIC_LISTENER_HPP_

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopic.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_TOPIC_BUILTIN_TOPIC_HPP_
 #define CYCLONEDDS_TOPIC_BUILTIN_TOPIC_HPP_
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicCopy.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicCopy.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 #ifndef CYCLONEDDS_TOPIC_BUILTIN_TOPIC_COPY_HPP_
 #define CYCLONEDDS_TOPIC_BUILTIN_TOPIC_COPY_HPP_

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicKeyDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicKeyDelegate.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicTraits.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicTraits.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_TOPIC_BUILTIN_TOPIC_TRAITS_HPP
 #define CYCLONEDDS_TOPIC_BUILTIN_TOPIC_TRAITS_HPP
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/CDRBlob.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/CDRBlob.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_TOPIC_CDRBLOB_HPP
 #define CYCLONEDDS_TOPIC_CDRBLOB_HPP
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/FilterDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/FilterDelegate.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef CYCLONEDDS_DDS_TOPIC_DETAIL_FILTER_HPP_
 #define CYCLONEDDS_DDS_TOPIC_DETAIL_FILTER_HPP_
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/TBuiltinTopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/TBuiltinTopic.hpp
@@ -1,14 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 #ifndef CYCLONEDDS_TOPIC_TBUILTIN_TOPIC_HPP_
 #define CYCLONEDDS_TOPIC_TBUILTIN_TOPIC_HPP_

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicListener.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicListener.hpp
@@ -1,15 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #ifndef CYCLONEDDS_TOPIC_TOPIC_LISTENER_HPP_
 #define CYCLONEDDS_TOPIC_TOPIC_LISTENER_HPP_
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicTraits.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/TopicTraits.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2020 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2020 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef DDSCXXDATATOPIC_HPP_
 #define DDSCXXDATATOPIC_HPP_
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/discovery.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/discovery.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/find.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/find.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/hash.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/hash.hpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
  /**
   * @file

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/qos/TopicQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/qos/TopicQosDelegate.hpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/src/dds/core/Duration.cpp
+++ b/src/ddscxx/src/dds/core/Duration.cpp
@@ -54,8 +54,8 @@ void dds::core::Duration::sec(int64_t s)
     if(s < 0) {
         ISOCPP_THROW_EXCEPTION(ISOCPP_ERROR, "dds::core::Duration::sec out of bounds");
     } else {
-        /** @internal @bug OSPL-2308 RTF Time-ish coercion issue
-        @see http://jira.prismtech.com:8080/browse/OSPL-2308 */
+        /// @internal @bug OSPL-2308 RTF Time-ish coercion issue
+        /// @see http://jira.prismtech.com:8080/browse/OSPL-2308
         sec_ = static_cast<int32_t>(s);
     }
 }

--- a/src/ddscxx/src/dds/core/Duration.cpp
+++ b/src/ddscxx/src/dds/core/Duration.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/dds/core/Exception.cpp
+++ b/src/ddscxx/src/dds/core/Exception.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/dds/core/Reference.cpp
+++ b/src/ddscxx/src/dds/core/Reference.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/dds/core/Time.cpp
+++ b/src/ddscxx/src/dds/core/Time.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/dds/core/Time.cpp
+++ b/src/ddscxx/src/dds/core/Time.cpp
@@ -53,8 +53,8 @@ void dds::core::Time::sec(int64_t s)
     if(s < 0 && s != -1) {
         ISOCPP_THROW_EXCEPTION(ISOCPP_ERROR, "dds::core::Time::sec out of bounds");
     } else {
-        /** @internal @bug OSPL-2308 RTF Time-ish coercion issue
-        @see http://jira.prismtech.com:8080/browse/OSPL-2308 */
+        /// @internal @bug OSPL-2308 RTF Time-ish coercion issue
+        /// @see http://jira.prismtech.com:8080/browse/OSPL-2308
         sec_ =  s;
     }
 }

--- a/src/ddscxx/src/dds/core/policy/CorePolicy.cpp
+++ b/src/ddscxx/src/dds/core/policy/CorePolicy.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/dds/core/status/State.cpp
+++ b/src/ddscxx/src/dds/core/status/State.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/dds/core/status/State.cpp
+++ b/src/ddscxx/src/dds/core/status/State.cpp
@@ -24,16 +24,16 @@ namespace status
 SampleRejectedState::SampleRejectedState() : MaskType() { }
 
 SampleRejectedState::SampleRejectedState(const SampleRejectedState& src) : MaskType(
-    /** @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
-    * @see http://connect.microsoft.com/VisualStudio/feedback/details/532897 */
+    /// @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
+    /// @see http://connect.microsoft.com/VisualStudio/feedback/details/532897
 #if _MSC_VER == 1600
         static_cast<int>
 #endif
         (src.to_ulong())) { }
 
 SampleRejectedState::SampleRejectedState(const MaskType& src) : MaskType(
-    /** @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
-    * @see http://connect.microsoft.com/VisualStudio/feedback/details/532897 */
+    /// @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
+    /// @see http://connect.microsoft.com/VisualStudio/feedback/details/532897 */
 #if _MSC_VER == 1600
         static_cast<int>
 #endif
@@ -41,8 +41,8 @@ SampleRejectedState::SampleRejectedState(const MaskType& src) : MaskType(
 
 SampleRejectedState::SampleRejectedState(uint32_t s)
     : MaskType(
-    /** @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
-    * @see http://connect.microsoft.com/VisualStudio/feedback/details/532897 */
+    /// @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
+    /// @see http://connect.microsoft.com/VisualStudio/feedback/details/532897
 #if _MSC_VER == 1600
         static_cast<int>
 #endif
@@ -52,16 +52,16 @@ SampleRejectedState::SampleRejectedState(uint32_t s)
 StatusMask::StatusMask() { }
 
 StatusMask::StatusMask(uint32_t mask) : MaskType(
-    /** @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
-    * @see http://connect.microsoft.com/VisualStudio/feedback/details/532897 */
+    /// @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
+    /// @see http://connect.microsoft.com/VisualStudio/feedback/details/532897
 #if _MSC_VER == 1600
         static_cast<int>
 #endif
         (mask)) { }
 
 StatusMask::StatusMask(const StatusMask& other) : MaskType(
-    /** @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
-    * @see http://connect.microsoft.com/VisualStudio/feedback/details/532897 */
+    /// @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
+    /// @see http://connect.microsoft.com/VisualStudio/feedback/details/532897
 #if _MSC_VER == 1600
         static_cast<int>
 #endif

--- a/src/ddscxx/src/dds/domain/discovery.cpp
+++ b/src/ddscxx/src/dds/domain/discovery.cpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/src/dds/domain/find.cpp
+++ b/src/ddscxx/src/dds/domain/find.cpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/src/dds/pub/pubdiscovery.cpp
+++ b/src/ddscxx/src/dds/pub/pubdiscovery.cpp
@@ -1,16 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 /**
  * @file
  */

--- a/src/ddscxx/src/dds/sub/status/DataState.cpp
+++ b/src/ddscxx/src/dds/sub/status/DataState.cpp
@@ -1,14 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 
 /**
@@ -28,22 +26,22 @@ namespace status
 
 SampleState::SampleState() : MaskType() { }
 SampleState::SampleState(uint32_t i) : MaskType(
-    /** @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
-     * @see http://connect.microsoft.com/VisualStudio/feedback/details/532897 */
+    /// @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
+    /// @see http://connect.microsoft.com/VisualStudio/feedback/details/532897
 #if _MSC_VER == 1600
         static_cast<int>
 #endif
         (i)) { }
 SampleState::SampleState(const SampleState& src) : MaskType(
-    /** @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
-     * @see http://connect.microsoft.com/VisualStudio/feedback/details/532897 */
+    /// @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
+    /// @see http://connect.microsoft.com/VisualStudio/feedback/details/532897
 #if _MSC_VER == 1600
         static_cast<int>
 #endif
         (src.to_ulong())) { }
 SampleState::SampleState(const MaskType& src) : MaskType(
-    /** @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
-    * @see http://connect.microsoft.com/VisualStudio/feedback/details/532897 */
+    /// @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
+    /// @see http://connect.microsoft.com/VisualStudio/feedback/details/532897
 #if _MSC_VER == 1600
         static_cast<int>
 #endif
@@ -51,45 +49,45 @@ SampleState::SampleState(const MaskType& src) : MaskType(
 
 ViewState::ViewState() : MaskType() { }
 ViewState::ViewState(uint32_t m) : MaskType(
-    /** @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
-    * @see http://connect.microsoft.com/VisualStudio/feedback/details/532897 */
+    /// @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
+    /// @see http://connect.microsoft.com/VisualStudio/feedback/details/532897
 #if _MSC_VER == 1600
         static_cast<int>
 #endif
         (m)) { }
 ViewState::ViewState(const ViewState& src) : MaskType(
-    /** @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
-    * @see http://connect.microsoft.com/VisualStudio/feedback/details/532897 */
+    /// @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
+    /// @see http://connect.microsoft.com/VisualStudio/feedback/details/532897
 #if _MSC_VER == 1600
         static_cast<int>
 #endif
         (src.to_ulong())) { }
 ViewState::ViewState(const MaskType& src) : MaskType(
-    /** @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
-    * @see http://connect.microsoft.com/VisualStudio/feedback/details/532897 */
+    /// @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
+    /// @see http://connect.microsoft.com/VisualStudio/feedback/details/532897
 #if _MSC_VER == 1600
         static_cast<int>
 #endif
         (src.to_ulong())) { }
 
 InstanceState::InstanceState(uint32_t m) : MaskType(
-    /** @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
-    * @see http://connect.microsoft.com/VisualStudio/feedback/details/532897 */
+    /// @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
+    /// @see http://connect.microsoft.com/VisualStudio/feedback/details/532897
 #if _MSC_VER == 1600
         static_cast<int>
 #endif
         (m)) { }
 InstanceState::InstanceState() : MaskType() { }
 InstanceState::InstanceState(const InstanceState& src) : MaskType(
-    /** @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
-    * @see http://connect.microsoft.com/VisualStudio/feedback/details/532897 */
+    /// @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
+    /// @see http://connect.microsoft.com/VisualStudio/feedback/details/532897
 #if _MSC_VER == 1600
         static_cast<int>
 #endif
         (src.to_ulong())) { }
 InstanceState::InstanceState(const MaskType& src) : MaskType(
-    /** @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
-    * @see http://connect.microsoft.com/VisualStudio/feedback/details/532897 */
+    /// @internal @note MSVC bug: Problems constructing a bitset from an unsigned long in the VC RC
+    /// @see http://connect.microsoft.com/VisualStudio/feedback/details/532897
 #if _MSC_VER == 1600
         static_cast<int>
 #endif

--- a/src/ddscxx/src/dds/sub/subdiscovery.cpp
+++ b/src/ddscxx/src/dds/sub/subdiscovery.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/dds/sub/subfind.cpp
+++ b/src/ddscxx/src/dds/sub/subfind.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/DDScObjectDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/DDScObjectDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/EntityDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/EntityDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/EntitySet.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/EntitySet.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/InstanceHandleDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/InstanceHandleDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/ListenerDispatcher.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/ListenerDispatcher.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/MiscUtils.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/MiscUtils.cpp
@@ -1,14 +1,12 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/Mutex.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/Mutex.cpp
@@ -1,14 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/ObjectDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/ObjectDelegate.cpp
@@ -1,14 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/ObjectSet.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/ObjectSet.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/ReportUtils.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/ReportUtils.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.cpp
@@ -1,14 +1,12 @@
-/*
- * Copyright(c) 2021 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2021 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 #include <org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp>
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/cdr_stream.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/cdr_stream.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2020 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2020 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <cstring>
 #include <assert.h>
 #include <algorithm>

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/entity_properties.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/entity_properties.cpp
@@ -1,14 +1,12 @@
-/*
- * Copyright(c) 2021 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2021 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 #include <org/eclipse/cyclonedds/core/cdr/entity_properties.hpp>
 #include <iostream>

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.cpp
@@ -1,14 +1,12 @@
-/*
- * Copyright(c) 2020 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2020 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 #include <org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.hpp>
 #include <algorithm>

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.cpp
@@ -1,14 +1,12 @@
-/*
- * Copyright(c) 2020 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2020 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 #include <org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp>
 #include <algorithm>

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/fragchain.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/fragchain.cpp
@@ -1,14 +1,12 @@
-/*
- * Copyright(c) 2022 ZettaScale Technology
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 #include "org/eclipse/cyclonedds/core/cdr/fragchain.hpp"
 #include "dds/core/Exception.hpp"

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/ConditionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/ConditionDelegate.cpp
@@ -1,14 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 #include <org/eclipse/cyclonedds/core/cond/ConditionDelegate.hpp>
 #include <org/eclipse/cyclonedds/core/cond/WaitSetDelegate.hpp>

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/GuardConditionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/GuardConditionDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/StatusConditionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/StatusConditionDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/WaitSetDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cond/WaitSetDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/policy/PolicyDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/policy/PolicyDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/Domain.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/Domain.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantRegistry.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantRegistry.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainWrap.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainWrap.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <org/eclipse/cyclonedds/domain/DomainWrap.hpp>
 #include <org/eclipse/cyclonedds/core/ReportUtils.hpp>
 #include <org/eclipse/cyclonedds/domain/Domain.hpp>

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/qos/DomainParticipantQosDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/qos/DomainParticipantQosDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/AnyDataWriterDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/PublisherDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/PublisherDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/qos/PublisherQosDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/qos/PublisherQosDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/BuiltinSubscriberDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/BuiltinSubscriberDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/QueryDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/QueryDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/SubscriberDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/SubscriberDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/cond/QueryConditionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/cond/QueryConditionDelegate.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <org/eclipse/cyclonedds/sub/cond/QueryConditionDelegate.hpp>
 #include <org/eclipse/cyclonedds/core/ScopedLock.hpp>
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/cond/ReadConditionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/cond/ReadConditionDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 #include <org/eclipse/cyclonedds/sub/cond/ReadConditionDelegate.hpp>
 #include <org/eclipse/cyclonedds/core/ScopedLock.hpp>

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/qos/SubscriberQosDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/qos/SubscriberQosDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/AnyTopicDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/AnyTopicDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/FilterDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/FilterDelegate.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 /**
  * @file
  */

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/TopicDescriptionDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/find.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/find.cpp
@@ -1,14 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 #include <org/eclipse/cyclonedds/topic/find.hpp>
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/hash.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/hash.cpp
@@ -1,14 +1,12 @@
-/*
- * Copyright(c) 2006 to 2020 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2020 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 #include <org/eclipse/cyclonedds/topic/hash.hpp>
 #include "dds/ddsrt/md5.h"

--- a/src/ddscxx/src/org/eclipse/cyclonedds/topic/qos/TopicQosDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/topic/qos/TopicQosDelegate.cpp
@@ -1,15 +1,12 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
-
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 /**
  * @file

--- a/src/ddscxx/tests/Bounded.cpp
+++ b/src/ddscxx/tests/Bounded.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <gtest/gtest.h>
 #include <string>
 

--- a/src/ddscxx/tests/CDRStreamer.cpp
+++ b/src/ddscxx/tests/CDRStreamer.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "CdrDataModels.hpp"

--- a/src/ddscxx/tests/Condition.cpp
+++ b/src/ddscxx/tests/Condition.cpp
@@ -87,7 +87,7 @@ private:
 // class FunctorQueryCondition {
 // public:
 //     void operator ()(dds::sub::cond::QueryCondition) {
-//         /* Empty. */
+//         // Empty
 //     }
 // };
 

--- a/src/ddscxx/tests/Condition.cpp
+++ b/src/ddscxx/tests/Condition.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <gtest/gtest.h>
 
 #include "dds/dds.hpp"

--- a/src/ddscxx/tests/Conversions.cpp
+++ b/src/ddscxx/tests/Conversions.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <gtest/gtest.h>
 
 #include "dds/dds.hpp"

--- a/src/ddscxx/tests/DataModels.cpp
+++ b/src/ddscxx/tests/DataModels.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2022 ZettaScale Technologies
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2022 ZettaScale Technologies
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "CdrDataModels.hpp"

--- a/src/ddscxx/tests/DataReader.cpp
+++ b/src/ddscxx/tests/DataReader.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <gtest/gtest.h>
 
 #include "dds/dds.hpp"

--- a/src/ddscxx/tests/DataReaderManipulatorSelector.cpp
+++ b/src/ddscxx/tests/DataReaderManipulatorSelector.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <gtest/gtest.h>
 
 #include "dds/dds.hpp"

--- a/src/ddscxx/tests/DataReaderSelector.cpp
+++ b/src/ddscxx/tests/DataReaderSelector.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <gtest/gtest.h>
 
 #include "dds/dds.hpp"

--- a/src/ddscxx/tests/DataWriter.cpp
+++ b/src/ddscxx/tests/DataWriter.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "Space.hpp"

--- a/src/ddscxx/tests/DeferredDestruction.cpp
+++ b/src/ddscxx/tests/DeferredDestruction.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2023 ZettaScale Technologies
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2023 ZettaScale Technologies
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "HelloWorldData.hpp"
 
 #include <chrono>

--- a/src/ddscxx/tests/DomainParticipant.cpp
+++ b/src/ddscxx/tests/DomainParticipant.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "dds/ddsrt/environ.h"

--- a/src/ddscxx/tests/Duration.cpp
+++ b/src/ddscxx/tests/Duration.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "dds/dds.hpp"
 
 #include <gtest/gtest.h>

--- a/src/ddscxx/tests/Exception.cpp
+++ b/src/ddscxx/tests/Exception.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "dds/dds.hpp"
 
 #include <gtest/gtest.h>

--- a/src/ddscxx/tests/ExtendedTypes.cpp
+++ b/src/ddscxx/tests/ExtendedTypes.cpp
@@ -1,14 +1,12 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>

--- a/src/ddscxx/tests/External.cpp
+++ b/src/ddscxx/tests/External.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "dds/dds.hpp"
 #include <dds/core/External.hpp>
 #include <thread>

--- a/src/ddscxx/tests/FindDataReader.cpp
+++ b/src/ddscxx/tests/FindDataReader.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <iostream>
 #include <gtest/gtest.h>
 

--- a/src/ddscxx/tests/FindDataWriter.cpp
+++ b/src/ddscxx/tests/FindDataWriter.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <iostream>
 #include <gtest/gtest.h>
 

--- a/src/ddscxx/tests/FindTopic.cpp
+++ b/src/ddscxx/tests/FindTopic.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "Space.hpp"

--- a/src/ddscxx/tests/GeneratedEntities.cpp
+++ b/src/ddscxx/tests/GeneratedEntities.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "EntityProperties.hpp"

--- a/src/ddscxx/tests/Listener.cpp
+++ b/src/ddscxx/tests/Listener.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <chrono>
 #include <thread>
 #include <gtest/gtest.h>

--- a/src/ddscxx/tests/ListenerStress.cpp
+++ b/src/ddscxx/tests/ListenerStress.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <chrono>
 #include <thread>
 

--- a/src/ddscxx/tests/Publisher.cpp
+++ b/src/ddscxx/tests/Publisher.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "HelloWorldData.hpp"

--- a/src/ddscxx/tests/Qos.cpp
+++ b/src/ddscxx/tests/Qos.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 

--- a/src/ddscxx/tests/Query.cpp
+++ b/src/ddscxx/tests/Query.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "Space.hpp"

--- a/src/ddscxx/tests/Regression.cpp
+++ b/src/ddscxx/tests/Regression.cpp
@@ -1,14 +1,12 @@
-/*
- * Copyright(c) 2006 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 #include "dds/ddsrt/misc.h"
 

--- a/src/ddscxx/tests/SampleInfo.cpp
+++ b/src/ddscxx/tests/SampleInfo.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "Space.hpp"

--- a/src/ddscxx/tests/Serdata.cpp
+++ b/src/ddscxx/tests/Serdata.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <gtest/gtest.h>
 
 #include "dds/dds.hpp"

--- a/src/ddscxx/tests/Subscriber.cpp
+++ b/src/ddscxx/tests/Subscriber.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "HelloWorldData.hpp"

--- a/src/ddscxx/tests/Time.cpp
+++ b/src/ddscxx/tests/Time.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 

--- a/src/ddscxx/tests/Topic.cpp
+++ b/src/ddscxx/tests/Topic.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "Space.hpp"

--- a/src/ddscxx/tests/TopicTypeDiscovery.cpp
+++ b/src/ddscxx/tests/TopicTypeDiscovery.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "Space.hpp"

--- a/src/ddscxx/tests/Util.cpp
+++ b/src/ddscxx/tests/Util.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "dds/dds.h"
 #include "dds/ddsrt/atomics.h"
 #include "dds/ddsrt/process.h"

--- a/src/ddscxx/tests/Util.hpp
+++ b/src/ddscxx/tests/Util.hpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef _TEST_UTIL_H
 #define _TEST_UTIL_H
 

--- a/src/ddscxx/tests/WaitSet.cpp
+++ b/src/ddscxx/tests/WaitSet.cpp
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2006 to 2021 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <gtest/gtest.h>
 
 #include "dds/dds.hpp"

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2020 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2020 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <assert.h>
 #include <stdint.h>
 #include <inttypes.h>

--- a/src/idlcxx/src/generator.h
+++ b/src/idlcxx/src/generator.h
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2021 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2021 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #ifndef GENERATOR_H
 #define GENERATOR_H
 

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2021 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2021 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <assert.h>
 #include <stdarg.h>
 #include <stdlib.h>

--- a/src/idlcxx/src/traits.c
+++ b/src/idlcxx/src/traits.c
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2020 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2020 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include <string.h>
 
 #include "idl/stream.h"

--- a/src/idlcxx/src/types.c
+++ b/src/idlcxx/src/types.c
@@ -1,14 +1,13 @@
-/*
- * Copyright(c) 2021 to 2022 ZettaScale Technology and others
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
- * v. 1.0 which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+// Copyright(c) 2021 to 2022 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ 
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>


### PR DESCRIPTION
This resolves the issue of // within /*...*/ comments. These typically feature within the URLs present in the copyright blurbs and are allowed within comments starting with a // but not the /*...*/ style comments. This is applied across all .c, .h, .cpp and .hpp files. See #402 for the PR that includes the GitHub code scanning for the same rule.