### PR TITLE
Switch union std::variant access to being by index

### DIFF
--- a/src/ddscxx/tests/Regression.cpp
+++ b/src/ddscxx/tests/Regression.cpp
@@ -218,6 +218,11 @@ TEST_F(Regression, union_duplicate_types)
   d_s.c_1({1,2,3,4,5,6});
 }
 
+TEST_F(Regression, union_duplicate_string_types)
+{
+  duplicate_string_types_union d_t;
+}
+
 TEST_F(Regression, delimiters_bitmask)
 {
   bytes s_bm1_bytes =

--- a/src/ddscxx/tests/data/RegressionModels.idl
+++ b/src/ddscxx/tests/data/RegressionModels.idl
@@ -119,12 +119,29 @@ union duplicate_types_union_2 switch(long) {
 typedef unsigned long ulong_arr[4];
 typedef sequence<ulong_arr> seq_ulong_arr;
 typedef sequence<unsigned long> seq_ulong;
+typedef string string_typedef;
+typedef string_typedef string_typedef_2;
+
 
 union duplicate_sequences_union switch (unsigned long) {
   case 0:
     seq_ulong_arr c_0;
   case 1:
     seq_ulong c_1;
+};
+
+union duplicate_string_types_union switch(long) {
+  case 1:
+    string<20> s_1;
+  case 2:
+  case 3:
+    string<40> s_2;
+  case 4:
+    string_typedef s_3;
+  case 5:
+    string_typedef_2 s_4;
+  default:
+    string d_1;
 };
 
 @bit_bound(16) bitmask bm1 {


### PR DESCRIPTION
Accessing std::variant by index means the type list for the variant doesn't have to be de-duped, saving a chunk of logic and ensuring bounded and unbounded strings can be mixed in unions with no problems.

Preserve access by type for use with boost::variant, where it is the only option.