### PR TITLE
Fix read_cdr and take_cdr

### DIFF
--- a/src/ddscxx/include/dds/sub/detail/SamplesHolder.hpp
+++ b/src/ddscxx/include/dds/sub/detail/SamplesHolder.hpp
@@ -92,7 +92,6 @@ public:
         copy_buffer_to_cdr_blob(reinterpret_cast<uint8_t *>(blob_content.iov_base),
                                 blob_content.iov_len, sample_data.kind(), sample_data);
         ddsi_serdata_to_ser_unref(sd, &blob_content);
-        ddsi_serdata_unref(sd);
     }
 
 private:

--- a/src/ddscxx/tests/DataReader.cpp
+++ b/src/ddscxx/tests/DataReader.cpp
@@ -942,6 +942,41 @@ TEST_F(DataReader, readtake2)
 }
 
 
+TEST_F(DataReader, readcdr)
+{
+#if DDSRT_ENDIAN == DDSRT_LITTLE_ENDIAN
+    const std::array<char, 4> encoding{0x00, 0x01, 0x00, 0x00};
+    const std::vector<uint8_t> payloadcdr{0x00,0x00,0x00,0x00, 0x01,0x00,0x00,0x00, 0x02,0x00,0x00,0x00};
+#else
+    const std::array<char, 4> encoding{0x00, 0x00, 0x00, 0x00};
+    const std::vector<uint8_t> payloadcdr{0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x01, 0x00,0x00,0x00,0x02};
+#endif
+    dds::sub::LoanedSamples<org::eclipse::cyclonedds::topic::CDRBlob> read_samples;
+    dds::sub::LoanedSamples<org::eclipse::cyclonedds::topic::CDRBlob> take_samples;
+
+    /* Create and write data. */
+    std::vector<Space::Type1> testDataList = this->WriteData(1);
+
+    /* Check result by reading. */
+    read_samples = this->reader->read_cdr();
+    dds::sub::status::DataState notReadState(dds::sub::status::SampleState::not_read(),
+                                             dds::sub::status::ViewState::new_view(),
+                                             dds::sub::status::InstanceState::alive());
+    ASSERT_EQ(read_samples.begin()->data().kind(), org::eclipse::cyclonedds::topic::BlobKind::Data);
+    ASSERT_EQ(read_samples.begin()->data().encoding(), encoding);
+    ASSERT_EQ(read_samples.begin()->data().payload(), payloadcdr);
+
+    /* Check result. */
+    take_samples = this->reader->take_cdr();
+    dds::sub::status::DataState readState(dds::sub::status::SampleState::read(),
+                                          dds::sub::status::ViewState::not_new_view(),
+                                          dds::sub::status::InstanceState::alive());
+    ASSERT_EQ(take_samples.begin()->data().kind(), org::eclipse::cyclonedds::topic::BlobKind::Data);
+    ASSERT_EQ(take_samples.begin()->data().encoding(), encoding);
+    ASSERT_EQ(take_samples.begin()->data().payload(), payloadcdr);
+}
+
+
 TEST_F(DataReader, lookup_instance)
 {
     static const uint32_t MAX_INSTANCES = 7;


### PR DESCRIPTION
... and incidentally address the
```
/home/vsts/work/1/s/src/ddscxx/include/dds/sub/detail/SamplesHolder.hpp:89:9: error: ignoring return value of function declared with 'warn_unused_result' attribute [-Werror,-Wunused-result]
        ddsi_serdata_to_ser_ref(sd, 0, ddsi_serdata_size(sd), &blob_content);
        ^~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
flagged by the CI in #480 but not caused by it. (It was caused by https://github.com/eclipse-cyclonedds/cyclonedds/pull/1947 adding the `warn_unused_result` attribute, and that's a good thing as it helped catch the bugs and the missing test.)