### PR TITLE
Set RUNPATH in installed targets and fix roundtrip example install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,12 @@ include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 include(CTest)
 
+if(APPLE)
+  set(CMAKE_INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}")
+else()
+  set(CMAKE_INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+endif()
+
 set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
 # Generate <Package>Config.cmake

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -40,12 +40,12 @@ add_subdirectory(throughput)
 
 install(
   FILES roundtrip/ping.cpp
-        roundtrip/ping.cpp
+        roundtrip/pong.cpp
         roundtrip/roundtrip_common.hpp
         roundtrip/RoundTrip.idl
         roundtrip/CMakeLists.txt
         roundtrip/readme.rst
-  DESTINATION "${CMAKE_INSTALL_EXAMPLESDIR}/throughput"
+  DESTINATION "${CMAKE_INSTALL_EXAMPLESDIR}/roundtrip"
   COMPONENT dev)
 
 add_subdirectory(roundtrip)

--- a/examples/helloworld/CMakeLists.txt
+++ b/examples/helloworld/CMakeLists.txt
@@ -9,8 +9,8 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-project(helloworld LANGUAGES C CXX)
 cmake_minimum_required(VERSION 3.16)
+project(helloworld LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 

--- a/examples/roundtrip/CMakeLists.txt
+++ b/examples/roundtrip/CMakeLists.txt
@@ -9,8 +9,8 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-project(throughput LANGUAGES C CXX)
 cmake_minimum_required(VERSION 3.16)
+project(throughput LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 

--- a/examples/throughput/CMakeLists.txt
+++ b/examples/throughput/CMakeLists.txt
@@ -9,8 +9,8 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-project(throughput LANGUAGES C CXX)
 cmake_minimum_required(VERSION 3.16)
+project(throughput LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 


### PR DESCRIPTION
This sets RUNPATH (same as in [eclipse-cyclonedds/cyclonedds](https://github.com/eclipse-cyclonedds/cyclonedds) so the runtime linker can use it to find dependent libraries (like `libddsc`) when they are installed to the same directory as the C++ library.
Also found and fixed some typo's which caused the roundtrip example to not be correctly installed.