### PR TITLE
Remove absolute path in implementation header include

### DIFF
--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -654,9 +654,13 @@ print_header(FILE *fh, const char *in, const char *out)
 static idl_retcode_t
 print_impl_header(FILE *fh, const char *in, const char *out, const char *hdr)
 {
+  const char *sep = hdr;
+  for (const char *ptr = sep; *ptr; ptr++)
+    if (idl_isseparator((unsigned char)*ptr))
+      sep = ptr+1;
   const char *fmt = "#include \"%s\"\n\n";
   if (print_header(fh, in, out)
-   || idl_fprintf(fh, fmt, hdr) < 0)
+   || idl_fprintf(fh, fmt, sep) < 0)
     return IDL_RETCODE_NO_MEMORY;
   return IDL_RETCODE_OK;
 }


### PR DESCRIPTION
The header include statement in the source was using an absolute path.
Update idlcxx file generator.c to matches the reference implementation in [libidlc__generator.c](https://github.com/eclipse-cyclonedds/cyclonedds/blob/447912e79fd08e2a0dcb439a0022116a96267c90/src/tools/idlc/src/libidlc/libidlc__generator.c#L150
)
Now the header import in the source only contains the header file.
