### PR TITLE
Fix compilation error on RedHat when compiling with -Werror=sign-conversion

### DIFF
--- a/src/ddscxx/tests/QosProvider.cpp
+++ b/src/ddscxx/tests/QosProvider.cpp
@@ -183,10 +183,10 @@ static uint32_t b64_encode (const unsigned char *text, const uint32_t sz, unsign
     unsigned char chunk[4] = {0x00, 0x00, 0x00, 0x00};
     size_t cp_sz = (sz - j);
     unsigned char tmp[3] = {text[j], static_cast<unsigned char>(((cp_sz > 1)? text[j+1]: 0x00)), static_cast<unsigned char>((cp_sz > 2)? text[j+2]: 0x00)};
-    chunk[3] = base64_etable[tmp[2] & 0x3FU];
-    chunk[2] = base64_etable[((tmp[1] & 0x0FU) << 0x02U) | (tmp[2] & 0xC0U) >> 0x06U];
-    chunk[1] = base64_etable[((tmp[0] & 0x03U) << 0x04U) | (tmp[1] >> 0x04U)];
-    chunk[0] = base64_etable[(tmp[0] >> 0x02U)];
+    chunk[3] = base64_etable[tmp[2] & 0x3F];
+    chunk[2] = base64_etable[((tmp[1] & 0x0F) << 0x02) | (tmp[2] & 0xC0) >> 0x06];
+    chunk[1] = base64_etable[((tmp[0] & 0x03) << 0x04) | (tmp[1] >> 0x04)];
+    chunk[0] = base64_etable[(tmp[0] >> 0x02)];
     (void) memcpy(*(buff)+i, chunk, cp_sz < 3? cp_sz + 1: 4U);
   }
 


### PR DESCRIPTION
The following compilation error was generated on RedHat platforms with older gcc compilers (e.g. gcc8.4) when compiling with the  -Werror=sign-conversion:
"conversion to 'unsigned int' from 'int' may change the sign of the result"
This was caused by an implicit promotion to int32_t from the result of a logical AND operator on an unsigned char with a uint32_t as the mask. A subsequent logical OR on this result with an unsigned char shifted by four bits would cause the signed/unsigned conflict. By making sure all parameters are promoted to type int, we avoid this situation.