### PR TITLE
Do not throw an exception on times before 19700101

### DIFF
--- a/src/ddscxx/src/dds/core/Time.cpp
+++ b/src/ddscxx/src/dds/core/Time.cpp
@@ -50,13 +50,7 @@ int64_t dds::core::Time::sec() const
 
 void dds::core::Time::sec(int64_t s)
 {
-    if(s < 0 && s != -1) {
-        ISOCPP_THROW_EXCEPTION(ISOCPP_ERROR, "dds::core::Time::sec out of bounds");
-    } else {
-        /// @internal @bug OSPL-2308 RTF Time-ish coercion issue
-        /// @see http://jira.prismtech.com:8080/browse/OSPL-2308
-        sec_ =  s;
-    }
+    sec_ = s;
 }
 
 uint32_t dds::core::Time::nanosec() const

--- a/src/ddscxx/tests/Time.cpp
+++ b/src/ddscxx/tests/Time.cpp
@@ -166,11 +166,6 @@ TEST(Time, sec)
     t = dds::core::Time::from_secs(secs);
     ASSERT_EQ(t.sec(), 10);
     ASSERT_EQ(t.nanosec(), 500000000);
-
-    ASSERT_THROW({
-        /* Negative secs. */
-        t.sec(-2);
-    }, dds::core::Error);
 }
 
 TEST(Time, greater)


### PR DESCRIPTION
This stops throwing the C++ wrapper from throwing an exception in the dds:core::Time class on trying to construct a time stamp prior to the 00:00:00 UTC on 1 January 1970. There is no reason to do that and it makes it vulnerable to receiving samples with earlier time stamps.

It is tricky to test: Cyclone won't allow writing these. I've tested it in a rather convoluted manner by hand ...