### PR TITLE
Fix for cross compiling examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,12 @@ endif()
 
 configure_file(features.hpp.in "${CMAKE_CURRENT_BINARY_DIR}/src/ddscxx/include/dds/features.hpp")
 
+install(
+  FILES "${CycloneDDS-CXX_SOURCE_DIR}/src/idlcxx/Generate.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/idlcxx"
+  COMPONENT dev)
+
+
 add_subdirectory(src)
 if(BUILD_EXAMPLES)
   add_subdirectory(examples)

--- a/PackageConfig.cmake.in
+++ b/PackageConfig.cmake.in
@@ -20,9 +20,7 @@ if(@ENABLE_LEGACY@)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/idlcxx/Generate.cmake")
 
-if(TARGET CycloneDDS-CXX::idlcxx)
-    include("${CMAKE_CURRENT_LIST_DIR}/idlcxx/Generate.cmake")
-endif()
 
 check_required_components("@PROJECT_NAME@")

--- a/src/idlcxx/CMakeLists.txt
+++ b/src/idlcxx/CMakeLists.txt
@@ -41,9 +41,4 @@ install(
   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT idlcxx
   ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT idlcxx)
 
-install(
-  FILES Generate.cmake
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/idlcxx"
-  COMPONENT idlcxx)
-
 include(Generate.cmake)


### PR DESCRIPTION
matched the behavior with cyclonedds 