### PR TITLE
feature/print-sample-into-trace

### DIFF
--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -624,6 +624,7 @@ size_t serdata_print(
   (void)tpcmn;
   (void)dcmn;
 
+  size_t copy_len = 0;
   auto d = const_cast<ddscxx_serdata<T>*>(static_cast<const ddscxx_serdata<T>*>(dcmn));
   auto t_ptr = d->getT();
 
@@ -634,16 +635,16 @@ size_t serdata_print(
     const std::string data = ss.str();
     const size_t len = data.size();
 
+    copy_len = bufsize - 1;
     if (len < bufsize) {
-      strncpy(buf, data.c_str(), len);
-      buf[len] = '\0'; // Null-terminate the string
-      return len;
+      copy_len = len;
     }
+
+    strncpy(buf, data.c_str(), copy_len);
+    buf[copy_len] = '\0'; // Null-terminate the string
   }
 
-  if (bufsize > 0)
-    buf[0] = 0x0;
-  return 0;
+  return copy_len;
 }
 
 template <typename T>

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -11,6 +11,7 @@
 #ifndef DDSCXXDATATOPIC_HPP_
 #define DDSCXXDATATOPIC_HPP_
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <cstring>

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -623,7 +623,24 @@ size_t serdata_print(
 {
   (void)tpcmn;
   (void)dcmn;
-  //implementation to follow!!!
+
+  auto d = const_cast<ddscxx_serdata<T>*>(static_cast<const ddscxx_serdata<T>*>(dcmn));
+  auto t_ptr = d->getT();
+
+  if (t_ptr) {
+    std::stringstream ss;
+    ss << *t_ptr;
+
+    const std::string data = ss.str();
+    const size_t len = data.size();
+
+    if (len < bufsize) {
+      strncpy(buf, data.c_str(), len);
+      buf[len] = '\0'; // Null-terminate the string
+      return len;
+    }
+  }
+
   if (bufsize > 0)
     buf[0] = 0x0;
   return 0;

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/datatopic.hpp
@@ -634,14 +634,10 @@ size_t serdata_print(
 
     const std::string data = ss.str();
     const size_t len = data.size();
+    copy_len = len < bufsize ? len : bufsize;
 
-    copy_len = bufsize - 1;
-    if (len < bufsize) {
-      copy_len = len;
-    }
-
-    strncpy(buf, data.c_str(), copy_len);
-    buf[copy_len] = '\0'; // Null-terminate the string
+    std::copy_n(data.c_str(), copy_len, buf);
+    buf[len < bufsize ? copy_len : copy_len - 1] = '\0';
   }
 
   return copy_len;


### PR DESCRIPTION
This PR implements the `serdata_print` method which prints the sample into the trace file.

Example output:

```bash
1711111797.031053 [0]    3223925: write_sample 1102a1e:3fb3f5fd:3848a570:202 #1: ST0 HelloWorldData_Msg/HelloWorldData::Msg:[userID: 1, message: Hello World]
```