### PR TITLE
Fixed missing callbacks for pending events

### DIFF
--- a/src/ddscxx/include/dds/pub/detail/DataWriter.hpp
+++ b/src/ddscxx/include/dds/pub/detail/DataWriter.hpp
@@ -60,9 +60,7 @@ public:
 
     DataWriter(const dds::pub::Publisher& pub,
                const ::dds::topic::Topic<T>& topic,
-               const dds::pub::qos::DataWriterQos& qos,
-               dds::pub::DataWriterListener<T>* listener,
-               const dds::core::status::StatusMask& mask);
+               const dds::pub::qos::DataWriterQos& qos);
 
     virtual ~DataWriter();
 

--- a/src/ddscxx/include/dds/sub/detail/DataReader.hpp
+++ b/src/ddscxx/include/dds/sub/detail/DataReader.hpp
@@ -45,18 +45,13 @@ public:
 
     DataReader(const dds::sub::Subscriber& sub,
                const dds::topic::Topic<T>& topic,
-               const dds::sub::qos::DataReaderQos& qos,
-               dds::sub::DataReaderListener<T>* listener = NULL,
-               const dds::core::status::StatusMask& mask = ::dds::core::status::StatusMask::none());
+               const dds::sub::qos::DataReaderQos& qos);
 
     DataReader(const dds::sub::Subscriber& sub,
                const dds::topic::ContentFilteredTopic<T, dds::topic::detail::ContentFilteredTopic>& topic,
-               const dds::sub::qos::DataReaderQos& qos,
-               dds::sub::DataReaderListener<T>* listener = NULL,
-               const dds::core::status::StatusMask& mask = ::dds::core::status::StatusMask::none());
+               const dds::sub::qos::DataReaderQos& qos);
 
-    void common_constructor(dds::sub::DataReaderListener<T>* listener,
-                            const dds::core::status::StatusMask& mask);
+    void common_constructor();
 
     virtual ~DataReader();
 

--- a/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TTopicImpl.hpp
@@ -229,7 +229,7 @@ dds::topic::detail::Topic<T>::close()
         ISOCPP_THROW_EXCEPTION(ISOCPP_PRECONDITION_NOT_MET_ERROR, "Topic still has unclosed dependencies (e.g. Readers/Writers/ContentFilteredTopics)");
     }
 
-    this->listener_set(NULL, dds::core::status::StatusMask::none());
+    this->listener_set(NULL, dds::core::status::StatusMask::none(), true);
 
     this->myParticipant.delegate()->remove_topic(*this);
 
@@ -260,7 +260,7 @@ dds::topic::detail::Topic<T>::listener(TopicListener<T>* listener,
                                        const ::dds::core::status::StatusMask& mask)
 {
     org::eclipse::cyclonedds::core::ScopedObjectLock scopedLock(*this);
-    this->listener_set(listener, mask);
+    this->listener_set(listener, mask, true);
     scopedLock.unlock();
 }
 

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/EntityDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/EntityDelegate.hpp
@@ -30,6 +30,14 @@ namespace cyclonedds
 {
 namespace core
 {
+class OMG_DDS_API EntityDelegate;
+
+struct ListenerArg {
+    EntityDelegate *cpp_ref;
+    bool reset_on_invoke;
+
+    ListenerArg(EntityDelegate *cpp_ref_, bool reset_on_invoke_);
+};
 
 class OMG_DDS_API EntityDelegate :
     public virtual ::org::eclipse::cyclonedds::core::DDScObjectDelegate
@@ -62,7 +70,10 @@ public:
 
 protected:
     void listener_set(void *listener,
-            const dds::core::status::StatusMask& mask);
+            const dds::core::status::StatusMask& mask,
+            bool reset_on_invoke);
+
+    void prevent_callbacks();
 
 public:
     const dds::core::status::StatusMask get_listener_mask() const ;
@@ -118,7 +129,6 @@ protected:
     static volatile unsigned int entityID_;
     bool enabled_;
     dds::core::status::StatusMask listener_mask;
-    void prevent_callbacks();
     long callback_count;
     dds_listener_t *listener_callbacks;
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/ListenerDispatcher.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/ListenerDispatcher.cpp
@@ -33,15 +33,15 @@ extern "C"
   DDS_FN_EXPORT void callback_on_inconsistent_topic
     (dds_entity_t topic, dds_inconsistent_topic_status_t status, void* arg)
   {
-    org::eclipse::cyclonedds::core::EntityDelegate *ed =
-        reinterpret_cast<org::eclipse::cyclonedds::core::EntityDelegate *>(arg);
+    org::eclipse::cyclonedds::core::ListenerArg *la =
+      reinterpret_cast<org::eclipse::cyclonedds::core::ListenerArg *>(arg);
 
-    if (ed->obtain_callback_lock())
+    if (la->reset_on_invoke && la->cpp_ref->obtain_callback_lock())
     {
-       org::eclipse::cyclonedds::core::InconsistentTopicStatusDelegate sd;
-       sd.ddsc_status(&status);
-       ed->on_inconsistent_topic(topic, sd);
-       ed->release_callback_lock();
+      org::eclipse::cyclonedds::core::InconsistentTopicStatusDelegate sd;
+      sd.ddsc_status(&status);
+      la->cpp_ref->on_inconsistent_topic(topic, sd);
+      la->cpp_ref->release_callback_lock();
     }
   }
 
@@ -49,60 +49,60 @@ extern "C"
   DDS_FN_EXPORT void callback_on_offered_deadline_missed
     (dds_entity_t writer, dds_offered_deadline_missed_status_t status, void* arg)
   {
-    org::eclipse::cyclonedds::core::EntityDelegate *ed =
-        reinterpret_cast<org::eclipse::cyclonedds::core::EntityDelegate *>(arg);
+    org::eclipse::cyclonedds::core::ListenerArg *la =
+      reinterpret_cast<org::eclipse::cyclonedds::core::ListenerArg *>(arg);
 
-    if (ed->obtain_callback_lock())
+    if (la->reset_on_invoke && la->cpp_ref->obtain_callback_lock())
     {
-       org::eclipse::cyclonedds::core::OfferedDeadlineMissedStatusDelegate sd;
-       sd.ddsc_status(&status);
-       ed->on_offered_deadline_missed(writer, sd);
-       ed->release_callback_lock();
+      org::eclipse::cyclonedds::core::OfferedDeadlineMissedStatusDelegate sd;
+      sd.ddsc_status(&status);
+      la->cpp_ref->on_offered_deadline_missed(writer, sd);
+      la->cpp_ref->release_callback_lock();
     }
   }
 
   DDS_FN_EXPORT void callback_on_offered_incompatible_qos
     (dds_entity_t writer, dds_offered_incompatible_qos_status_t status, void* arg)
   {
-    org::eclipse::cyclonedds::core::EntityDelegate *ed =
-      reinterpret_cast<org::eclipse::cyclonedds::core::EntityDelegate *>(arg);
+    org::eclipse::cyclonedds::core::ListenerArg *la =
+      reinterpret_cast<org::eclipse::cyclonedds::core::ListenerArg *>(arg);
 
-    if (ed->obtain_callback_lock())
+    if (la->reset_on_invoke && la->cpp_ref->obtain_callback_lock())
     {
-       org::eclipse::cyclonedds::core::OfferedIncompatibleQosStatusDelegate sd;
-       sd.ddsc_status(&status);
-       ed->on_offered_incompatible_qos(writer, sd);
-       ed->release_callback_lock();
+      org::eclipse::cyclonedds::core::OfferedIncompatibleQosStatusDelegate sd;
+      sd.ddsc_status(&status);
+      la->cpp_ref->on_offered_incompatible_qos(writer, sd);
+      la->cpp_ref->release_callback_lock();
     }
   }
 
   DDS_FN_EXPORT void callback_on_liveliness_lost
     (dds_entity_t writer, dds_liveliness_lost_status_t status, void* arg)
   {
-    org::eclipse::cyclonedds::core::EntityDelegate *ed =
-        reinterpret_cast<org::eclipse::cyclonedds::core::EntityDelegate *>(arg);
+    org::eclipse::cyclonedds::core::ListenerArg *la =
+      reinterpret_cast<org::eclipse::cyclonedds::core::ListenerArg *>(arg);
 
-    if (ed->obtain_callback_lock())
+    if (la->reset_on_invoke && la->cpp_ref->obtain_callback_lock())
     {
-       org::eclipse::cyclonedds::core::LivelinessLostStatusDelegate sd;
-       sd.ddsc_status(&status);
-       ed->on_liveliness_lost(writer, sd);
-       ed->release_callback_lock();
+      org::eclipse::cyclonedds::core::LivelinessLostStatusDelegate sd;
+      sd.ddsc_status(&status);
+      la->cpp_ref->on_liveliness_lost(writer, sd);
+      la->cpp_ref->release_callback_lock();
     }
   }
 
   DDS_FN_EXPORT void callback_on_publication_matched
     (dds_entity_t writer, dds_publication_matched_status_t status, void* arg)
   {
-    org::eclipse::cyclonedds::core::EntityDelegate *ed =
-        reinterpret_cast<org::eclipse::cyclonedds::core::EntityDelegate *>(arg);
+    org::eclipse::cyclonedds::core::ListenerArg *la =
+      reinterpret_cast<org::eclipse::cyclonedds::core::ListenerArg *>(arg);
 
-    if (ed->obtain_callback_lock())
+    if (la->reset_on_invoke && la->cpp_ref->obtain_callback_lock())
     {
-       org::eclipse::cyclonedds::core::PublicationMatchedStatusDelegate sd;
-       sd.ddsc_status(&status);
-       ed->on_publication_matched(writer, sd);
-       ed->release_callback_lock();
+      org::eclipse::cyclonedds::core::PublicationMatchedStatusDelegate sd;
+      sd.ddsc_status(&status);
+      la->cpp_ref->on_publication_matched(writer, sd);
+      la->cpp_ref->release_callback_lock();
     }
   }
 
@@ -110,113 +110,115 @@ extern "C"
   DDS_FN_EXPORT void callback_on_requested_deadline_missed
     (dds_entity_t reader, dds_requested_deadline_missed_status_t status, void* arg)
   {
-    org::eclipse::cyclonedds::core::EntityDelegate *ed =
-        reinterpret_cast<org::eclipse::cyclonedds::core::EntityDelegate *>(arg);
+    org::eclipse::cyclonedds::core::ListenerArg *la =
+      reinterpret_cast<org::eclipse::cyclonedds::core::ListenerArg *>(arg);
 
-    if (ed->obtain_callback_lock())
+    if (la->reset_on_invoke && la->cpp_ref->obtain_callback_lock())
     {
-       org::eclipse::cyclonedds::core::RequestedDeadlineMissedStatusDelegate sd;
-       sd.ddsc_status(&status);
-       ed->on_requested_deadline_missed(reader, sd);
-       ed->release_callback_lock();
+      org::eclipse::cyclonedds::core::RequestedDeadlineMissedStatusDelegate sd;
+      sd.ddsc_status(&status);
+      la->cpp_ref->on_requested_deadline_missed(reader, sd);
+      la->cpp_ref->release_callback_lock();
     }
   }
 
   DDS_FN_EXPORT void callback_on_requested_incompatible_qos
     (dds_entity_t reader, dds_requested_incompatible_qos_status_t status, void* arg)
   {
-    org::eclipse::cyclonedds::core::EntityDelegate *ed =
-        reinterpret_cast<org::eclipse::cyclonedds::core::EntityDelegate *>(arg);
+    org::eclipse::cyclonedds::core::ListenerArg *la =
+      reinterpret_cast<org::eclipse::cyclonedds::core::ListenerArg *>(arg);
 
-    if (ed->obtain_callback_lock())
+    if (la->reset_on_invoke && la->cpp_ref->obtain_callback_lock())
     {
-       org::eclipse::cyclonedds::core::RequestedIncompatibleQosStatusDelegate sd;
-       sd.ddsc_status(&status);
-       ed->on_requested_incompatible_qos(reader, sd);
-       ed->release_callback_lock();
+      org::eclipse::cyclonedds::core::RequestedIncompatibleQosStatusDelegate sd;
+      sd.ddsc_status(&status);
+      la->cpp_ref->on_requested_incompatible_qos(reader, sd);
+      la->cpp_ref->release_callback_lock();
     }
   }
 
   DDS_FN_EXPORT void callback_on_sample_rejected
     (dds_entity_t reader, dds_sample_rejected_status_t status, void* arg)
   {
-    org::eclipse::cyclonedds::core::EntityDelegate *ed =
-        reinterpret_cast<org::eclipse::cyclonedds::core::EntityDelegate *>(arg);
+    org::eclipse::cyclonedds::core::ListenerArg *la =
+      reinterpret_cast<org::eclipse::cyclonedds::core::ListenerArg *>(arg);
 
-    if (ed->obtain_callback_lock())
+    if (la->reset_on_invoke && la->cpp_ref->obtain_callback_lock())
     {
-       org::eclipse::cyclonedds::core::SampleRejectedStatusDelegate sd;
-       sd.ddsc_status(&status);
-       ed->on_sample_rejected(reader, sd);
-       ed->release_callback_lock();
+      org::eclipse::cyclonedds::core::SampleRejectedStatusDelegate sd;
+      sd.ddsc_status(&status);
+      la->cpp_ref->on_sample_rejected(reader, sd);
+      la->cpp_ref->release_callback_lock();
     }
   }
 
   DDS_FN_EXPORT void callback_on_liveliness_changed
     (dds_entity_t reader, dds_liveliness_changed_status_t status, void* arg)
   {
-    org::eclipse::cyclonedds::core::EntityDelegate *ed =
-        reinterpret_cast<org::eclipse::cyclonedds::core::EntityDelegate *>(arg);
+    org::eclipse::cyclonedds::core::ListenerArg *la =
+      reinterpret_cast<org::eclipse::cyclonedds::core::ListenerArg *>(arg);
 
-    if (ed->obtain_callback_lock())
+    if (la->reset_on_invoke && la->cpp_ref->obtain_callback_lock())
     {
-       org::eclipse::cyclonedds::core::LivelinessChangedStatusDelegate sd;
-       sd.ddsc_status(&status);
-       ed->on_liveliness_changed(reader, sd);
-       ed->release_callback_lock();
+      org::eclipse::cyclonedds::core::LivelinessChangedStatusDelegate sd;
+      sd.ddsc_status(&status);
+      la->cpp_ref->on_liveliness_changed(reader, sd);
+      la->cpp_ref->release_callback_lock();
     }
   }
 
   DDS_FN_EXPORT void callback_on_data_available (dds_entity_t reader, void* arg)
   {
-    org::eclipse::cyclonedds::core::EntityDelegate *ed =
-        reinterpret_cast<org::eclipse::cyclonedds::core::EntityDelegate *>(arg);
-    if (ed->obtain_callback_lock())
+    org::eclipse::cyclonedds::core::ListenerArg *la =
+      reinterpret_cast<org::eclipse::cyclonedds::core::ListenerArg *>(arg);
+
+    if (la->reset_on_invoke && la->cpp_ref->obtain_callback_lock())
     {
-       ed->on_data_available(reader);
-       ed->release_callback_lock();
+      la->cpp_ref->on_data_available(reader);
+      la->cpp_ref->release_callback_lock();
     }
   }
 
   DDS_FN_EXPORT void callback_on_subscription_matched
     (dds_entity_t reader, dds_subscription_matched_status_t status, void* arg)
   {
-    org::eclipse::cyclonedds::core::EntityDelegate *ed =
-        reinterpret_cast<org::eclipse::cyclonedds::core::EntityDelegate *>(arg);
+    org::eclipse::cyclonedds::core::ListenerArg *la =
+      reinterpret_cast<org::eclipse::cyclonedds::core::ListenerArg *>(arg);
 
-    if (ed->obtain_callback_lock())
+    if (la->reset_on_invoke && la->cpp_ref->obtain_callback_lock())
     {
-       org::eclipse::cyclonedds::core::SubscriptionMatchedStatusDelegate sd;
-       sd.ddsc_status(&status);
-       ed->on_subscription_matched(reader, sd);
-       ed->release_callback_lock();
+      org::eclipse::cyclonedds::core::SubscriptionMatchedStatusDelegate sd;
+      sd.ddsc_status(&status);
+      la->cpp_ref->on_subscription_matched(reader, sd);
+      la->cpp_ref->release_callback_lock();
     }
   }
 
   DDS_FN_EXPORT void callback_on_sample_lost
     (dds_entity_t reader, dds_sample_lost_status_t status, void* arg)
   {
-    org::eclipse::cyclonedds::core::EntityDelegate *ed =
-        reinterpret_cast<org::eclipse::cyclonedds::core::EntityDelegate *>(arg);
+    org::eclipse::cyclonedds::core::ListenerArg *la =
+      reinterpret_cast<org::eclipse::cyclonedds::core::ListenerArg *>(arg);
 
-    if (ed->obtain_callback_lock())
+    if (la->reset_on_invoke && la->cpp_ref->obtain_callback_lock())
     {
-       org::eclipse::cyclonedds::core::SampleLostStatusDelegate sd;
-       sd.ddsc_status(&status);
-       ed->on_sample_lost(reader, sd);
-       ed->release_callback_lock();
+      org::eclipse::cyclonedds::core::SampleLostStatusDelegate sd;
+      sd.ddsc_status(&status);
+      la->cpp_ref->on_sample_lost(reader, sd);
+      la->cpp_ref->release_callback_lock();
     }
   }
 
   // Subscriber callback
   DDS_FN_EXPORT void callback_on_data_readers (dds_entity_t subscriber, void* arg)
   {
-    org::eclipse::cyclonedds::core::EntityDelegate *ed =
-        reinterpret_cast<org::eclipse::cyclonedds::core::EntityDelegate *>(arg);
-    if (ed->obtain_callback_lock())
+    org::eclipse::cyclonedds::core::ListenerArg *la =
+      reinterpret_cast<org::eclipse::cyclonedds::core::ListenerArg *>(arg);
+
+    if (la->reset_on_invoke && la->cpp_ref->obtain_callback_lock())
     {
-       ed->on_data_readers(subscriber);
-       ed->release_callback_lock();
+      la->cpp_ref->on_data_readers(subscriber);
+      la->cpp_ref->release_callback_lock();
     }
   }
 }

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/DomainParticipantDelegate.cpp
@@ -274,7 +274,7 @@ org::eclipse::cyclonedds::domain::DomainParticipantDelegate::close()
     this->topics.all_close();
 
     /* Stop listener. */
-    this->listener_set(NULL, dds::core::status::StatusMask::none());
+    this->listener_set(NULL, dds::core::status::StatusMask::none(), true);
 
     org::eclipse::cyclonedds::domain::DomainParticipantRegistry::remove(this);
 
@@ -584,7 +584,7 @@ org::eclipse::cyclonedds::domain::DomainParticipantDelegate::listener(
         const ::dds::core::status::StatusMask& mask)
 {
     org::eclipse::cyclonedds::core::ScopedObjectLock scopedLock(*this);
-    this->listener_set(listener, mask);
+    this->listener_set(listener, mask, true);
     scopedLock.unlock();
 }
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/PublisherDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/PublisherDelegate.cpp
@@ -98,7 +98,7 @@ PublisherDelegate::close()
     this->writers.all_close();
 
     /* Stop listener. */
-    this->listener_set(NULL, dds::core::status::StatusMask::none());
+    this->listener_set(NULL, dds::core::status::StatusMask::none(), true);
 
     /* Unregister Publisher from Participant. */
     this->dp_.delegate()->remove_publisher(*this);
@@ -187,7 +187,7 @@ PublisherDelegate::listener(dds::pub::PublisherListener* listener,
                             const ::dds::core::status::StatusMask& mask)
 {
     org::eclipse::cyclonedds::core::ScopedObjectLock scopedLock(*this);
-    this->listener_set(listener, mask);
+    this->listener_set(listener, mask, true);
     scopedLock.unlock();
 }
 

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/SubscriberDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/SubscriberDelegate.cpp
@@ -98,7 +98,7 @@ SubscriberDelegate::close()
     this->readers.all_close();
 
     /* Stop listener. */
-    this->listener_set(NULL, dds::core::status::StatusMask::none());
+    this->listener_set(NULL, dds::core::status::StatusMask::none(), true);
 
     /* Unregister Subscriber from Participant. */
     this->dp_.delegate()->remove_subscriber(*this);
@@ -173,7 +173,7 @@ SubscriberDelegate::listener(dds::sub::SubscriberListener* listener,
                             const ::dds::core::status::StatusMask& mask)
 {
     org::eclipse::cyclonedds::core::ScopedObjectLock scopedLock(*this);
-    this->listener_set(listener, mask);
+    this->listener_set(listener, mask, true);
     scopedLock.unlock();
 }
 

--- a/src/ddscxx/tests/Listener.cpp
+++ b/src/ddscxx/tests/Listener.cpp
@@ -1015,7 +1015,7 @@ TEST_F(Listener, liveliness_changed)
     ASSERT_EQ(status.last_publication_handle(), instance_handle);
 }
 
-TEST_F(Listener, DISABLED_incompatible_qos)
+TEST_F(Listener, incompatible_qos)
 {
     DataReaderListener readerListener;
     DataWriterListener writerListener;
@@ -1421,7 +1421,7 @@ TEST_F(Listener, data_available_participant)
 // TODO:
 // this test does not work because listener on publisher is triggered when writer is created
 // but before ddsc handle for writer is stored in the writer entity.
-TEST_F(Listener, DISABLED_propagation)
+TEST_F(Listener, propagation)
 {
     DomainParticipantListener participantListener;
     SubscriberListener subscriberListener;


### PR DESCRIPTION
When creating an Entity with a Listener, any instantaneous events that occurred during creation would miss their callback. 
This was caused by the C++ API not being able to wrap the underlying C API with a C++ object prior to C already trying to invoking the callback. 
That is now resolved by not setting the Listener at creation time, but by setting it after successfully putting a C++ wrapper around the underlying C Entity.
This should fix issue #410
A prerequisite for applying this fix is to make sure pull request #https://github.com/eclipse-cyclonedds/cyclonedds/pull/1717 is applied to the cyclonedds repository.