### PR TITLE
Removed superfluous template parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,11 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
     -Wunused -Winfinite-recursion -Wassign-enum -Wcomma -Wdocumentation
     -Wconditional-uninitialized -Wshadow -Wsign-conversion -Wpedantic)
   add_compile_options("$<$<STREQUAL:$<TARGET_PROPERTY:LINKER_LANGUAGE>,CXX>:-Wold-style-cast>")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "12.0.0")
+    #the dtor-name compiler option did not exist for older versions
+  else()
+    add_compile_options(-Wno-dtor-name) #suppressing these errors due to CLang adhering too close to the standard, which will be made more in the "spirit" of template classes starting C++23
+  endif()
   if(WERROR)
     add_compile_options(-Werror)
   endif()

--- a/src/ddscxx/include/dds/core/detail/ReferenceImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/ReferenceImpl.hpp
@@ -59,7 +59,7 @@ dds::core::Reference<DELEGATE>::Reference(const DELEGATE_REF_T& p) : impl_(p)
 }
 
 template <typename DELEGATE>
-dds::core::Reference<DELEGATE>::~Reference<DELEGATE>()
+dds::core::Reference<DELEGATE>::~Reference()
 {
 }
 

--- a/src/ddscxx/include/dds/pub/detail/DataWriterImpl.hpp
+++ b/src/ddscxx/include/dds/pub/detail/DataWriterImpl.hpp
@@ -395,7 +395,7 @@ dds::pub::detail::DataWriter<T>::DataWriter(
 }
 
 template <typename T>
-dds::pub::detail::DataWriter<T>::~DataWriter<T>()
+dds::pub::detail::DataWriter<T>::~DataWriter()
 {
     if (!this->closed) {
         try {

--- a/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TDataReaderImpl.hpp
@@ -510,7 +510,7 @@ dds::sub::detail::DataReader<T>::common_constructor(
 }
 
 template <typename T>
-dds::sub::detail::DataReader<T>::~DataReader<T>()
+dds::sub::detail::DataReader<T>::~DataReader()
 {
     if (!this->closed) {
         try {

--- a/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
@@ -208,7 +208,7 @@ dds::topic::detail::Topic<T>::Topic(const dds::domain::DomainParticipant& dp,
 
 
 template <typename T>
-dds::topic::detail::Topic<T>::~Topic<T>()
+dds::topic::detail::Topic<T>::~Topic()
 {
     if (!closed) {
         try {


### PR DESCRIPTION
This due to an error in the spec which is not due to be fixed until C++23
As CLang compiles with pedantic by default, the template signature warnings are now also included by default, these warnings are now suppressed, but only for CLang version>=12

This should also solve PR #187 without having code inside #ifdefs