### PR TITLE
Support all debian architectue in cpack 

### DIFF
--- a/CMakeCPack.cmake
+++ b/CMakeCPack.cmake
@@ -103,11 +103,20 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
     set(CPACK_RPM_DEV_PACKAGE_REQUIRES "${CPACK_RPM_LIB_PACKAGE_NAME} = ${CPACK_PACKAGE_VERSION}")
   elseif(EXISTS "/etc/debian_version")
     set(CPACK_DEB_COMPONENT_INSTALL ON)
-    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-      set(__arch "amd64")
-    else()
-      set(__arch "i386")
-    endif()
+    find_program(DPKG_CMD dpkg)
+    if(NOT DPKG_CMD)
+      if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(__arch "amd64")
+      else()
+        set(__arch "i386")
+      endif()
+    else ()
+      execute_process(COMMAND "${DPKG_CMD}" --print-architecture
+              OUTPUT_VARIABLE __arch
+              OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+    endif ()
+
 
     set(CPACK_GENERATOR "DEB;TGZ;${CPACK_GENERATOR}" CACHE STRING "List of package generators")
 


### PR DESCRIPTION
Sister PR: https://github.com/eclipse-cyclonedds/cyclonedds/pull/2121
Cpack enforces architecture debian architecture i386 or amd64 even when compiling for arm64.
Now the architecture is detected by dpkg as per the standard debian process:
https://github.com/Kitware/CMake/blob/f3f9ad9499526963a46c10733ab9e8b3c0ebfcb1/Modules/Internal/CPack/CPackDeb.cmake#L541