### PR TITLE
Added output directory to idlcxx

### DIFF
--- a/src/idlcxx/Generate.cmake
+++ b/src/idlcxx/Generate.cmake
@@ -11,7 +11,7 @@
 #
 
 function(IDLCXX_GENERATE)
-  set(one_value_keywords TARGET DEFAULT_EXTENSIBILITY OUTPUT_DIR)
+  set(one_value_keywords TARGET DEFAULT_EXTENSIBILITY BASE_DIR OUTPUT_DIR)
   set(multi_value_keywords FILES FEATURES INCLUDES WARNINGS)
   cmake_parse_arguments(
     IDLCXX "" "${one_value_keywords}" "${multi_value_keywords}" "" ${ARGN})
@@ -34,6 +34,7 @@ function(IDLCXX_GENERATE)
 
   idlc_generate_generic(TARGET ${IDLCXX_TARGET}
     BACKEND ${_idlcxx_shared_lib}
+    BASE_DIR ${IDLCXX_BASE_DIR}
     FILES ${IDLCXX_FILES}
     FEATURES ${IDLCXX_FEATURES}
     INCLUDES ${IDLCXX_INCLUDES}


### PR DESCRIPTION
The output directory parameter was not being used in when passed from idlc compiler to idlcxx library
Fixed so the output directory is now used in idlcxx
This should fix issue #413

@vecenyang : thanks for the suggested solution, can I rely on you to do a review of this PR?