### PR TITLE
Fix code generation for unions inside topics by simplifying it.

### DIFF
--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -533,7 +533,9 @@ bool is_nested(const void *node)
 
 static bool sc_union(const idl_union_t *_union)
 {
-  if (!is_selfcontained(_union->switch_type_spec->type_spec))
+  return false;
+  
+/*  if (!is_selfcontained(_union->switch_type_spec->type_spec))
     return false;
 
   const idl_case_t *_case = NULL;
@@ -542,7 +544,7 @@ static bool sc_union(const idl_union_t *_union)
       return false;
   }
 
-  return true;
+  return true;*/
 }
 
 static bool sc_struct(const idl_struct_t *str)


### PR DESCRIPTION
Code does not correctly handle complex unions that have hold values that resolve to different sizes. This can lead to failures to publish data if the first time the topic publishes it uses a value in the union is smaller than others.