### PR TITLE
delete associated dds_entity in DDScObjectDelegate.close

### DIFF
--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/DDScObjectDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/DDScObjectDelegate.cpp
@@ -30,6 +30,13 @@ org::eclipse::cyclonedds::core::DDScObjectDelegate::DDScObjectDelegate () :
 
 org::eclipse::cyclonedds::core::DDScObjectDelegate::~DDScObjectDelegate ()
 {
+    if (!this->closed) {
+        try {
+            this->close();
+        } catch (...) {
+
+        }
+    }
 }
 
 void

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/DDScObjectDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/DDScObjectDelegate.cpp
@@ -30,17 +30,18 @@ org::eclipse::cyclonedds::core::DDScObjectDelegate::DDScObjectDelegate () :
 
 org::eclipse::cyclonedds::core::DDScObjectDelegate::~DDScObjectDelegate ()
 {
+}
+
+void
+org::eclipse::cyclonedds::core::DDScObjectDelegate::close ()
+{
     delete_from_entity_map();
 
     if (this->ddsc_entity > 0) {
         dds_delete(this->ddsc_entity);
         this->ddsc_entity = 0;
     }
-}
 
-void
-org::eclipse::cyclonedds::core::DDScObjectDelegate::close ()
-{
     org::eclipse::cyclonedds::core::ObjectDelegate::close();
 }
 


### PR DESCRIPTION
The cyclone dds_entity associated with an CXX Entity must be deleted when the close on that entity is called