### PR TITLE
Clean up the C++ code to read/take samples from a DataReader

### DIFF
--- a/src/ddscxx/CMakeLists.txt
+++ b/src/ddscxx/CMakeLists.txt
@@ -59,6 +59,7 @@ set(sources
     src/org/eclipse/cyclonedds/sub/SubscriberDelegate.cpp
     src/org/eclipse/cyclonedds/sub/BuiltinSubscriberDelegate.cpp
     src/org/eclipse/cyclonedds/sub/QueryDelegate.cpp
+    src/org/eclipse/cyclonedds/sub/SampleInfoImpl.cpp
     src/org/eclipse/cyclonedds/sub/cond/ReadConditionDelegate.cpp
     src/org/eclipse/cyclonedds/sub/cond/QueryConditionDelegate.cpp
     src/org/eclipse/cyclonedds/sub/qos/SubscriberQosDelegate.cpp

--- a/src/ddscxx/include/dds/sub/TSampleInfo.hpp
+++ b/src/ddscxx/include/dds/sub/TSampleInfo.hpp
@@ -71,6 +71,14 @@ public:
     TSampleInfo();
     /** @endcond */
 
+    /** @cond
+     * Create a SampleInfo with the specified contents in the delegate.
+     * This constructor is required for containers.
+     * An application would normally not create a SampleInfo itself.
+     * So, do not put the creation in the API documentation for clarity.
+     */
+    TSampleInfo(const DELEGATE &d);
+
 public:
     /**
      * Gets the timestamp of the sample.

--- a/src/ddscxx/include/dds/sub/detail/LoanedSamples.hpp
+++ b/src/ddscxx/include/dds/sub/detail/LoanedSamples.hpp
@@ -76,6 +76,10 @@ public:
         return this->samples_.data();
     }
 
+    void append_sample(dds::sub::SampleRef<T, dds::sub::detail::SampleRef>& s) {
+        samples_.push_back(s);
+    }
+
 
 private:
     LoanedSamplesContainer samples_;
@@ -137,6 +141,10 @@ public:
 
     dds::sub::Sample<org::eclipse::cyclonedds::topic::CDRBlob, dds::sub::detail::Sample> * get_buffer() {
         return this->samples_.data();
+    }
+
+    void append_sample(dds::sub::Sample<org::eclipse::cyclonedds::topic::CDRBlob, dds::sub::detail::Sample>& s) {
+        samples_.push_back(s);
     }
 
 

--- a/src/ddscxx/include/dds/sub/detail/Sample.hpp
+++ b/src/ddscxx/include/dds/sub/detail/Sample.hpp
@@ -29,7 +29,7 @@ class Sample;
 }}}
 
 #include <dds/sub/SampleInfo.hpp>
-//#include <dds/sub/detail/TSampleImpl.hpp>
+#include <org/eclipse/cyclonedds/topic/datatopic.hpp>
 
 namespace dds
 {
@@ -43,11 +43,8 @@ class Sample
 public:
     Sample() { }
 
-    Sample(const T& d, const dds::sub::SampleInfo& i)
-    {
-        this->data_ = d;
-        this->info_ = i;
-    }
+    Sample(const T& d, const dds::sub::SampleInfo& i) : data_(d), info_(i)
+    {  }
 
     Sample(const Sample& other)
     {

--- a/src/ddscxx/include/dds/sub/detail/SampleRef.hpp
+++ b/src/ddscxx/include/dds/sub/detail/SampleRef.hpp
@@ -46,9 +46,9 @@ public:
       this->data_ = nullptr;
     }
 
-    SampleRef(ddscxx_serdata<T>* d, const dds::sub::SampleInfo& i)
+    SampleRef(ddscxx_serdata<T>* sd, const dds::sub::SampleInfo& i)
     {
-        this->data_ = d;
+        this->data_ = static_cast<ddscxx_serdata<T> *>(ddsi_serdata_ref (sd));
         this->info_ = i;
     }
 
@@ -59,9 +59,9 @@ public:
 
     virtual ~SampleRef()
     {
-      if (data_ != nullptr) {
-        ddsi_serdata_unref(reinterpret_cast<ddsi_serdata *>(data_));
-      }
+        if (data_ != nullptr) {
+            ddsi_serdata_unref(data_);
+        }
     }
 
     SampleRef& operator=(const SampleRef& other)
@@ -78,7 +78,7 @@ public:
     {
       if (data_ == nullptr)
       {
-        throw dds::core::Error("Data is Null");
+          throw dds::core::Error("Data is Null");
       }
       return *data_->getT();
     }
@@ -93,6 +93,10 @@ public:
         return info_;
     }
 
+    void info(const dds::sub::SampleInfo &sid) {
+        this->info_ = sid;
+    }
+
     bool operator ==(const SampleRef& other) const
     {
         (void)other;
@@ -104,6 +108,13 @@ public:
         return this->data_;
     }
 
+    void data_ptr(const ddscxx_serdata<T> *sd)
+    {
+        if (data_ != nullptr) {
+            ddsi_serdata_unref(data_);
+        }
+        this->data_ = static_cast<ddscxx_serdata<T> *>(ddsi_serdata_ref (sd));
+    }
 
 private:
     void copy(const SampleRef& other)
@@ -112,8 +123,7 @@ private:
         {
             throw dds::core::Error("Other data is Null");
         }
-        static_cast<void>(ddsi_serdata_ref(reinterpret_cast<ddsi_serdata* const>(other.data_)));
-        this->data_ = other.data_;
+        this->data_ = static_cast<ddscxx_serdata<T> *>(ddsi_serdata_ref (other.data_));
         this->info_ = other.info_;
     }
 

--- a/src/ddscxx/include/dds/sub/detail/TSampleInfoImpl.hpp
+++ b/src/ddscxx/include/dds/sub/detail/TSampleInfoImpl.hpp
@@ -30,6 +30,9 @@ template <typename DELEGATE>
 TSampleInfo<DELEGATE>::TSampleInfo() { }
 
 template <typename DELEGATE>
+TSampleInfo<DELEGATE>::TSampleInfo(const DELEGATE &d) : dds::core::Value<DELEGATE>(d) { }
+
+template <typename DELEGATE>
 const dds::core::Time TSampleInfo<DELEGATE>::timestamp() const
 {
     return this->delegate().timestamp();

--- a/src/ddscxx/include/dds/topic/detail/ContentFilteredTopic.hpp
+++ b/src/ddscxx/include/dds/topic/detail/ContentFilteredTopic.hpp
@@ -213,11 +213,7 @@ public:
 
     bool check_sample(const void *, const dds_sample_info_t * sampleinfo) override
     {
-      dds::sub::SampleInfo cxxSampleInfo;
-      org::eclipse::cyclonedds::sub::AnyDataReaderDelegate::copy_sample_infos(
-        *sampleinfo,
-        cxxSampleInfo);
-      return myFunctor(cxxSampleInfo);
+      return myFunctor(dds::sub::detail::SamplesHolder::sample_info_from_c(sampleinfo));
     }
 
 private:
@@ -234,10 +230,7 @@ public:
 
     bool check_sample(const void * sample, const dds_sample_info_t * sampleinfo) override
     {
-      dds::sub::SampleInfo cxxSampleInfo;
-      org::eclipse::cyclonedds::sub::AnyDataReaderDelegate::copy_sample_infos(*sampleinfo,
-        cxxSampleInfo);
-      return myFunctor(*(reinterpret_cast<const T*>(sample)), cxxSampleInfo);
+      return myFunctor(*(reinterpret_cast<const T*>(sample)), dds::sub::detail::SamplesHolder::sample_info_from_c(sampleinfo));
     }
 
 private:

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/SampleInfoImpl.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/SampleInfoImpl.hpp
@@ -18,6 +18,11 @@
 #include <org/eclipse/cyclonedds/core/config.hpp>
 #include <dds/sub/Rank.hpp>
 #include <dds/sub/GenerationCount.hpp>
+#include <dds/core/Time.hpp>
+#include <dds/sub/status/DataState.hpp>
+#include <dds/core/InstanceHandle.hpp>
+
+#include <dds/dds.h>
 
 namespace org
 {
@@ -38,7 +43,8 @@ class org::eclipse::cyclonedds::sub::SampleInfoImpl
 {
 public:
     SampleInfoImpl() : valid_(false) { }
-public:
+
+    SampleInfoImpl(const dds_sample_info_t *from);
 
     inline const dds::core::Time timestamp() const
     {
@@ -110,27 +116,13 @@ public:
         this->publication_handle_ = h;
     }
 
-    bool operator==(const SampleInfoImpl& other) const
-    {
-        return this->source_timestamp_ == other.timestamp()
-               && state_is_equal(this->state_, other.state())
-               && this->generation_count_ == other.generation_count()
-               && this->rank_ == other.rank()
-               && this->valid_ == other.valid()
-               && this->instance_handle_ == other.instance_handle()
-               && this->publication_handle_ == other.publication_handle();
-    }
+    bool operator==(const SampleInfoImpl& other) const;
 
 
 private:
     static bool state_is_equal(
                     const dds::sub::status::DataState& s1,
-                    const dds::sub::status::DataState& s2)
-    {
-        return s1.instance_state() == s2.instance_state()
-               && s1.view_state() == s2.view_state()
-               && s1.sample_state() == s2.sample_state();
-    }
+                    const dds::sub::status::DataState& s2);
 
 private:
     dds::core::Time source_timestamp_;
@@ -142,6 +134,5 @@ private:
     dds::core::InstanceHandle publication_handle_;
 
 };
-
 
 #endif /* CYCLONEDDS_SUB_SAMPLE_INFO_IMPL_HPP_ */

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/SampleInfoImpl.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/SampleInfoImpl.cpp
@@ -1,0 +1,53 @@
+// Copyright(c) 2006 to 2021 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+/**
+ * @file
+ */
+
+#include <org/eclipse/cyclonedds/sub/SampleInfoImpl.hpp>
+#include <org/eclipse/cyclonedds/core/MiscUtils.hpp>
+#include <dds/sub/status/detail/DataStateImpl.hpp>
+
+//org::eclipse::cyclonedds::sub::SampleInfoImpl::SampleInfoImpl() : valid_(false) { }
+
+org::eclipse::cyclonedds::sub::SampleInfoImpl::SampleInfoImpl(const dds_sample_info_t *from) :
+    source_timestamp_(org::eclipse::cyclonedds::core::convertTime(from->source_timestamp)),
+    state_(dds::sub::status::DataState(
+        from->sample_state == DDS_SST_READ ? dds::sub::status::SampleState::read() : dds::sub::status::SampleState::not_read(),
+        from->view_state == DDS_VST_NEW ? dds::sub::status::ViewState::new_view() : dds::sub::status::ViewState::not_new_view(),
+        from->instance_state == DDS_IST_ALIVE ? dds::sub::status::InstanceState::alive() :
+            (from->instance_state == DDS_IST_NOT_ALIVE_DISPOSED ? dds::sub::status::InstanceState::not_alive_disposed() : dds::sub::status::InstanceState::not_alive_no_writers()))),
+    generation_count_(static_cast<int32_t>(from->disposed_generation_count), static_cast<int32_t>(from->no_writers_generation_count)),
+    rank_(static_cast<int32_t>(from->sample_rank),static_cast<int32_t>(from->generation_rank),static_cast<int32_t>(from->absolute_generation_rank)),
+    valid_(from->valid_data),
+    instance_handle_(from->instance_handle),
+    publication_handle_(from->publication_handle)
+{ }
+
+bool
+org::eclipse::cyclonedds::sub::SampleInfoImpl::operator==(const SampleInfoImpl& other) const
+{
+    return this->source_timestamp_ == other.timestamp()
+           && state_is_equal(this->state_, other.state())
+           && this->generation_count_ == other.generation_count()
+           && this->rank_ == other.rank()
+           && this->valid_ == other.valid()
+           && this->instance_handle_ == other.instance_handle()
+           && this->publication_handle_ == other.publication_handle();
+}
+
+bool
+org::eclipse::cyclonedds::sub::SampleInfoImpl::state_is_equal(const dds::sub::status::DataState& s1, const dds::sub::status::DataState& s2)
+{
+    return s1.instance_state() == s2.instance_state()
+           && s1.view_state() == s2.view_state()
+           && s1.sample_state() == s2.sample_state();
+}


### PR DESCRIPTION
Clean up the C++ code to read/take samples from a DataReader by delegating them to the new dds_read/take_with_collector calls added to the C-API.

The old code base was using some dirty tricks to peek into the contents of the reader cache in order to allocate matching C++ resources, prior to the invocation of the regular dds_read/take calls of the underlying C-API. In order for the contents of the reader cache not to change in between the peek and the actual consumption of the data, the readercache lock would not be released by the peek operation and not be claimed by the dds_read/take operation (upon passing it a special value for the max_samples parameter). However, such a dirty trick goes against many coding conventions, and for that purpose a more flexible set of data accessor operations have been added as part of https://github.com/eclipse-cyclonedds/cyclonedds/pull/1744.