### PR TITLE
Keyhash field sequencing

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.hpp
@@ -71,7 +71,7 @@ public:
  * @param[out] toread The variable to read into.
  * @param[in] N The number of entities to read.
  */
-template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 bool read(basic_cdr_stream& str, T& toread, size_t N = 1) {
   return read_enum_impl<basic_cdr_stream,T,uint32_t>(str, toread, N);
 }
@@ -84,7 +84,7 @@ bool read(basic_cdr_stream& str, T& toread, size_t N = 1) {
  * @param[in] towrite The variable to write.
  * @param[in] N The number of entities to write.
  */
-template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 bool write(basic_cdr_stream& str, const T& towrite, size_t N = 1) {
   return write_enum_impl<basic_cdr_stream,T,uint32_t>(str, towrite, N);
 }
@@ -96,7 +96,7 @@ bool write(basic_cdr_stream& str, const T& towrite, size_t N = 1) {
  * @param[in, out] str The stream whose cursor is moved.
  * @param[in] N The number of entities to move.
  */
-template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 bool move(basic_cdr_stream& str, const T&, size_t N = 1) {
   return move(str, uint32_t(0), N);
 }
@@ -108,7 +108,7 @@ bool move(basic_cdr_stream& str, const T&, size_t N = 1) {
  * @param[in, out] str The stream whose cursor is moved.
  * @param[in] N The number of entities at most to move.
  */
-template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 bool max(basic_cdr_stream& str, const T&, size_t N = 1) {
   return max(str, uint32_t(0), N);
 }

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp
@@ -589,7 +589,6 @@ protected:
  * @return Whether the operation was completed succesfully.
  */
 template<typename S, typename T, std::enable_if_t<std::is_arithmetic<T>::value
-                                               && !std::is_enum<T>::value
                                                && std::is_base_of<cdr_stream, S>::value, bool> = true >
 bool read(S &str, T& toread, size_t N = 1)
 {
@@ -665,7 +664,6 @@ bool read_enum_impl(S& str, T& toread, size_t N)
  * @return Whether the operation was completed succesfully.
  */
 template<typename S, typename T, std::enable_if_t<std::is_arithmetic<T>::value
-                                               && !std::is_enum<T>::value
                                                && std::is_base_of<cdr_stream, S>::value, bool> = true >
 bool write(S& str, const T& towrite, size_t N = 1)
 {
@@ -741,7 +739,6 @@ bool write_enum_impl(S& str, const T& towrite, size_t N)
  * @return Whether the operation was completed succesfully.
  */
 template<typename S, typename T, std::enable_if_t<std::is_arithmetic<T>::value
-                                               && !std::is_enum<T>::value
                                                && std::is_base_of<cdr_stream, S>::value, bool> = true >
 bool move(S& str, const T&, size_t N = 1)
 {
@@ -776,7 +773,6 @@ bool move(S& str, const T&, size_t N = 1)
  * @return Whether the operation was completed succesfully.
  */
 template<typename S, typename T, std::enable_if_t<std::is_arithmetic<T>::value
-                                               && !std::is_enum<T>::value
                                                && std::is_base_of<cdr_stream, S>::value, bool> = true >
 bool max(S& str, const T& max_sz, size_t N = 1)
 {

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp
@@ -199,7 +199,7 @@ public:
      *
      * @return The current stream alignment.
      */
-    size_t alignment() const { return m_current_alignment; }
+    inline size_t alignment() const { return m_current_alignment; }
 
     /**
      * @brief
@@ -211,7 +211,7 @@ public:
      *
      * @return The value the alignment has been set to.
      */
-    size_t alignment(size_t newalignment) { return m_current_alignment = newalignment; }
+    inline size_t alignment(size_t newalignment) { return m_current_alignment = newalignment; }
 
     /**
      * @brief
@@ -245,7 +245,7 @@ public:
      *
      * @return The value the offset has been set to.
      */
-    size_t position(size_t newposition) { return m_position = newposition; }
+    inline size_t position(size_t newposition) { return m_position = newposition; }
 
     /**
      * @brief
@@ -258,7 +258,7 @@ public:
      *
      * @return The cursor position after this operation.
      */
-    size_t incr_position(size_t incr_by) { if (m_position != SIZE_MAX) m_position += incr_by; return m_position; }
+    size_t incr_position(size_t incr_by);
 
     /**
      * @brief
@@ -300,7 +300,7 @@ public:
      *
      * @return The stream endianness.
      */
-    const endianness& stream_endianness() const { return m_stream_endianness; }
+    inline const endianness& stream_endianness() const { return m_stream_endianness; }
 
     /**
      * @brief
@@ -311,7 +311,7 @@ public:
      * @retval false If the stream endianness DOES match the local endianness.
      * @retval true If the stream endianness DOES NOT match the local endianness.
      */
-    bool swap_endianness() const { return m_swap; }
+    inline bool swap_endianness() const { return m_swap; }
 
     /**
      * @brief
@@ -337,7 +337,7 @@ public:
      *
      * @return The current status of serialization.
      */
-    uint64_t status() const { return m_status; }
+    inline uint64_t status() const { return m_status; }
 
     /**
      * @brief
@@ -350,7 +350,7 @@ public:
      * @retval false If the serialization status of the stream HAS NOT YET reached one of the serialization errors which it is not set to ignore.
      * @retval true If the serialization status of the stream HAS reached one of the serialization errors which it is not set to ignore.
      */
-    bool status(serialization_status toadd) { m_status |= static_cast<uint64_t>(toadd); return abort_status(); }
+    bool status(serialization_status toadd);
 
     /**
      * @brief
@@ -387,7 +387,7 @@ public:
      *
      * @return Whether the streaming is done only over the key values.
      */
-    inline bool is_key() const {assert(m_key != key_mode::unset); return m_key == key_mode::sorted || m_key == key_mode::unsorted;}
+    bool is_key() const;
 
     /**
      * @brief
@@ -399,7 +399,7 @@ public:
      * @param[in] mode The streaming mode to set for the stream.
      * @param[in] key The key mode to set for the stream.
      */
-    void set_mode(stream_mode mode, key_mode key) {assert(key != key_mode::unset); m_mode = mode; m_key = key; reset();}
+    void set_mode(stream_mode mode, key_mode key);
 
     /**
      * @brief
@@ -509,14 +509,14 @@ public:
 protected:
 
     /**
-     * @brief Implementation for starting the recording the size and starting offset of a member.
+     * @brief Function for starting the recording the size and starting offset of a member.
      */
-    inline void push_member_start() { m_e_sz.push(0); m_e_off.push(static_cast<uint32_t>(position())); }
+    void push_member_start();
 
     /**
-     * @brief Implementation for finishing the recording the size and starting offset of a member.
+     * @brief Function for finishing the recording the size and starting offset of a member.
      */
-    inline void pop_member_start() { m_e_sz.pop(); m_e_off.pop(); }
+    void pop_member_start();
 
     /**
      * @brief

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/cdr_stream.hpp
@@ -387,7 +387,7 @@ public:
      *
      * @return Whether the streaming is done only over the key values.
      */
-    inline bool is_key() const {return m_key;}
+    inline bool is_key() const {assert(m_key != key_mode::unset); return m_key == key_mode::sorted || m_key == key_mode::unsorted;}
 
     /**
      * @brief
@@ -399,7 +399,7 @@ public:
      * @param[in] mode The streaming mode to set for the stream.
      * @param[in] key The key mode to set for the stream.
      */
-    void set_mode(stream_mode mode, bool key) {m_mode = mode; m_key = key; reset();}
+    void set_mode(stream_mode mode, key_mode key) {assert(key != key_mode::unset); m_mode = mode; m_key = key; reset();}
 
     /**
      * @brief
@@ -553,7 +553,7 @@ protected:
              m_fault_mask;                        /**< the mask for statuses that will cause streaming
                                                        to be aborted*/
     stream_mode m_mode = stream_mode::unset;      /**< the current streaming mode*/
-    bool m_key = false;                           /**< the current key mode*/
+    key_mode m_key = key_mode::unset;             /**< the current key mode*/
     bool m_swap = false;                          /**< whether to swap endianness*/
 
     DDSCXX_WARNING_MSVC_OFF(4251)

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
@@ -53,7 +53,7 @@ namespace cdr {
  * @var bit_bound::bb_32_bits The bit width of the entity is at most 32 bits (4 bytes).
  * @var bit_bound::bb_64_bits The bit width of the entity is at most 64 bits (8 bytes).
  */
-enum bit_bound {
+enum class bit_bound {
   bb_unset = 0,
   bb_8_bits = 1,
   bb_16_bits = 2,
@@ -86,19 +86,19 @@ template<typename T, DDSCXX_STD_IMPL::enable_if_t<std::is_arithmetic<T>::value |
 bit_bound get_bit_bound() {
   switch (sizeof(T)) {
     case 1:
-      return bb_8_bits;
+      return bit_bound::bb_8_bits;
       break;
     case 2:
-      return bb_16_bits;
+      return bit_bound::bb_16_bits;
       break;
     case 4:
-      return bb_32_bits;
+      return bit_bound::bb_32_bits;
       break;
     case 8:
-      return bb_64_bits;
+      return bit_bound::bb_64_bits;
       break;
     default:
-      return bb_unset;
+      return bit_bound::bb_unset;
   }
 }
 
@@ -111,7 +111,7 @@ bit_bound get_bit_bound() {
  * @return bb_unset always.
  */
 template<typename T, DDSCXX_STD_IMPL::enable_if_t<!std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
-constexpr bit_bound get_bit_bound() { return bb_unset;}
+constexpr bit_bound get_bit_bound() { return bit_bound::bb_unset;}
 
 typedef struct entity_properties entity_properties_t;
 typedef std::vector<entity_properties_t> propvec;
@@ -132,7 +132,7 @@ struct OMG_DDS_API entity_properties
     uint32_t _depth = 0,
     uint32_t _m_id = 0,
     bool _is_optional = false,
-    bit_bound _bb = bb_unset,
+    bit_bound _bb = bit_bound::bb_unset,
     extensibility _ext = extensibility::ext_final,
     bool _must_understand = true):
       e_ext(_ext),
@@ -153,7 +153,7 @@ struct OMG_DDS_API entity_properties
   bool ignore = false;                            /**< Indicates that this field must be ignored.*/
   bool is_optional = false;                       /**< Indicates that this field can be empty (length 0) for reading/writing purposes.*/
   bool is_key = false;                            /**< Indicates that this field is a key field.*/
-  bit_bound e_bb = bb_unset;                      /**< The minimum number of bytes necessary to represent this entity/bitmask.*/
+  bit_bound e_bb = bit_bound::bb_unset;           /**< The minimum number of bytes necessary to represent this entity/bitmask.*/
 
   entity_properties_t  *next_on_level = nullptr,  /**< Pointer to the next entity on the same level.*/
                        *prev_on_level = nullptr,  /**< Pointer to the previous entity on the same level.*/

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
@@ -132,7 +132,7 @@ bit_bound get_bit_bound() {
  * @return bb_unset always.
  */
 template<typename T, DDSCXX_STD_IMPL::enable_if_t<!std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
-constexpr bit_bound get_bit_bound() { return bit_bound::bb_unset;}
+constexpr bit_bound get_bit_bound() { return bit_bound::bb_unset; }
 
 typedef struct entity_properties entity_properties_t;
 typedef std::vector<entity_properties_t> propvec;
@@ -194,18 +194,6 @@ struct OMG_DDS_API entity_properties
    * This function write the contents (id, is_key, is_optional, must_understand, xtypes_necessary) of this entity to std::cout.
    */
   void print() const;
-
-  /**
-   * @brief
-   * Checks whether this entity is not keyless.
-   *
-   * This function will check all members (if any) and if any of them has the is_key flag set, this will return true.
-   * If none have this flag set, it will return false.
-   * Used in the finish function to finish the entire entity_properties_t tree.
-   *
-   * @return true if any of the members have a key, false otherwise.
-   */
-  bool has_keys() const;
 
   /**
    * @brief
@@ -290,6 +278,21 @@ struct OMG_DDS_API entity_properties
     * @return Pointer to the previous entity, or nullptr if there are none.
     */
   const entity_properties_t* previous_entity(key_mode key) const;
+
+private:
+
+  /**
+   * @brief
+   * Checks whether this entity is not keyless.
+   *
+   * This function will check all members (if any) and if any of them has the is_key flag set, this will return true.
+   * This function is called BEFORE the total key calculation is done, so looking at the pointers to key members does not work yet.
+   * If none have this flag set, it will return false.
+   * Used in the finish function to finish the entire entity_properties_t tree.
+   *
+   * @return true if any of the members have a key, false otherwise.
+   */
+  bool has_keys() const;
 };
 
 /**

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
@@ -96,43 +96,63 @@ DDSCXX_WARNING_MSVC_ON(4251)
 
 /**
  * @brief
- * Primitive type/enum get_bit_bound function.
- *
- * Returns a bb_unset for all primitive types and enums.
- * This function will be implemented for all enums with a manually defined bit_bound.
- *
- * @return The bit bound for the primitive type.
- */
-template<typename T, DDSCXX_STD_IMPL::enable_if_t<std::is_arithmetic<T>::value || std::is_enum<T>::value, bool> = true >
-bit_bound get_bit_bound() {
-  switch (sizeof(T)) {
-    case 1:
-      return bit_bound::bb_8_bits;
-      break;
-    case 2:
-      return bit_bound::bb_16_bits;
-      break;
-    case 4:
-      return bit_bound::bb_32_bits;
-      break;
-    case 8:
-      return bit_bound::bb_64_bits;
-      break;
-    default:
-      return bit_bound::bb_unset;
-  }
-}
-
-/**
- * @brief
  * Generic get_bit_bound fallback function.
  *
- * Returns a bb_unset for all non-primitive, non-enum types.
+ * Returns a bb_unset for all non-primitive, non-enum types or primitives/enums with non 1,2,4,8 sizes.
  *
  * @return bb_unset always.
  */
-template<typename T, DDSCXX_STD_IMPL::enable_if_t<!std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
+template<typename T, DDSCXX_STD_IMPL::enable_if_t<(!std::is_arithmetic<T>::value && !std::is_enum<T>::value) || (sizeof(T) != 1 && sizeof(T) != 2 && sizeof(T) != 4 && sizeof(T) != 8), bool> = true >
 constexpr bit_bound get_bit_bound() { return bit_bound::bb_unset; }
+
+/**
+ * @brief
+ * Primitive type/enum get_bit_bound function.
+ *
+ * Returns the bitbound for primitives/enums with size 1.
+ * This function will be specialized for all enums with a manually defined bit_bound.
+ *
+ * @return bb_8_bits always.
+ */
+template<typename T, DDSCXX_STD_IMPL::enable_if_t<(std::is_arithmetic<T>::value || std::is_enum<T>::value) && sizeof(T) == 1, bool> = true >
+constexpr bit_bound get_bit_bound() { return bit_bound::bb_8_bits; }
+
+/**
+ * @brief
+ * Primitive type/enum get_bit_bound function.
+ *
+ * Returns the bitbound for primitives/enums with size 2.
+ * This function will be specialized for all enums with a manually defined bit_bound.
+ *
+ * @return bb_16_bits always.
+ */
+template<typename T, DDSCXX_STD_IMPL::enable_if_t<(std::is_arithmetic<T>::value || std::is_enum<T>::value) && sizeof(T) == 2, bool> = true >
+constexpr bit_bound get_bit_bound() { return bit_bound::bb_16_bits; }
+
+/**
+ * @brief
+ * Primitive type/enum get_bit_bound function.
+ *
+ * Returns the bitbound for primitives/enums with size 4.
+ * This function will be specialized for all enums with a manually defined bit_bound.
+ *
+ * @return bb_32_bits always.
+ */
+template<typename T, DDSCXX_STD_IMPL::enable_if_t<(std::is_arithmetic<T>::value || std::is_enum<T>::value) && sizeof(T) == 4, bool> = true >
+constexpr bit_bound get_bit_bound() { return bit_bound::bb_32_bits; }
+
+
+/**
+ * @brief
+ * Primitive type/enum get_bit_bound function.
+ *
+ * Returns the bitbound for primitives/enums with size 8.
+ * This function will be specialized for all enums with a manually defined bit_bound.
+ *
+ * @return bb_64_bits always.
+ */
+template<typename T, DDSCXX_STD_IMPL::enable_if_t<(std::is_arithmetic<T>::value || std::is_enum<T>::value) && sizeof(T) == 8, bool> = true >
+constexpr bit_bound get_bit_bound() { return bit_bound::bb_64_bits; }
 
 typedef struct entity_properties entity_properties_t;
 typedef std::vector<entity_properties_t> propvec;

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/entity_properties.hpp
@@ -63,6 +63,27 @@ enum class bit_bound {
 
 /**
  * @brief
+ * Key mode descriptors.
+ *
+ * @enum key_mode Describes the manner of writing of a stream.
+ *
+ * This value is used to determine which fields to write and in which order to write them.
+ * Mainly used to get the first/next/previous entity from the entity properties describing a datatype.
+ *
+ * @var key_mode::unset The key_mode of streaming is unset.
+ * @var key_mode::not_key The key_mode of streaming is not a key, all members will be streamed in declaration order.
+ * @var key_mode::unsorted The key_mode of streaming is key mode, only members will be streamed in declaration order.
+ * @var key_mode::sorted The key_mode of streaming is keyhash mode, only members will be streamed in member id order.
+ */
+enum class key_mode {
+  unset,
+  not_key,
+  unsorted,
+  sorted
+};
+
+/**
+ * @brief
  * Helper struct to keep track of key endpoints of the a struct
  */
 DDSCXX_WARNING_MSVC_OFF(4251)
@@ -155,10 +176,16 @@ struct OMG_DDS_API entity_properties
   bool is_key = false;                            /**< Indicates that this field is a key field.*/
   bit_bound e_bb = bit_bound::bb_unset;           /**< The minimum number of bytes necessary to represent this entity/bitmask.*/
 
-  entity_properties_t  *next_on_level = nullptr,  /**< Pointer to the next entity on the same level.*/
-                       *prev_on_level = nullptr,  /**< Pointer to the previous entity on the same level.*/
-                       *parent        = nullptr,  /**< Pointer to the parent of this entity.*/
-                       *first_member  = nullptr;  /**< Pointer to the first entity which is a member of this entity.*/
+  entity_properties_t  *parent              = nullptr,  /**< Pointer to the parent of this entity.*/
+                       *first_member        = nullptr,  /**< Pointer to the first entity which is a member of this entity.*/
+                       *next_on_level       = nullptr,  /**< Pointer to the next entity on the same level.*/
+                       *prev_on_level       = nullptr,  /**< Pointer to the previous entity on the same level.*/
+                       *first_unsorted_key  = nullptr,  /**< Pointer to the first entity which is a key member of this entity, going by declaration order.*/
+                       *next_unsorted_key   = nullptr,  /**< Pointer to the next entity which is a key member on the same level, going by declaration order.*/
+                       *prev_unsorted_key   = nullptr,  /**< Pointer to the previous entity which is a key member on the same level, going by declaration order.*/
+                       *first_sorted_key    = nullptr,  /**< Pointer to the first entity which is a key member of this entity, going by member id order.*/
+                       *next_sorted_key     = nullptr,  /**< Pointer to the next entity which is a key member on the same level, going by member id order.*/
+                       *prev_sorted_key     = nullptr;  /**< Pointer to the previous entity which is a key member on the same level, going by member id order.*/
 
   /**
    * @brief
@@ -233,6 +260,36 @@ struct OMG_DDS_API entity_properties
    * @param[in] in The tree to print.
    */
   static void print(const propvec &in);
+
+  /**
+    * @brief
+    * Returns the previous entity at the current level (if any).
+    *
+    * @param[in] key The key mode to get the first entity for.
+    *
+    * @return Pointer to the first entity, or nullptr if there are none.
+    */
+  const entity_properties_t* first_entity(key_mode key) const;
+
+  /**
+    * @brief
+    * Returns the next entity at the current level (if any).
+    *
+    * @param[in] key The key mode to get the next entity for.
+    *
+    * @return Pointer to the next entity, or nullptr if there are none.
+    */
+  const entity_properties_t* next_entity(key_mode key) const;
+
+  /**
+    * @brief
+    * Returns the previous entity at the current level (if any).
+    *
+    * @param[in] key The key mode to get the previous entity for.
+    *
+    * @return Pointer to the previous entity, or nullptr if there are none.
+    */
+  const entity_properties_t* previous_entity(key_mode key) const;
 };
 
 /**

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.hpp
@@ -242,7 +242,7 @@ private:
  *
  * @return Whether the operation was completed succesfully.
  */
-template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 bool read(xcdr_v1_stream& str, T& toread, size_t N = 1)
 {
   switch (str.is_key() ? bit_bound::bb_32_bits : get_bit_bound<T>())
@@ -272,7 +272,7 @@ bool read(xcdr_v1_stream& str, T& toread, size_t N = 1)
  *
  * @return Whether the operation was completed succesfully.
  */
-template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 bool write(xcdr_v1_stream& str, const T& towrite, size_t N = 1)
 {
   switch (str.is_key() ? bit_bound::bb_32_bits : get_bit_bound<T>())
@@ -301,7 +301,7 @@ bool write(xcdr_v1_stream& str, const T& towrite, size_t N = 1)
  *
  * @return Whether the operation was completed succesfully.
  */
-template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 bool move(xcdr_v1_stream& str, const T&, size_t N = 1)
 {
   switch (str.is_key() ? bit_bound::bb_32_bits : get_bit_bound<T>())
@@ -331,7 +331,7 @@ bool move(xcdr_v1_stream& str, const T&, size_t N = 1)
  *
  * @return Whether the operation was completed succesfully.
  */
-template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 bool max(xcdr_v1_stream& str, const T& max_sz, size_t N = 1)
 {
   return move(str, max_sz, N);

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.hpp
@@ -245,15 +245,15 @@ private:
 template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
 bool read(xcdr_v1_stream& str, T& toread, size_t N = 1)
 {
-  switch (str.is_key() ? bb_32_bits : get_bit_bound<T>())
+  switch (str.is_key() ? bit_bound::bb_32_bits : get_bit_bound<T>())
   {
-    case bb_8_bits:
+    case bit_bound::bb_8_bits:
       return read_enum_impl<xcdr_v1_stream,T,uint8_t>(str, toread, N);
       break;
-    case bb_16_bits:
+    case bit_bound::bb_16_bits:
       return read_enum_impl<xcdr_v1_stream,T,uint16_t>(str, toread, N);
       break;
-    case bb_32_bits:
+    case bit_bound::bb_32_bits:
       return read_enum_impl<xcdr_v1_stream,T,uint32_t>(str, toread, N);
       break;
     default:
@@ -275,15 +275,15 @@ bool read(xcdr_v1_stream& str, T& toread, size_t N = 1)
 template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
 bool write(xcdr_v1_stream& str, const T& towrite, size_t N = 1)
 {
-  switch (str.is_key() ? bb_32_bits : get_bit_bound<T>())
+  switch (str.is_key() ? bit_bound::bb_32_bits : get_bit_bound<T>())
   {
-    case bb_8_bits:
+    case bit_bound::bb_8_bits:
       return write_enum_impl<xcdr_v1_stream,T,uint8_t>(str, towrite, N);
       break;
-    case bb_16_bits:
+    case bit_bound::bb_16_bits:
       return write_enum_impl<xcdr_v1_stream,T,uint16_t>(str, towrite, N);
       break;
-    case bb_32_bits:
+    case bit_bound::bb_32_bits:
       return write_enum_impl<xcdr_v1_stream,T,uint32_t>(str, towrite, N);
       break;
     default:
@@ -304,15 +304,15 @@ bool write(xcdr_v1_stream& str, const T& towrite, size_t N = 1)
 template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
 bool move(xcdr_v1_stream& str, const T&, size_t N = 1)
 {
-  switch (str.is_key() ? bb_32_bits : get_bit_bound<T>())
+  switch (str.is_key() ? bit_bound::bb_32_bits : get_bit_bound<T>())
   {
-    case bb_8_bits:
+    case bit_bound::bb_8_bits:
       return move(str, int8_t(0), N);
       break;
-    case bb_16_bits:
+    case bit_bound::bb_16_bits:
       return move(str, int16_t(0), N);
       break;
-    case bb_32_bits:
+    case bit_bound::bb_32_bits:
       return move(str, int32_t(0), N);
       break;
     default:

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.hpp
@@ -127,7 +127,7 @@ private:
    *
    * @return Whether a header is necessary for the entity.
    */
-  bool header_necessary(const entity_properties_t &props);
+  inline bool header_necessary(const entity_properties_t &props) const { return props.p_ext == extensibility::ext_mutable || props.is_optional; }
 
   /**
    * @brief
@@ -137,7 +137,7 @@ private:
    *
    * @return Whether a parameter list is necessary for the entity.
    */
-  bool list_necessary(const entity_properties_t &props);
+  inline bool list_necessary(const entity_properties_t &props) const { return props.e_ext == extensibility::ext_mutable; }
 
   /**
    * @brief
@@ -245,7 +245,7 @@ private:
 template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 bool read(xcdr_v1_stream& str, T& toread, size_t N = 1)
 {
-  switch (str.is_key() ? bit_bound::bb_32_bits : get_bit_bound<T>())
+  switch (get_bit_bound<T>())
   {
     case bit_bound::bb_8_bits:
       return read_enum_impl<xcdr_v1_stream,T,uint8_t>(str, toread, N);
@@ -275,7 +275,7 @@ bool read(xcdr_v1_stream& str, T& toread, size_t N = 1)
 template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 bool write(xcdr_v1_stream& str, const T& towrite, size_t N = 1)
 {
-  switch (str.is_key() ? bit_bound::bb_32_bits : get_bit_bound<T>())
+  switch (get_bit_bound<T>())
   {
     case bit_bound::bb_8_bits:
       return write_enum_impl<xcdr_v1_stream,T,uint8_t>(str, towrite, N);
@@ -304,7 +304,7 @@ bool write(xcdr_v1_stream& str, const T& towrite, size_t N = 1)
 template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 bool move(xcdr_v1_stream& str, const T&, size_t N = 1)
 {
-  switch (str.is_key() ? bit_bound::bb_32_bits : get_bit_bound<T>())
+  switch (get_bit_bound<T>())
   {
     case bit_bound::bb_8_bits:
       return move(str, int8_t(0), N);

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
@@ -241,7 +241,7 @@ private:
    *
    * @return Whether the operation was completed succesfully.
    */
-  bool move_d_header() {return move(*this, uint32_t(0));}
+  inline bool move_d_header() {return move(*this, uint32_t(0));}
 
   /**
    * @brief
@@ -275,7 +275,7 @@ private:
    *
    * @return Whether the entity props needs a D-header
    */
-  bool d_header_necessary(const entity_properties_t &props);
+  bool d_header_necessary(const entity_properties_t &props) const;
 
   /**
    * @brief
@@ -285,7 +285,7 @@ private:
    *
    * @return Whether the entity props needs a EM-header
    */
-  bool em_header_necessary(const entity_properties_t &props);
+  inline bool em_header_necessary(const entity_properties_t &props) const { return props.p_ext == extensibility::ext_mutable && !is_key(); }
 
   /**
    * @brief
@@ -298,7 +298,7 @@ private:
    *
    * @return Whether a list is necessary for this entity.
    */
-  bool list_necessary(const entity_properties_t &props);
+  inline bool list_necessary(const entity_properties_t &props) const { return props.e_ext == extensibility::ext_mutable && !is_key(); }
 };
 
 /**

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
@@ -313,15 +313,15 @@ private:
  */
 template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
 bool read(xcdr_v2_stream& str, T& toread, size_t N = 1) {
-  switch (str.is_key() ? bb_32_bits : get_bit_bound<T>())
+  switch (str.is_key() ? bit_bound::bb_32_bits : get_bit_bound<T>())
   {
-    case bb_8_bits:
+    case bit_bound::bb_8_bits:
       return read_enum_impl<xcdr_v2_stream,T,uint8_t>(str, toread, N);
       break;
-    case bb_16_bits:
+    case bit_bound::bb_16_bits:
       return read_enum_impl<xcdr_v2_stream,T,uint16_t>(str, toread, N);
       break;
-    case bb_32_bits:
+    case bit_bound::bb_32_bits:
       return read_enum_impl<xcdr_v2_stream,T,uint32_t>(str, toread, N);
       break;
     default:
@@ -342,15 +342,15 @@ bool read(xcdr_v2_stream& str, T& toread, size_t N = 1) {
  */
 template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
 bool write(xcdr_v2_stream& str, const T& towrite, size_t N = 1) {
-  switch (str.is_key() ? bb_32_bits : get_bit_bound<T>())
+  switch (str.is_key() ? bit_bound::bb_32_bits : get_bit_bound<T>())
   {
-    case bb_8_bits:
+    case bit_bound::bb_8_bits:
       return write_enum_impl<xcdr_v2_stream,T,uint8_t>(str, towrite, N);
       break;
-    case bb_16_bits:
+    case bit_bound::bb_16_bits:
       return write_enum_impl<xcdr_v2_stream,T,uint16_t>(str, towrite, N);
       break;
-    case bb_32_bits:
+    case bit_bound::bb_32_bits:
       return write_enum_impl<xcdr_v2_stream,T,uint32_t>(str, towrite, N);
       break;
     default:
@@ -370,15 +370,15 @@ bool write(xcdr_v2_stream& str, const T& towrite, size_t N = 1) {
  */
 template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
 bool move(xcdr_v2_stream& str, const T&, size_t N = 1) {
-  switch (str.is_key() ? bb_32_bits : get_bit_bound<T>())
+  switch (str.is_key() ? bit_bound::bb_32_bits : get_bit_bound<T>())
   {
-    case bb_8_bits:
+    case bit_bound::bb_8_bits:
       return move(str, int8_t(0), N);
       break;
-    case bb_16_bits:
+    case bit_bound::bb_16_bits:
       return move(str, int16_t(0), N);
       break;
-    case bb_32_bits:
+    case bit_bound::bb_32_bits:
       return move(str, int32_t(0), N);
       break;
     default:

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
@@ -311,7 +311,7 @@ private:
  *
  * @return Whether the operation was completed succesfully.
  */
-template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 bool read(xcdr_v2_stream& str, T& toread, size_t N = 1) {
   switch (str.is_key() ? bit_bound::bb_32_bits : get_bit_bound<T>())
   {
@@ -340,7 +340,7 @@ bool read(xcdr_v2_stream& str, T& toread, size_t N = 1) {
  *
  * @return Whether the operation was completed succesfully.
  */
-template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 bool write(xcdr_v2_stream& str, const T& towrite, size_t N = 1) {
   switch (str.is_key() ? bit_bound::bb_32_bits : get_bit_bound<T>())
   {
@@ -368,7 +368,7 @@ bool write(xcdr_v2_stream& str, const T& towrite, size_t N = 1) {
  *
  * @return Whether the operation was completed succesfully.
  */
-template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 bool move(xcdr_v2_stream& str, const T&, size_t N = 1) {
   switch (str.is_key() ? bit_bound::bb_32_bits : get_bit_bound<T>())
   {
@@ -397,7 +397,7 @@ bool move(xcdr_v2_stream& str, const T&, size_t N = 1) {
  *
  * @return Whether the operation was completed succesfully.
  */
-template<typename T, std::enable_if_t<std::is_enum<T>::value && !std::is_arithmetic<T>::value, bool> = true >
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 bool max(xcdr_v2_stream& str, const T& max_sz, size_t N = 1) {
   return move(str, max_sz, N);
 }

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.hpp
@@ -275,7 +275,7 @@ private:
    *
    * @return Whether the entity props needs a D-header
    */
-  bool d_header_necessary(const entity_properties_t &props) const;
+  inline bool d_header_necessary(const entity_properties_t &props) const { return props.e_ext == extensibility::ext_appendable || props.e_ext == extensibility::ext_mutable; }
 
   /**
    * @brief
@@ -285,7 +285,7 @@ private:
    *
    * @return Whether the entity props needs a EM-header
    */
-  inline bool em_header_necessary(const entity_properties_t &props) const { return props.p_ext == extensibility::ext_mutable && !is_key(); }
+  inline bool em_header_necessary(const entity_properties_t &props) const { return props.p_ext == extensibility::ext_mutable; }
 
   /**
    * @brief
@@ -298,7 +298,7 @@ private:
    *
    * @return Whether a list is necessary for this entity.
    */
-  inline bool list_necessary(const entity_properties_t &props) const { return props.e_ext == extensibility::ext_mutable && !is_key(); }
+  inline bool list_necessary(const entity_properties_t &props) const { return props.e_ext == extensibility::ext_mutable; }
 };
 
 /**
@@ -313,7 +313,7 @@ private:
  */
 template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 bool read(xcdr_v2_stream& str, T& toread, size_t N = 1) {
-  switch (str.is_key() ? bit_bound::bb_32_bits : get_bit_bound<T>())
+  switch (get_bit_bound<T>())
   {
     case bit_bound::bb_8_bits:
       return read_enum_impl<xcdr_v2_stream,T,uint8_t>(str, toread, N);
@@ -342,7 +342,7 @@ bool read(xcdr_v2_stream& str, T& toread, size_t N = 1) {
  */
 template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 bool write(xcdr_v2_stream& str, const T& towrite, size_t N = 1) {
-  switch (str.is_key() ? bit_bound::bb_32_bits : get_bit_bound<T>())
+  switch (get_bit_bound<T>())
   {
     case bit_bound::bb_8_bits:
       return write_enum_impl<xcdr_v2_stream,T,uint8_t>(str, towrite, N);
@@ -370,7 +370,7 @@ bool write(xcdr_v2_stream& str, const T& towrite, size_t N = 1) {
  */
 template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true >
 bool move(xcdr_v2_stream& str, const T&, size_t N = 1) {
-  switch (str.is_key() ? bit_bound::bb_32_bits : get_bit_bound<T>())
+  switch (get_bit_bound<T>())
   {
     case bit_bound::bb_8_bits:
       return move(str, int8_t(0), N);

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -553,7 +553,7 @@ ddsi_serdata *serdata_to_untyped(const ddsi_serdata* dcmn)
 
   auto t = d->getT();
   size_t sz = 0;
-  if (t == nullptr || !get_serialized_size<T,S,key_mode::sorted>(*t, sz))
+  if (t == nullptr || !get_serialized_size<T,S,key_mode::unsorted>(*t, sz))
     goto failure;
 
   sz += CDR_HEADER_SIZE;

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/basic_cdr_ser.cpp
@@ -18,7 +18,7 @@ namespace cdr {
 
 bool basic_cdr_stream::start_struct(const entity_properties_t &props)
 {
-  if (!is_key() && props.xtypes_necessary && status(unsupported_xtypes))
+  if (key_mode::sorted != m_key && props.xtypes_necessary && status(unsupported_xtypes))
     return false;
 
   return cdr_stream::start_struct(props);

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/cdr_stream.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/cdr_stream.cpp
@@ -63,33 +63,22 @@ bool cdr_stream::finish_struct(const entity_properties_t &props, const member_id
   }
 }
 
-const entity_properties_t *cdr_stream::first_entity(const entity_properties_t *props)
+const entity_properties_t *cdr_stream::first_entity(const entity_properties_t *prop)
 {
-  const entity_properties_t *prop = props->first_member;
-  while (m_key && prop && !prop->is_key)
-    prop = next_entity(prop);
-
-  return prop;
+  assert(prop);
+  return prop->first_entity(m_key);
 }
 
 const entity_properties_t* cdr_stream::next_entity(const entity_properties_t *prop)
 {
-  prop = prop->next_on_level;
-  if (m_key) {
-    while (prop && !prop->is_key)
-      prop = prop->next_on_level;
-  }
-  return prop;
+  assert(prop);
+  return prop->next_entity(m_key);
 }
 
 const entity_properties_t* cdr_stream::previous_entity(const entity_properties_t *prop)
 {
-  prop = prop->prev_on_level;
-  if (m_key) {
-    while (prop && !prop->is_key)
-      prop = prop->prev_on_level;
-  }
-  return prop;
+  assert(prop);
+  return prop->previous_entity(m_key);
 }
 
 bool cdr_stream::bytes_available(size_t N, bool peek)

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/cdr_stream.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/cdr_stream.cpp
@@ -133,6 +133,45 @@ bool cdr_stream::finish_member(const entity_properties_t &props, member_id_set &
   return true;
 }
 
+void cdr_stream::set_mode(stream_mode mode, key_mode key)
+{
+  assert(key != key_mode::unset);
+  m_mode = mode;
+  m_key = key;
+  reset();
+}
+
+size_t cdr_stream::incr_position(size_t incr_by)
+{
+  if (m_position != SIZE_MAX)
+    m_position += incr_by;
+  return m_position;
+}
+
+bool cdr_stream::status(serialization_status toadd)
+{
+  m_status |= static_cast<uint64_t>(toadd);
+  return abort_status();
+}
+
+bool cdr_stream::is_key() const
+{
+  assert(m_key != key_mode::unset);
+  return m_key == key_mode::sorted || m_key == key_mode::unsorted;
+}
+
+void cdr_stream::push_member_start()
+{
+  m_e_sz.push(0);
+  m_e_off.push(static_cast<uint32_t>(position()));
+}
+
+void cdr_stream::pop_member_start()
+{
+  m_e_sz.pop();
+  m_e_off.pop();
+}
+
 }
 }
 }

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.cpp
@@ -203,7 +203,7 @@ const entity_properties_t* xcdr_v1_stream::first_entity(const entity_properties_
 
 bool xcdr_v1_stream::header_necessary(const entity_properties_t &props)
 {
-  return (props.p_ext == extensibility::ext_mutable || props.is_optional) && !m_key;
+  return (props.p_ext == extensibility::ext_mutable || props.is_optional) && !is_key();
 }
 
 bool xcdr_v1_stream::read_header(entity_properties_t &out, bool &is_final)
@@ -309,7 +309,7 @@ bool xcdr_v1_stream::finish_struct(const entity_properties_t &props, const membe
 
 bool xcdr_v1_stream::list_necessary(const entity_properties_t &props)
 {
-  return props.e_ext == extensibility::ext_mutable && !m_key;
+  return props.e_ext == extensibility::ext_mutable && !is_key();
 }
 
 bool xcdr_v1_stream::write_final_list_entry()

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.cpp
@@ -201,11 +201,6 @@ const entity_properties_t* xcdr_v1_stream::first_entity(const entity_properties_
   return prop;
 }
 
-bool xcdr_v1_stream::header_necessary(const entity_properties_t &props)
-{
-  return (props.p_ext == extensibility::ext_mutable || props.is_optional) && !is_key();
-}
-
 bool xcdr_v1_stream::read_header(entity_properties_t &out, bool &is_final)
 {
   uint16_t smallid = 0, smalllength = 0;
@@ -305,11 +300,6 @@ bool xcdr_v1_stream::finish_struct(const entity_properties_t &props, const membe
       return false;
   }
   return true;
-}
-
-bool xcdr_v1_stream::list_necessary(const entity_properties_t &props)
-{
-  return props.e_ext == extensibility::ext_mutable && !is_key();
 }
 
 bool xcdr_v1_stream::write_final_list_entry()

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v1_ser.cpp
@@ -338,7 +338,7 @@ bool xcdr_v1_stream::move_header(const entity_properties_t &props)
 
 bool xcdr_v1_stream::extended_header(const entity_properties_t &props)
 {
-  return props.e_bb == bb_unset || props.m_id >= pid_extended;
+  return props.e_bb == bit_bound::bb_unset || props.m_id >= pid_extended;
 }
 
 }

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.cpp
@@ -276,12 +276,12 @@ bool xcdr_v2_stream::read_d_header()
 bool xcdr_v2_stream::d_header_necessary(const entity_properties_t &props)
 {
   return (props.e_ext == extensibility::ext_appendable || props.e_ext == extensibility::ext_mutable)
-      && !m_key;
+      && !is_key();
 }
 
 bool xcdr_v2_stream::list_necessary(const entity_properties_t &props)
 {
-  return props.e_ext == extensibility::ext_mutable && !m_key;
+  return props.e_ext == extensibility::ext_mutable && !is_key();
 }
 
 bool xcdr_v2_stream::start_struct(const entity_properties_t &props)
@@ -331,7 +331,7 @@ bool xcdr_v2_stream::finish_struct(const entity_properties_t &props, const membe
 
 bool xcdr_v2_stream::start_consecutive(bool is_array, bool primitive)
 {
-  if (m_key)
+  if (is_key())
     return true;
 
   bool d_hdr_necessary =  false;
@@ -370,7 +370,7 @@ bool xcdr_v2_stream::start_consecutive(bool is_array, bool primitive)
 
 bool xcdr_v2_stream::finish_consecutive()
 {
-  if (m_key)
+  if (is_key())
     return true;
 
   assert(m_consecutives.size());
@@ -461,7 +461,7 @@ bool xcdr_v2_stream::finish_em_header()
 
 bool xcdr_v2_stream::em_header_necessary(const entity_properties_t &props)
 {
-  return props.p_ext == extensibility::ext_mutable && !m_key;
+  return props.p_ext == extensibility::ext_mutable && !is_key();
 }
 
 }

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/cdr/extended_cdr_v2_ser.cpp
@@ -273,15 +273,10 @@ bool xcdr_v2_stream::read_d_header()
   return true;
 }
 
-bool xcdr_v2_stream::d_header_necessary(const entity_properties_t &props)
+bool xcdr_v2_stream::d_header_necessary(const entity_properties_t &props) const
 {
   return (props.e_ext == extensibility::ext_appendable || props.e_ext == extensibility::ext_mutable)
       && !is_key();
-}
-
-bool xcdr_v2_stream::list_necessary(const entity_properties_t &props)
-{
-  return props.e_ext == extensibility::ext_mutable && !is_key();
 }
 
 bool xcdr_v2_stream::start_struct(const entity_properties_t &props)
@@ -457,11 +452,6 @@ bool xcdr_v2_stream::finish_em_header()
   alignment(current_alignment);
 
   return true;
-}
-
-bool xcdr_v2_stream::em_header_necessary(const entity_properties_t &props)
-{
-  return props.p_ext == extensibility::ext_mutable && !is_key();
 }
 
 }

--- a/src/ddscxx/tests/Bounded.cpp
+++ b/src/ddscxx/tests/Bounded.cpp
@@ -186,7 +186,7 @@ TEST_F(Bounds, strings)
     str.set_buffer(arr, 16);
 
     Bounded::Msg msg;
-    read(str, msg, false);
+    read(str, msg, key_mode::not_key);
 
     ASSERT_EQ (static_cast<serialization_status>(str.status()), serialization_status::illegal_field_value);
 }

--- a/src/ddscxx/tests/CMakeLists.txt
+++ b/src/ddscxx/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ idlcxx_generate(TARGET ddscxx_test_types FILES
   data/RegressionModels.idl
   data/RegressionModels_pragma.idl
   data/ExternalModels.idl
+  data/KeyHashModels.idl
   data/TraitsModels.idl
   WARNINGS no-implicit-extensibility)
 
@@ -67,7 +68,8 @@ set(sources
   External.cpp
   DataModels.cpp
   SampleInfo.cpp
-  DeferredDestruction.cpp)
+  DeferredDestruction.cpp
+  KeyHash.cpp)
 
 if (ENABLE_TYPE_DISCOVERY AND ENABLE_TOPIC_DISCOVERY)
   # Add topic/type discovery tests

--- a/src/ddscxx/tests/ExtendedTypes.cpp
+++ b/src/ddscxx/tests/ExtendedTypes.cpp
@@ -39,7 +39,7 @@ public:
     bool exp_contents = true)
   {
     S str;
-    bool move_result = move(str, in, false);
+    bool move_result = move(str, in, key_mode::not_key);
     ASSERT_EQ(move_result, exp_write_result);
 
     if (!move_result)
@@ -48,7 +48,7 @@ public:
     bytes buffer(str.position(), 0x0);
     str.set_buffer(buffer.data(), buffer.size());
 
-    bool write_result = write(str, in, false);
+    bool write_result = write(str, in, key_mode::not_key);
     ASSERT_EQ(write_result, exp_write_result);
 
     if (!write_result)
@@ -56,7 +56,7 @@ public:
 
     MSGOUT out;
     str.reset();
-    bool read_result = read(str, out, false);
+    bool read_result = read(str, out, key_mode::not_key);
     ASSERT_EQ(read_result, exp_read_result);
 
     if (!read_result || !exp_read_result)
@@ -73,7 +73,7 @@ public:
     bool exp_contents = true)
   {
     S str;
-    bool move_result = move(str, in, false);
+    bool move_result = move(str, in, key_mode::not_key);
     ASSERT_EQ(move_result, exp_write_result);
 
     if (!move_result)
@@ -82,7 +82,7 @@ public:
     bytes buffer(str.position(), 0x0);
     str.set_buffer(buffer.data(), buffer.size());
 
-    bool write_result = write(str, in, false);
+    bool write_result = write(str, in, key_mode::not_key);
     ASSERT_EQ(write_result, exp_write_result);
 
     if (!write_result)
@@ -90,7 +90,7 @@ public:
 
     MSGOUT out;
     str.reset();
-    bool read_result = read(str, out, false);
+    bool read_result = read(str, out, key_mode::not_key);
     ASSERT_EQ(read_result, exp_read_result);
 
     if (!read_result || !exp_read_result)

--- a/src/ddscxx/tests/KeyHash.cpp
+++ b/src/ddscxx/tests/KeyHash.cpp
@@ -1,0 +1,157 @@
+// Copyright(c) 2023 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#include "StreamingUtility.hpp"
+#include "KeyHashModels.hpp"
+
+using namespace Keyhash_testing;
+
+/**
+ * Fixture for the KeyHash tests
+ */
+class KeyHash : public ::testing::Test
+{
+public:
+    const bytes
+        s_k_o_h = {
+            0x01 /*a*/, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 /*padding*/,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03 /*c*/},
+        s_k_ih_h = {
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03 /*c*/,
+            0x01 /*a*/},
+        s_s = {
+            0x01 /*a*/, 0x0, 0x0, 0x0 /*padding*/,
+            0x00, 0x00, 0x00, 0x04 /*b.length*/, 'a', 'b', 'c', '\0' /*b.c_str*/},
+        s_n_h_1 = {
+            0x01 /*z.a*/, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 /*padding*/,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03 /*z.c*/,
+            0x04 /*x*/},
+        s_n_h_2 = {
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03 /*z.c*/,
+            0x01 /*z.a*/, 0x04 /*x*/},
+        n_f_i_h = {
+            0x00, 0x00, 0x00, 0x07 /*f*/,
+            0x03 /*d.z.a*/, 0x00, 0x00, 0x00 /*padding*/,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05/*d.z.c*/,
+            0x02 /*d.y*/,
+            0x01 /*d.x*/},
+        n_f_i_2_h = {
+            0x01 /*a.c.e.x*/,
+            0x02 /*a.c.e.y*/,
+            0x05 /*a.d.e.x*/,
+            0x06 /*a.d.e.y*/},
+        n_m_i_h = {
+            0x00, 0x00, 0x00, 0x0b /*f*/,
+            0x03 /*d.z.a*/, 0x00, 0x00, 0x00 /*padding*/,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05 /*d.z.c*/,
+            0x02 /*d.y*/,
+            0x01 /*d.x*/},
+        s_o_h{
+          0x00, 0x00, 0x00, 0x05, /*o_1.i_2*/
+          0x00, 0x00, 0x00, 0x02, /*o_3.i_1*/
+          0x00, 0x00, 0x00, 0x01  /*o_3.i_2*/};
+
+    KeyHash()
+    {
+    }
+
+    void SetUp() { }
+
+    void TearDown() { }
+
+};
+
+#define hash_test(_struct, _bytes) { VerifyWrite(_struct, _bytes, basic_cdr_stream, key_mode::sorted, true, true); }
+
+TEST_F(KeyHash, basic_types)
+{
+  SerdataKeyOrder s_k_o{1,2,3};
+  SerdataKeyOrderId s_k_i{1,2,3};
+  SerdataKeyOrderHashId s_k_h{1,2,3};
+  SerdataKeyOrderAppendable s_a{1,2,3};
+  SerdataKeyOrderMutable s_m{1,2,3};
+
+  hash_test(s_k_o, s_k_o_h);
+  hash_test(s_k_i, s_k_ih_h);
+  hash_test(s_k_h, s_k_ih_h);
+  hash_test(s_a, s_k_ih_h);
+  hash_test(s_m, s_k_ih_h);
+}
+
+TEST_F(KeyHash, string_types)
+{
+  SerdataKeyString s{1, "abc"};
+  SerdataKeyStringBounded s_b{1, "abc"};
+  SerdataKeyStringAppendable s_a{1, "abc"};
+  SerdataKeyStringBoundedAppendable s_b_a{1, "abc"};
+
+  hash_test(s, s_s);
+  hash_test(s_b, s_s);
+  hash_test(s_a, s_s);
+  hash_test(s_b_a, s_s);
+}
+
+TEST_F(KeyHash, nested_types)
+{
+  SerdataOuter s_o{SerdataInner1{1,2},SerdataInner1{3,4},SerdataInner2{5,6}};
+  SerdataKeyOrderFinalNestedMutable f_n_m{4,5,SerdataKeyOrderMutable{1,2,3}};
+  SerdataKeyOrderAppendableNestedMutable a_n_m{4,5,SerdataKeyOrderMutable{1,2,3}};
+  SerdataKeyOrderMutableNestedMutable m_n_m{4,5,SerdataKeyOrderMutable{1,2,3}};
+  SerdataKeyOrderMutableNestedAppendable m_n_a{4,5,SerdataKeyOrderAppendable{1,2,3}};
+  SerdataKeyOrderMutableNestedFinal m_n_f{4,5,SerdataKeyOrder{1,2,3}};
+
+
+  hash_test(s_o, s_o_h);
+  hash_test(f_n_m, s_n_h_2);
+  hash_test(a_n_m, s_n_h_2);
+  hash_test(m_n_m, s_n_h_2);
+  hash_test(m_n_a, s_n_h_2);
+  hash_test(m_n_f, s_n_h_1);
+}
+
+TEST_F(KeyHash, nested_types_implicit)
+{
+  SerdataKeyNestedFinalImplicit n_f_i{
+    SerdataKeyNestedFinalImplicitSubtype{1,2,SerdataKeyOrder{3,4,5}},
+    SerdataKeyNestedFinalImplicitSubtype{6,7,SerdataKeyOrder{8,9,10}},
+    7};
+
+  SerdataKeyNestedFinalImplicit2 n_f_i_2{
+    SerdataKeyNestedFinalImplicit2Subtype1{ /*a*/
+      SerdataKeyNestedFinalImplicit2Subtype2{ /*a.c*/
+        SerdataKeyNestedFinalImplicit2Subtype3{1,2}, /*a.c.e*/
+        SerdataKeyNestedFinalImplicit2Subtype3{3,4} /*a.c.f*/},
+      SerdataKeyNestedFinalImplicit2Subtype2{ /*a.d*/
+        SerdataKeyNestedFinalImplicit2Subtype3{5,6}, /*a.d.e*/
+        SerdataKeyNestedFinalImplicit2Subtype3{7,8} /*a.d.f*/}},
+    SerdataKeyNestedFinalImplicit2Subtype1{ /*b*/
+      SerdataKeyNestedFinalImplicit2Subtype2{ /*b.c*/
+        SerdataKeyNestedFinalImplicit2Subtype3{9,10}, /*b.c.e*/
+        SerdataKeyNestedFinalImplicit2Subtype3{11,12} /*b.c.f*/},
+      SerdataKeyNestedFinalImplicit2Subtype2{ /*b.d*/
+        SerdataKeyNestedFinalImplicit2Subtype3{13,14}, /*b.d.e*/
+        SerdataKeyNestedFinalImplicit2Subtype3{15,16} /*b.d.f*/}}};
+
+  SerdataKeyNestedMutableImplicit n_m_i{
+    SerdataKeyNestedMutableImplicitSubtype{ /*d*/
+      1, /*d.x*/
+      2, /*d.y*/
+      SerdataKeyOrder{3, 4, 5}}, /*d.z*/
+    SerdataKeyNestedMutableImplicitSubtype{ /*e*/
+      6, /*e.x*/
+      7, /*e.y*/
+      SerdataKeyOrder{8, 9, 10}}, /*e.z*/
+      11 /*f*/};
+
+  hash_test(n_f_i, n_f_i_h);
+  hash_test(n_f_i_2, n_f_i_2_h);
+  hash_test(n_m_i, n_m_i_h);
+}
+

--- a/src/ddscxx/tests/Regression.cpp
+++ b/src/ddscxx/tests/Regression.cpp
@@ -42,7 +42,7 @@ template<typename T, typename S>
 void VerifyWrite_impl(const T& in, const bytes &out, S &stream, bool as_key = false, bool write_success = true, bool compare_success = true)
 {
   bytes buffer;
-  bool result = move(stream, in, as_key);
+  bool result = move(stream, in, as_key ? key_mode::unsorted : key_mode::not_key);
   ASSERT_EQ(result, write_success);
 
   if (!result)
@@ -50,7 +50,7 @@ void VerifyWrite_impl(const T& in, const bytes &out, S &stream, bool as_key = fa
 
   buffer.resize(stream.position());
   stream.set_buffer(buffer.data(), buffer.size());
-  ASSERT_TRUE(write(stream, in, as_key));
+  ASSERT_TRUE(write(stream, in, as_key ? key_mode::unsorted : key_mode::not_key));
 
   result = (buffer == out);
   ASSERT_EQ(result, compare_success);
@@ -62,7 +62,7 @@ void VerifyRead_impl(const bytes &in, const T& out, S &stream, bool as_key = fal
   bytes incopy(in);
   T buffer;
   stream.set_buffer(incopy.data(), incopy.size());
-  bool result = read(stream, buffer, as_key);
+  bool result = read(stream, buffer, as_key ? key_mode::unsorted : key_mode::not_key);
   ASSERT_EQ(result, read_success);
 
   if (!result)
@@ -343,13 +343,13 @@ TEST_F(Regression, memberless_struct)
   const auto &props = get_type_props<s_memberless>();
 
   xcdr_v1_stream v1(endianness::big_endian);
-  v1.set_mode(cdr_stream::stream_mode::read, false);
+  v1.set_mode(cdr_stream::stream_mode::read, key_mode::not_key);
   auto ptr1 = v1.first_entity(props.data());
   EXPECT_EQ(ptr1, nullptr);
 
 
   xcdr_v2_stream v2(endianness::big_endian);
-  v2.set_mode(cdr_stream::stream_mode::read, false);
+  v2.set_mode(cdr_stream::stream_mode::read, key_mode::not_key);
   auto ptr2 = v2.first_entity(props.data());
   EXPECT_EQ(ptr2, nullptr);
 }
@@ -370,36 +370,36 @@ TEST_F(Regression, unaligned_access)
 
   basic_cdr_stream b(swap_end);
   b.set_buffer(correct, 16);
-  ASSERT_TRUE(org::eclipse::cyclonedds::core::cdr::read(b, s, false));
+  ASSERT_TRUE(org::eclipse::cyclonedds::core::cdr::read(b, s, key_mode::not_key));
   ASSERT_EQ(s.l(), int32_t(0x00010203));  //size 4 reads should be done at 4 byte offsets in stream
   ASSERT_EQ(s.ll(), int64_t(0x08090A0B0C0D0E0F));  //size 8 reads should be done at 8 byte offsets in stream
 
   b.set_buffer(incorrect, 16);
-  ASSERT_TRUE(org::eclipse::cyclonedds::core::cdr::read(b, s, false));
+  ASSERT_TRUE(org::eclipse::cyclonedds::core::cdr::read(b, s, key_mode::not_key));
   ASSERT_EQ(s.l(), int32_t(0x04050607));  //size 4 reads should be done at 4 byte offsets in stream
   ASSERT_EQ(s.ll(), int64_t(0x0C0D0E0F10111213));  //size 8 reads should be done at 8 byte offsets in stream
 
   xcdr_v1_stream v1(swap_end);
 
   v1.set_buffer(correct, 16);
-  ASSERT_TRUE(org::eclipse::cyclonedds::core::cdr::read(v1, s, false));
+  ASSERT_TRUE(org::eclipse::cyclonedds::core::cdr::read(v1, s, key_mode::not_key));
   ASSERT_EQ(s.l(), int32_t(0x00010203));  //size 4 reads should be done at 4 byte offsets in stream
   ASSERT_EQ(s.ll(), int64_t(0x08090A0B0C0D0E0F));  //size 8 reads should be done at 8 byte offsets in stream
 
   v1.set_buffer(incorrect, 16);
-  ASSERT_TRUE(org::eclipse::cyclonedds::core::cdr::read(v1, s, false));
+  ASSERT_TRUE(org::eclipse::cyclonedds::core::cdr::read(v1, s, key_mode::not_key));
   ASSERT_EQ(s.l(), int32_t(0x04050607));  //size 4 reads should be done at 4 byte offsets in stream
   ASSERT_EQ(s.ll(), int64_t(0x0C0D0E0F10111213));  //size 8 reads should be done at 8 byte offsets in stream
 
   xcdr_v2_stream v2(swap_end);
 
   v2.set_buffer(correct, 16);
-  ASSERT_TRUE(org::eclipse::cyclonedds::core::cdr::read(v2, s, false));
+  ASSERT_TRUE(org::eclipse::cyclonedds::core::cdr::read(v2, s, key_mode::not_key));
   ASSERT_EQ(s.l(), int32_t(0x00010203));  //size 4 reads should be done at 4 byte offsets in stream
   ASSERT_EQ(s.ll(), int64_t(0x0405060708090A0B));  //size 4 reads should be done at 4 byte offsets in stream
 
   v2.set_buffer(incorrect, 16);
-  ASSERT_TRUE(org::eclipse::cyclonedds::core::cdr::read(v2, s, false));
+  ASSERT_TRUE(org::eclipse::cyclonedds::core::cdr::read(v2, s, key_mode::not_key));
   ASSERT_EQ(s.l(), int32_t(0x04050607));  //size 4 reads should be done at 4 byte offsets in stream
   ASSERT_EQ(s.ll(), int64_t(0x08090A0B0C0D0E0F));  //size 4 reads should be done at 4 byte offsets in stream
 }

--- a/src/ddscxx/tests/Regression.cpp
+++ b/src/ddscxx/tests/Regression.cpp
@@ -234,7 +234,7 @@ TEST_F(Regression, delimiters_bitmask)
 
 TEST_F(Regression, emumerators_properties)
 {
-  EXPECT_EQ(org::eclipse::cyclonedds::core::cdr::get_bit_bound<e1>(), bb_8_bits);
+  EXPECT_EQ(org::eclipse::cyclonedds::core::cdr::get_bit_bound<e1>(), bit_bound::bb_8_bits);
 }
 
 TEST_F(Regression, delimiters_emumerators)

--- a/src/ddscxx/tests/Serdata.cpp
+++ b/src/ddscxx/tests/Serdata.cpp
@@ -76,14 +76,14 @@ private:
     void validate_impl(const T &msg, const std::vector<uint8_t> &exp, endianness end) {
         basic_cdr_stream str(end);
 
-        move(str, msg, false);
+        move(str, msg, key_mode::not_key);
 
         size_t sz = str.position();
         ASSERT_EQ(sz, exp.size());
         std::vector<uint8_t> buffer(sz, 0x0);
         str.set_buffer(buffer.data(), buffer.size());
 
-        write(str, msg, false);
+        write(str, msg, key_mode::not_key);
 
         ASSERT_EQ(buffer, exp);
     }
@@ -103,7 +103,7 @@ TEST_F(Serdata, alignment)
     std::vector<unsigned char> vec(8,0x0);
     str.set_buffer(vec.data(), vec.size());
 
-    write(str, msg, false);
+    write(str, msg, key_mode::not_key);
 
     ASSERT_EQ(vec, std::vector<unsigned char>({16,25,36,0,255,255,0,0}));
 }

--- a/src/ddscxx/tests/StreamingUtility.hpp
+++ b/src/ddscxx/tests/StreamingUtility.hpp
@@ -91,10 +91,10 @@ VerifyRead(normal_bytes, test_struct, streamer, key_mode::not_key, true, true);\
 VerifyRead(key_bytes, key_struct, streamer, key_mode::unsorted, true, true);\
 }
 
-#define read_test_fail(test_struct, key_struct, key_bytes, streamer)\
+#define read_test_fail(test_struct, key_struct, streamer)\
 {\
-VerifyRead(bytes(256, 0x0), test_struct, streamer, key_mode::not_key, false, true);\
-VerifyRead(key_bytes, key_struct, streamer, key_mode::unsorted, true, true);\
+VerifyRead(bytes(256, 0x0), test_struct, streamer, key_mode::not_key, false, false);\
+VerifyRead(bytes(256, 0x0), key_struct, streamer, key_mode::unsorted, false, false);\
 }
 
 #define read_deeper_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
@@ -115,19 +115,19 @@ VerifyWrite(test_struct, normal_bytes, streamer, key_mode::not_key, true, true);
 VerifyWrite(key_struct, key_bytes, streamer, key_mode::unsorted, true, true);\
 }
 
-#define write_test_fail(test_struct, key_struct, key_bytes, streamer)\
+#define write_test_fail(test_struct, key_struct, streamer)\
 {\
 VerifyWrite(test_struct, bytes(256, 0x0), streamer, key_mode::not_key, false, false);\
-VerifyWrite(test_struct, key_bytes, streamer, key_mode::unsorted, true, true);\
+VerifyWrite(key_struct, bytes(256, 0x0), streamer, key_mode::unsorted, false, false);\
 }
 
 #define readwrite_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
 read_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
 write_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)
 
-#define readwrite_test_fail(test_struct, key_struct, key_bytes, streamer)\
-read_test_fail(test_struct, key_struct, key_bytes, streamer)\
-write_test_fail(test_struct, key_struct, key_bytes, streamer)
+#define readwrite_test_fail(test_struct, key_struct, streamer)\
+read_test_fail(test_struct, key_struct, streamer)\
+write_test_fail(test_struct, key_struct, streamer)
 
 #define readwrite_deeper_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
 read_deeper_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
@@ -142,13 +142,3 @@ readwrite_test(test_struct, test_struct, cdr_normal_bytes, key_bytes, xcdr_v2_st
 readwrite_test(test_struct, key_struct, cdr_normal_bytes, key_bytes, basic_cdr_stream)\
 readwrite_test(test_struct, key_struct, cdr_normal_bytes, key_bytes, xcdr_v1_stream)\
 readwrite_test(test_struct, key_struct, cdr_normal_bytes, key_bytes, xcdr_v2_stream)
-
-#define stream_test_fail_basic(test_struct, xcdr_v1_normal_bytes, xcdr_v2_normal_bytes, key_bytes)\
-readwrite_test_fail(test_struct, test_struct, key_bytes, basic_cdr_stream)\
-readwrite_test(test_struct, test_struct, xcdr_v1_normal_bytes, key_bytes, xcdr_v1_stream)\
-readwrite_test(test_struct, test_struct, xcdr_v2_normal_bytes, key_bytes, xcdr_v2_stream)
-
-#define stream_deeper_test(test_struct, cdr_normal_bytes, cdr_delimited_bytes, key_bytes)\
-readwrite_deeper_test(test_struct, test_struct, cdr_normal_bytes, key_bytes, basic_cdr_stream)\
-readwrite_deeper_test(test_struct, test_struct, cdr_normal_bytes, key_bytes, xcdr_v1_stream)\
-readwrite_deeper_test(test_struct, test_struct, cdr_delimited_bytes, key_bytes, xcdr_v2_stream)

--- a/src/ddscxx/tests/StreamingUtility.hpp
+++ b/src/ddscxx/tests/StreamingUtility.hpp
@@ -1,0 +1,154 @@
+
+#include "dds/dds.hpp"
+#include <gtest/gtest.h>
+#include <vector>
+
+#if DDSCXX_USE_BOOST
+#include <boost/optional.hpp>
+#include <boost/none.hpp>
+#define DDSCXX_STD_IMPL boost
+#define DDSCXX_STD_IMPL_NULLOPT boost::none
+#else
+#define DDSCXX_STD_IMPL std
+#define DDSCXX_STD_IMPL_NULLOPT std::nullopt
+#endif
+
+typedef std::vector<unsigned char> bytes;
+
+using namespace org::eclipse::cyclonedds::core::cdr;
+
+template<typename T, typename S>
+void VerifyWrite_Impl(const T& in, const bytes &out, S &stream, key_mode _key, bool write_success = true, bool compare_success = true)
+{
+  bytes buffer;
+  bool result = move(stream, in, _key);
+  ASSERT_EQ(result, write_success);
+
+  if (!result)
+    return;
+
+  buffer.resize(stream.position());
+  stream.set_buffer(buffer.data(), buffer.size());
+  ASSERT_TRUE(write(stream, in, _key));
+
+  result = (buffer == out);
+  ASSERT_EQ(result, compare_success);
+}
+
+template<typename T, typename S>
+void VerifyRead_Impl(const bytes &in, const T& out, S &stream, key_mode _key, bool read_success = true, bool compare_success = true)
+{
+  bytes incopy(in);
+  T buffer;
+  stream.set_buffer(incopy.data(), incopy.size());
+  bool result = read(stream, buffer, _key);
+  ASSERT_EQ(result, read_success);
+
+  if (!result)
+    return;
+
+  if (_key == key_mode::sorted || _key == key_mode::unsorted)
+    result = (buffer.c() == out.c());
+  else
+    result = (buffer == out);
+
+  ASSERT_EQ(result, compare_success);
+}
+
+template<typename T, typename S>
+void VerifyReadOneDeeper_Impl(const bytes &in, const T& out, S &stream, key_mode _key)
+{
+  bytes incopy(in);
+  T buffer;
+
+  stream.set_buffer(incopy.data(), incopy.size());
+  ASSERT_TRUE(read(stream, buffer, _key));
+
+  if (_key == key_mode::sorted || _key == key_mode::unsorted) {
+    ASSERT_EQ(buffer.c().size(), out.c().size());
+    for (size_t i = 0; i < buffer.c().size() && i < out.c().size(); i++)
+      ASSERT_EQ(buffer.c()[i].c(), out.c()[i].c());
+  } else {
+    ASSERT_EQ(buffer, out);
+  }
+}
+
+#define VerifyRead(_bytes, _struct, _streamer, _key, _read_success, _compare_success)\
+{\
+_streamer streamer_1(endianness::big_endian);\
+VerifyRead_Impl(_bytes, _struct, streamer_1, _key, _read_success, _compare_success);\
+}
+
+#define VerifyReadOneDeeper(_bytes, _struct, _streamer, _key)\
+{\
+_streamer streamer_1(endianness::big_endian);\
+VerifyReadOneDeeper_Impl(_bytes, _struct, streamer_1, _key);\
+}
+
+#define read_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
+{\
+VerifyRead(normal_bytes, test_struct, streamer, key_mode::not_key, true, true);\
+VerifyRead(key_bytes, key_struct, streamer, key_mode::unsorted, true, true);\
+}
+
+#define read_test_fail(test_struct, key_struct, key_bytes, streamer)\
+{\
+VerifyRead(bytes(256, 0x0), test_struct, streamer, key_mode::not_key, false, true);\
+VerifyRead(key_bytes, key_struct, streamer, key_mode::unsorted, true, true);\
+}
+
+#define read_deeper_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
+{\
+VerifyRead(normal_bytes, test_struct, streamer, key_mode::not_key, true, true);\
+VerifyReadOneDeeper(key_bytes, key_struct, streamer, key_mode::unsorted);\
+}
+
+#define VerifyWrite(_struct, _bytes, _streamer, _key, _write_success, _compare_success)\
+{\
+_streamer streamer_1(endianness::big_endian);\
+VerifyWrite_Impl(_struct, _bytes, streamer_1, _key, _write_success, _compare_success);\
+}
+
+#define write_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
+{\
+VerifyWrite(test_struct, normal_bytes, streamer, key_mode::not_key, true, true);\
+VerifyWrite(key_struct, key_bytes, streamer, key_mode::unsorted, true, true);\
+}
+
+#define write_test_fail(test_struct, key_struct, key_bytes, streamer)\
+{\
+VerifyWrite(test_struct, bytes(256, 0x0), streamer, key_mode::not_key, false, false);\
+VerifyWrite(test_struct, key_bytes, streamer, key_mode::unsorted, true, true);\
+}
+
+#define readwrite_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
+read_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
+write_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)
+
+#define readwrite_test_fail(test_struct, key_struct, key_bytes, streamer)\
+read_test_fail(test_struct, key_struct, key_bytes, streamer)\
+write_test_fail(test_struct, key_struct, key_bytes, streamer)
+
+#define readwrite_deeper_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
+read_deeper_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)\
+write_test(test_struct, key_struct, normal_bytes, key_bytes, streamer)
+
+#define stream_test(test_struct, cdr_normal_bytes, key_bytes)\
+readwrite_test(test_struct, test_struct, cdr_normal_bytes, key_bytes, basic_cdr_stream)\
+readwrite_test(test_struct, test_struct, cdr_normal_bytes, key_bytes, xcdr_v1_stream)\
+readwrite_test(test_struct, test_struct, cdr_normal_bytes, key_bytes, xcdr_v2_stream)
+
+#define stream_test_union(test_struct, key_struct, cdr_normal_bytes, key_bytes)\
+readwrite_test(test_struct, key_struct, cdr_normal_bytes, key_bytes, basic_cdr_stream)\
+readwrite_test(test_struct, key_struct, cdr_normal_bytes, key_bytes, xcdr_v1_stream)\
+readwrite_test(test_struct, key_struct, cdr_normal_bytes, key_bytes, xcdr_v2_stream)
+
+#define stream_test_fail_basic(test_struct, xcdr_v1_normal_bytes, xcdr_v2_normal_bytes, key_bytes)\
+readwrite_test_fail(test_struct, test_struct, key_bytes, basic_cdr_stream)\
+readwrite_test(test_struct, test_struct, xcdr_v1_normal_bytes, key_bytes, xcdr_v1_stream)\
+readwrite_test(test_struct, test_struct, xcdr_v2_normal_bytes, key_bytes, xcdr_v2_stream)
+
+#define stream_deeper_test(test_struct, cdr_normal_bytes, cdr_delimited_bytes, key_bytes)\
+readwrite_deeper_test(test_struct, test_struct, cdr_normal_bytes, key_bytes, basic_cdr_stream)\
+readwrite_deeper_test(test_struct, test_struct, cdr_normal_bytes, key_bytes, xcdr_v1_stream)\
+readwrite_deeper_test(test_struct, test_struct, cdr_delimited_bytes, key_bytes, xcdr_v2_stream)

--- a/src/ddscxx/tests/data/KeyHashModels.idl
+++ b/src/ddscxx/tests/data/KeyHashModels.idl
@@ -1,0 +1,192 @@
+// Copyright(c) 2023 ZettaScale Technology and others
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+// v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+module Keyhash_testing {
+
+@final struct SerdataInner1 {
+    @id(2) long i_2;
+    @id(1) long i_1;
+};
+
+@final struct SerdataInner2 {
+    @id(2) @key long i_2;
+    @id(1) long i_1;
+};
+
+@final struct SerdataOuter {
+    @id(3) @key SerdataInner1 o_3;
+    @id(2) SerdataInner1 o_2;
+    @id(1) @key SerdataInner2 o_1;
+};
+
+@final
+struct SerdataKeyOrder {
+    @key uint8 a;
+    uint8 b;
+    @key uint64 c;
+};
+
+@final
+struct SerdataKeyOrderId {
+    @id(2) @key uint8 a;
+    @id(3) uint8 b;
+    @id(1) @key uint64 c;
+};
+
+@final @autoid(HASH)
+struct SerdataKeyOrderHashId {
+    @key uint8 a;       // 0cc175b9
+    uint8 b;            // 92eb5ffe
+    @key uint64 c;      // 4a8a08f0
+};
+
+@appendable
+struct SerdataKeyOrderAppendable {
+    @id(3) @key uint8 a;
+    @id(2) uint8 b;
+    @id(1) @key uint64 c;
+};
+
+@mutable
+struct SerdataKeyOrderMutable {
+    @id(3) @key uint8 a;
+    @id(2) uint8 b;
+    @id(1) @key uint64 c;
+};
+
+@final
+struct SerdataKeyString {
+    @key uint8 a;
+    @key string b;
+};
+
+@final
+struct SerdataKeyStringBounded {
+    @key uint8 a;
+    @key string<3> b;
+};
+
+@appendable
+struct SerdataKeyStringAppendable {
+    @key uint8 a;
+    @key string b;
+};
+
+@appendable
+struct SerdataKeyStringBoundedAppendable {
+    @key uint8 a;
+    @key string<3> b;
+};
+
+@final
+struct SerdataKeyArr {
+    @key uint8 a[12];
+};
+
+// TODO: currently not supported
+// @final
+// struct SerdataKeyArrStrBounded {
+//     @key string<2> a[2];
+// };
+
+
+// Nested aggregated types
+
+@final
+struct SerdataKeyOrderFinalNestedMutable {
+    @id(3) @key uint8 x;
+    @id(2) uint8 y;
+    @id(1) @key SerdataKeyOrderMutable z;
+};
+
+@appendable
+struct SerdataKeyOrderAppendableNestedMutable {
+    @id(3) @key uint8 x;
+    @id(2) uint8 y;
+    @id(1) @key SerdataKeyOrderMutable z;
+};
+
+@mutable
+struct SerdataKeyOrderMutableNestedMutable {
+    @id(3) @key uint8 x;
+    @id(2) uint8 y;
+    @id(1) @key SerdataKeyOrderMutable z;
+};
+
+@mutable
+struct SerdataKeyOrderMutableNestedAppendable {
+    @id(3) @key uint8 x;
+    @id(2) uint8 y;
+    @id(1) @key SerdataKeyOrderAppendable z;
+};
+
+@mutable
+struct SerdataKeyOrderMutableNestedFinal {
+    @id(3) @key uint8 x;
+    @id(2) uint8 y;
+    @id(1) @key SerdataKeyOrder z;
+};
+
+// Implicit key members in nested type
+
+@final @nested
+struct SerdataKeyNestedFinalImplicitSubtype {
+    @id(3) uint8 x;
+    @id(2) uint8 y;
+    @id(1) SerdataKeyOrder z;
+};
+
+@final
+struct SerdataKeyNestedFinalImplicit {
+    @id(3) @key SerdataKeyNestedFinalImplicitSubtype d;
+    @id(2) SerdataKeyNestedFinalImplicitSubtype e;
+    @id(1) @key uint32 f;
+};
+
+
+@final @nested
+struct SerdataKeyNestedFinalImplicit2Subtype3 {
+    uint8 x;
+    uint8 y;
+};
+
+@final @nested
+struct SerdataKeyNestedFinalImplicit2Subtype2 {
+    @key SerdataKeyNestedFinalImplicit2Subtype3 e;
+    SerdataKeyNestedFinalImplicit2Subtype3 f;
+};
+
+@final @nested
+struct SerdataKeyNestedFinalImplicit2Subtype1 {
+    SerdataKeyNestedFinalImplicit2Subtype2 c;
+    SerdataKeyNestedFinalImplicit2Subtype2 d;
+};
+
+@final
+struct SerdataKeyNestedFinalImplicit2 {
+    @key SerdataKeyNestedFinalImplicit2Subtype1 a;
+    SerdataKeyNestedFinalImplicit2Subtype1 b;
+};
+
+@mutable @nested
+struct SerdataKeyNestedMutableImplicitSubtype {
+    @id(3) uint8 x;
+    @id(2) uint8 y;
+    @id(1) SerdataKeyOrder z;
+};
+
+@appendable
+struct SerdataKeyNestedMutableImplicit {
+    @id(3) @key SerdataKeyNestedMutableImplicitSubtype d;
+    @id(2) SerdataKeyNestedMutableImplicitSubtype e;
+    @id(1) @key uint32 f;
+};
+
+};

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -1186,9 +1186,9 @@ print_entry_point_functions(
 {
   static const char *fmt =
     "template<typename S, std::enable_if_t<std::is_base_of<cdr_stream, S>::value, bool> = true >\n"
-    "bool {T}(S& str, {C}%1$s& instance, bool as_key) {\n"
+    "bool {T}(S& str, {C}%1$s& instance, key_mode key) {\n"
     "  const auto &props = get_type_props<%1$s>();\n"
-    "  str.set_mode(cdr_stream::stream_mode::{T}, as_key);\n"
+    "  str.set_mode(cdr_stream::stream_mode::{T}, key);\n"
     "  return {T}(str, instance, props.data()); \n"
     "}\n\n";
 

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -715,7 +715,7 @@ generate_member_properties(
   }
 
   if (reset_bit_bound) {
-    if (putf(&streams->props, "  props.push_back(entity_properties_t(1, %1$"PRIu32", %2$s, bb_unset, extensibility::%3$s, %4$s));  //::%5$s\n", decl->id.value, opt, ext, m_u, idl_identifier(decl)))
+    if (putf(&streams->props, "  props.push_back(entity_properties_t(1, %1$"PRIu32", %2$s, bit_bound::bb_unset, extensibility::%3$s, %4$s));  //::%5$s\n", decl->id.value, opt, ext, m_u, idl_identifier(decl)))
       return IDL_RETCODE_NO_MEMORY;
   } else {
     if (putf(&streams->props, "  props.push_back(entity_properties_t(1, %1$"PRIu32", %2$s, get_bit_bound<%3$s>(), extensibility::%4$s, %5$s));  //::%6$s\n", decl->id.value, opt, type, ext, m_u, idl_identifier(decl)))
@@ -1106,7 +1106,7 @@ print_constructed_type_open(struct streams *streams, const idl_node_t *node)
    || putf(&streams->props, pfmt1, name, pfmt2)
    || idl_fprintf(streams->generator->header.handle, pfmt1, name, ";\n\n") < 0
    || multi_putf(streams, ALL, sfmt)
-   || putf(&streams->props, "  props.push_back(entity_properties_t(0, 0, false, bb_unset, extensibility::%1$s));  //root\n", ext))
+   || putf(&streams->props, "  props.push_back(entity_properties_t(0, 0, false, bit_bound::bb_unset, extensibility::%1$s));  //root\n", ext))
     return IDL_RETCODE_NO_MEMORY;
 
   return IDL_RETCODE_OK;
@@ -1466,7 +1466,7 @@ process_enum(
   static const char *conv_func = "template<>\n"\
                     "%s enum_conversion<%s>(uint32_t in)%s",
                     *bb_func = "template<>\n"\
-                    "constexpr bit_bound get_bit_bound<%s>() { return bb_%d_bits; }\n\n";
+                    "constexpr bit_bound get_bit_bound<%s>() { return bit_bound::bb_%d_bits; }\n\n";
 
   if (putf(&str->props, conv_func, fullname, fullname, " {\n  switch (in) {\n")
    || idl_fprintf(gen->header.handle, conv_func, fullname, fullname, ";\n\n") < 0)


### PR DESCRIPTION
This fixes the issue with the members being in definition order when serializing for keyhashes