### PR TITLE
feature/implement-matched publication data

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,13 +92,13 @@ strategy:
       cxx: g++-12
       type_lib: off
       topic_discovery: off
-    'macOS 12 with Clang 13 (Debug, x86_64)':
-      image: macOS-12
+    'macOS 14 with Clang 15 (Debug, x86_64)':
+      image: macOS-14
       sanitizer: address
       cc: clang
       cxx: clang++
-    'macOS 12 with Clang 13 (Release, x86_64)':
-      image: macOS-12
+    'macOS 14 with Clang 15 (Release, x86_64)':
+      image: macOS-14
       build_type: Release
       sanitizer: address,undefined
       cc: clang

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,13 +92,13 @@ strategy:
       cxx: g++-12
       type_lib: off
       topic_discovery: off
-    'macOS 11 with Clang 12 (Debug, x86_64)':
-      image: macOS-11
+    'macOS 12 with Clang 13 (Debug, x86_64)':
+      image: macOS-12
       sanitizer: address
       cc: clang
       cxx: clang++
-    'macOS 11 with Clang 12 (Release, x86_64)':
-      image: macOS-11
+    'macOS 12 with Clang 13 (Release, x86_64)':
+      image: macOS-12
       build_type: Release
       sanitizer: address,undefined
       cc: clang

--- a/src/ddscxx/include/dds/topic/TBuiltinTopicKey.hpp
+++ b/src/ddscxx/include/dds/topic/TBuiltinTopicKey.hpp
@@ -43,14 +43,14 @@ public:
      *
      * @return the BuiltinTopicKey
      */
-    const uint8_t* value() const;
+    const std::array<uint8_t, 16>& value() const;
 
     /**
      * Sets the BuiltinTopicKey.
      *
-     * @param v the value to set
+     * @param key the value to set
      */
-    void value(uint8_t v[]);
+    void value(const std::array<uint8_t, 16>& key);
 };
 
 #endif /* OMG_DDS_TOPIC_TBUILTIN_TOPIC_KEY_HPP_ */

--- a/src/ddscxx/include/dds/topic/TBuiltinTopicKey.hpp
+++ b/src/ddscxx/include/dds/topic/TBuiltinTopicKey.hpp
@@ -43,14 +43,14 @@ public:
      *
      * @return the BuiltinTopicKey
      */
-    const int32_t* value() const;
+    const uint8_t* value() const;
 
     /**
      * Sets the BuiltinTopicKey.
      *
      * @param v the value to set
      */
-    void value(int32_t v[]);
+    void value(uint8_t v[]);
 };
 
 #endif /* OMG_DDS_TOPIC_TBUILTIN_TOPIC_KEY_HPP_ */

--- a/src/ddscxx/include/dds/topic/detail/BuiltinTopicKey.hpp
+++ b/src/ddscxx/include/dds/topic/detail/BuiltinTopicKey.hpp
@@ -25,4 +25,6 @@ namespace dds { namespace topic { namespace detail {
       typedef dds::topic::TBuiltinTopicKey<org::eclipse::cyclonedds::topic::BuiltinTopicKeyDelegate> BuiltinTopicKey;
 } } }
 
+inline std::ostream& operator << (std::ostream& os, const dds::topic::detail::BuiltinTopicKey& h);
+
 #endif /* OMG_DDS_TOPIC_DETAIL_BUILTIN_TOPIC_KEY_HPP_ */

--- a/src/ddscxx/include/dds/topic/detail/TBuiltinTopicKeyImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TBuiltinTopicKeyImpl.hpp
@@ -28,18 +28,24 @@ namespace topic
 {
 
 template <typename D>
-const int32_t* TBuiltinTopicKey<D>::value() const
+const uint8_t* TBuiltinTopicKey<D>::value() const
 {
     return this->delegate().value();
 }
 
 template <typename D>
-void TBuiltinTopicKey<D>::value(int32_t v[])
+void TBuiltinTopicKey<D>::value(uint8_t v[])
 {
     return this->delegate().value(v);
 }
 
 }
+}
+
+inline std::ostream& operator << (std::ostream& os, const dds::topic::TBuiltinTopicKey<org::eclipse::cyclonedds::topic::BuiltinTopicKeyDelegate>& h)
+{
+     os << h.delegate();
+     return os;
 }
 
 // End of implementation

--- a/src/ddscxx/include/dds/topic/detail/TBuiltinTopicKeyImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TBuiltinTopicKeyImpl.hpp
@@ -28,15 +28,15 @@ namespace topic
 {
 
 template <typename D>
-const uint8_t* TBuiltinTopicKey<D>::value() const
+const std::array<uint8_t, 16>& TBuiltinTopicKey<D>::value() const
 {
     return this->delegate().value();
 }
 
 template <typename D>
-void TBuiltinTopicKey<D>::value(uint8_t v[])
+void TBuiltinTopicKey<D>::value(const std::array<uint8_t, 16>& key)
 {
-    return this->delegate().value(v);
+    return this->delegate().value(key);
 }
 
 }

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicDelegate.hpp
@@ -53,9 +53,9 @@ public:
         return key_;
     }
 
-    void key(const int32_t* key)
+    void key(const uint8_t* key)
     {
-        key_.delegate().value(const_cast<int32_t*>(key));
+        key_.delegate().value(const_cast<uint8_t*>(key));
     }
 
     const ::dds::core::policy::UserData& user_data() const
@@ -86,9 +86,9 @@ public:
         return key_;
     }
 
-    void key(const int32_t* key)
+    void key(const uint8_t* key)
     {
-        key_.delegate().value(const_cast<int32_t*>(key));
+        key_.delegate().value(const_cast<uint8_t*>(key));
     }
 
     const std::string&                  name() const
@@ -314,9 +314,9 @@ public:
         return key_;
     }
 
-    void key(const int32_t* key)
+    void key(const uint8_t* key)
     {
-        key_.delegate().value(const_cast<int32_t*>(key));
+        key_.delegate().value(const_cast<uint8_t*>(key));
     }
 
     const dds::topic::BuiltinTopicKey& participant_key() const
@@ -324,9 +324,9 @@ public:
         return participant_key_;
     }
 
-    void participant_key(const int32_t* key)
+    void participant_key(const uint8_t* key)
     {
-        participant_key_.delegate().value(const_cast<int32_t*>(key));
+        participant_key_.delegate().value(const_cast<uint8_t*>(key));
     }
 
     const std::string&                  topic_name() const
@@ -510,8 +510,8 @@ public:
 
         ddsc_endpoint_ = endpoint;
 
-        key((int32_t*)endpoint->key.v);
-        participant_key((int32_t*)endpoint->participant_key.v);
+        key(endpoint->key.v);
+        participant_key(endpoint->participant_key.v);
         topic_name(endpoint->topic_name);
         type_name(endpoint->type_name);
         durability(endpoint->qos);
@@ -604,9 +604,9 @@ public:
         return key_;
     }
 
-    void key(const int32_t* key)
+    void key(const uint8_t* key)
     {
-        key_.delegate().value(const_cast<int32_t*>(key));
+        key_.delegate().value(const_cast<uint8_t*>(key));
     }
 
     const dds::topic::BuiltinTopicKey& participant_key() const
@@ -614,9 +614,9 @@ public:
         return participant_key_;
     }
 
-    void participant_key(const int32_t* key)
+    void participant_key(const uint8_t* key)
     {
-        participant_key_.delegate().value(const_cast<int32_t*>(key));
+        participant_key_.delegate().value(const_cast<uint8_t*>(key));
     }
 
     const std::string&                  topic_name() const
@@ -822,9 +822,9 @@ public:
         return key_;
     }
 
-    void key(const int32_t* key)
+    void key(const uint8_t* key)
     {
-        key_.delegate().value(const_cast<int32_t*>(key));
+        key_.delegate().value(const_cast<uint8_t*>(key));
     }
 
     bool operator ==(const CMParticipantBuiltinTopicDataDelegate& other) const
@@ -848,9 +848,9 @@ public:
         return key_;
     }
 
-    void key(const int32_t* key)
+    void key(const uint8_t* key)
     {
-        key_.delegate().value(const_cast<int32_t*>(key));
+        key_.delegate().value(const_cast<uint8_t*>(key));
     }
 
     const dds::topic::BuiltinTopicKey&        participant_key() const
@@ -858,9 +858,9 @@ public:
         return participant_key_;
     }
 
-    void participant_key(const int32_t* key)
+    void participant_key(const uint8_t* key)
     {
-        participant_key_.delegate().value(const_cast<int32_t*>(key));
+        participant_key_.delegate().value(const_cast<uint8_t*>(key));
     }
 
     const std::string&                        name() const
@@ -922,9 +922,9 @@ public:
         return key_;
     }
 
-    void key(const int32_t* key)
+    void key(const uint8_t* key)
     {
-        key_.delegate().value(const_cast<int32_t*>(key));
+        key_.delegate().value(const_cast<uint8_t*>(key));
     }
 
     const dds::topic::BuiltinTopicKey&        participant_key() const
@@ -932,9 +932,9 @@ public:
         return participant_key_;
     }
 
-    void participant_key(const int32_t* key)
+    void participant_key(const uint8_t* key)
     {
-        participant_key_.delegate().value(const_cast<int32_t*>(key));
+        participant_key_.delegate().value(const_cast<uint8_t*>(key));
     }
 
     const std::string&                        name() const
@@ -998,7 +998,7 @@ public:
 
     void key(const dds_qos_t* key)
     {
-        key_.delegate().value(const_cast<int32_t*>(reinterpret_cast<const int32_t*>(key)));
+        key_.delegate().value(const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(key)));
     }
 
     const dds::topic::BuiltinTopicKey&              publisher_key() const
@@ -1008,7 +1008,7 @@ public:
 
     void publisher_key(const dds_qos_t* key)
     {
-        publisher_key_.delegate().value(const_cast<int32_t*>(reinterpret_cast<const int32_t*>(key)));
+        publisher_key_.delegate().value(const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(key)));
     }
 
     const std::string&                              name() const
@@ -1082,9 +1082,9 @@ public:
         return key_;
     }
 
-    void key(const int32_t* key)
+    void key(const uint8_t* key)
     {
-        key_.delegate().value(const_cast<int32_t*>(key));
+        key_.delegate().value(const_cast<uint8_t*>(key));
     }
 
     const dds::topic::BuiltinTopicKey&              subscriber_key() const
@@ -1092,9 +1092,9 @@ public:
         return subscriber_key_;
     }
 
-    void subscriber_key(const int32_t* key)
+    void subscriber_key(const uint8_t* key)
     {
-        subscriber_key_.delegate().value(const_cast<int32_t*>(key));
+        subscriber_key_.delegate().value(const_cast<uint8_t*>(key));
     }
 
     const std::string&                              name() const

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicDelegate.hpp
@@ -53,9 +53,9 @@ public:
         return key_;
     }
 
-    void key(const uint8_t* key)
+    void key(const std::array<uint8_t, 16>& key)
     {
-        key_.delegate().value(const_cast<uint8_t*>(key));
+        key_.delegate().value(key);
     }
 
     const ::dds::core::policy::UserData& user_data() const
@@ -86,9 +86,9 @@ public:
         return key_;
     }
 
-    void key(const uint8_t* key)
+    void key(const std::array<uint8_t, 16>& key)
     {
-        key_.delegate().value(const_cast<uint8_t*>(key));
+        key_.delegate().value(key);
     }
 
     const std::string&                  name() const
@@ -314,9 +314,9 @@ public:
         return key_;
     }
 
-    void key(const uint8_t* key)
+    void key(const std::array<uint8_t, 16>& key)
     {
-        key_.delegate().value(const_cast<uint8_t*>(key));
+        key_.delegate().value(key);
     }
 
     const dds::topic::BuiltinTopicKey& participant_key() const
@@ -324,9 +324,9 @@ public:
         return participant_key_;
     }
 
-    void participant_key(const uint8_t* key)
+    void participant_key(const std::array<uint8_t, 16>& key)
     {
-        participant_key_.delegate().value(const_cast<uint8_t*>(key));
+        participant_key_.delegate().value(key);
     }
 
     const std::string&                  topic_name() const
@@ -510,8 +510,8 @@ public:
 
         ddsc_endpoint_ = endpoint;
 
-        key(endpoint->key.v);
-        participant_key(endpoint->participant_key.v);
+        key_.delegate().set_ddsc_value(endpoint->key.v);
+        participant_key_.delegate().set_ddsc_value(endpoint->participant_key.v);
         topic_name(endpoint->topic_name);
         type_name(endpoint->type_name);
         durability(endpoint->qos);
@@ -604,9 +604,9 @@ public:
         return key_;
     }
 
-    void key(const uint8_t* key)
+    void key(const std::array<uint8_t, 16>& key)
     {
-        key_.delegate().value(const_cast<uint8_t*>(key));
+        key_.delegate().value(key);
     }
 
     const dds::topic::BuiltinTopicKey& participant_key() const
@@ -614,9 +614,9 @@ public:
         return participant_key_;
     }
 
-    void participant_key(const uint8_t* key)
+    void participant_key(const std::array<uint8_t, 16>& key)
     {
-        participant_key_.delegate().value(const_cast<uint8_t*>(key));
+        participant_key_.delegate().value(key);
     }
 
     const std::string&                  topic_name() const
@@ -822,9 +822,9 @@ public:
         return key_;
     }
 
-    void key(const uint8_t* key)
+    void key(const std::array<uint8_t, 16>& key)
     {
-        key_.delegate().value(const_cast<uint8_t*>(key));
+        key_.delegate().value(key);
     }
 
     bool operator ==(const CMParticipantBuiltinTopicDataDelegate& other) const
@@ -848,9 +848,9 @@ public:
         return key_;
     }
 
-    void key(const uint8_t* key)
+    void key(const std::array<uint8_t, 16>& key)
     {
-        key_.delegate().value(const_cast<uint8_t*>(key));
+        key_.delegate().value(key);
     }
 
     const dds::topic::BuiltinTopicKey&        participant_key() const
@@ -858,9 +858,9 @@ public:
         return participant_key_;
     }
 
-    void participant_key(const uint8_t* key)
+    void participant_key(const std::array<uint8_t, 16>& key)
     {
-        participant_key_.delegate().value(const_cast<uint8_t*>(key));
+        participant_key_.delegate().value(key);
     }
 
     const std::string&                        name() const
@@ -922,9 +922,9 @@ public:
         return key_;
     }
 
-    void key(const uint8_t* key)
+    void key(const std::array<uint8_t, 16>& key)
     {
-        key_.delegate().value(const_cast<uint8_t*>(key));
+        key_.delegate().value(key);
     }
 
     const dds::topic::BuiltinTopicKey&        participant_key() const
@@ -932,9 +932,9 @@ public:
         return participant_key_;
     }
 
-    void participant_key(const uint8_t* key)
+    void participant_key(const std::array<uint8_t, 16>& key)
     {
-        participant_key_.delegate().value(const_cast<uint8_t*>(key));
+        participant_key_.delegate().value(key);
     }
 
     const std::string&                        name() const
@@ -996,9 +996,9 @@ public:
         return key_;
     }
 
-    void key(const dds_qos_t* key)
+    void key(const std::array<uint8_t, 16>& key)
     {
-        key_.delegate().value(const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(key)));
+        key_.delegate().value(key);
     }
 
     const dds::topic::BuiltinTopicKey&              publisher_key() const
@@ -1006,9 +1006,9 @@ public:
         return publisher_key_;
     }
 
-    void publisher_key(const dds_qos_t* key)
+    void publisher_key(const std::array<uint8_t, 16>& key)
     {
-        publisher_key_.delegate().value(const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(key)));
+        publisher_key_.delegate().value(key);
     }
 
     const std::string&                              name() const
@@ -1082,9 +1082,9 @@ public:
         return key_;
     }
 
-    void key(const uint8_t* key)
+    void key(const std::array<uint8_t, 16>& key)
     {
-        key_.delegate().value(const_cast<uint8_t*>(key));
+        key_.delegate().value(key);
     }
 
     const dds::topic::BuiltinTopicKey&              subscriber_key() const
@@ -1092,9 +1092,9 @@ public:
         return subscriber_key_;
     }
 
-    void subscriber_key(const uint8_t* key)
+    void subscriber_key(const std::array<uint8_t, 16>& key)
     {
-        subscriber_key_.delegate().value(const_cast<uint8_t*>(key));
+        subscriber_key_.delegate().value(key);
     }
 
     const std::string&                              name() const

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicDelegate.hpp
@@ -301,6 +301,14 @@ class org::eclipse::cyclonedds::topic::PublicationBuiltinTopicDataDelegate
 public:
     PublicationBuiltinTopicDataDelegate() : ownership_strength_(0) { }
 
+    ~PublicationBuiltinTopicDataDelegate()
+    {
+        if (ddsc_endpoint_)
+        {
+            dds_builtintopic_free_endpoint(ddsc_endpoint_);
+        }
+    }
+
     const dds::topic::BuiltinTopicKey& key() const
     {
         return key_;
@@ -496,6 +504,36 @@ public:
         group_data_.delegate().set_iso_policy(policy);
     }
 
+    void set_ddsc_endpoint(dds_builtintopic_endpoint_t* endpoint)
+    {
+        assert(endpoint);
+
+        ddsc_endpoint_ = endpoint;
+
+        key((int32_t*)endpoint->key.v);
+        participant_key((int32_t*)endpoint->participant_key.v);
+        topic_name(endpoint->topic_name);
+        type_name(endpoint->type_name);
+        durability(endpoint->qos);
+#ifdef  OMG_DDS_PERSISTENCE_SUPPORT
+        // durability_service(endpoint->qos); // currently not supported in ddsc
+#endif
+        deadline(endpoint->qos);
+        latency_budget(endpoint->qos);
+        liveliness(endpoint->qos);
+        reliability(endpoint->qos);
+        lifespan(endpoint->qos);
+        user_data(endpoint->qos);
+        ownership(endpoint->qos);
+#ifdef  OMG_DDS_OWNERSHIP_SUPPORT
+        ownership_strength(endpoint->qos);
+#endif
+        destination_order(endpoint->qos);
+        partition(endpoint->qos);
+        presentation(endpoint->qos);
+        topic_data(endpoint->qos);
+        group_data(endpoint->qos);
+    }
 
     bool operator ==(const PublicationBuiltinTopicDataDelegate& other) const
     {
@@ -550,6 +588,8 @@ public:
     ::dds::core::policy::Partition          partition_;
     ::dds::core::policy::TopicData          topic_data_;
     ::dds::core::policy::GroupData          group_data_;
+
+    dds_builtintopic_endpoint_t* ddsc_endpoint_;
 };
 
 //==============================================================================

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicKeyDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicKeyDelegate.hpp
@@ -16,7 +16,9 @@
 #define CYCLONEDDS_TOPIC_BUILTIN_TOPIC_KEY_DELEGATE_HPP_
 
 #include <array>
+#include <algorithm>
 #include <iomanip>
+
 
 namespace org
 {

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicKeyDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicKeyDelegate.hpp
@@ -15,6 +15,8 @@
 #ifndef CYCLONEDDS_TOPIC_BUILTIN_TOPIC_KEY_DELEGATE_HPP_
 #define CYCLONEDDS_TOPIC_BUILTIN_TOPIC_KEY_DELEGATE_HPP_
 
+#include <iomanip>
+
 namespace org
 {
 namespace eclipse
@@ -27,37 +29,44 @@ namespace topic
 class BuiltinTopicKeyDelegate
 {
 public:
-    typedef uint32_t VALUE_T;
+    typedef uint8_t VALUE_T;
 public:
     BuiltinTopicKeyDelegate() { }
-    BuiltinTopicKeyDelegate(int32_t v[])
+    BuiltinTopicKeyDelegate(uint8_t v[16])
     {
-        key_[0] = v[0];
-        key_[1] = v[1];
-        key_[2] = v[2];
+        std::copy(v, v + 16, key_.begin());
     }
 public:
-    const int32_t* value() const
+    const uint8_t* value() const
     {
-        return key_;
+        return &key_[0];
     }
 
-    void value(int32_t v[])
+    void value(uint8_t v[16])
     {
-        key_[0] = v[0];
-        key_[1] = v[1];
-        key_[2] = v[2];
+        std::copy(v, v + 16, key_.begin());
     }
 
     bool operator ==(const BuiltinTopicKeyDelegate& other) const
     {
-        return other.key_[0] == key_[0]
-                 && other.key_[1] == key_[1]
-                 && other.key_[2] == key_[2];
+        return other.key_ == key_;
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, const BuiltinTopicKeyDelegate& key)
+    {
+        for (size_t i = 0; i < key.key_.size(); ++i)
+        {
+            if (i == 4 || i == 6 || i == 8 || i == 10)
+            {
+                os << '-';
+            }
+            os << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(key.key_[i]);
+        }
+        return os;
     }
 
 private:
-    int32_t key_[3];
+    std::array<uint8_t, 16> key_;
 };
 
 }

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicKeyDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicKeyDelegate.hpp
@@ -15,6 +15,7 @@
 #ifndef CYCLONEDDS_TOPIC_BUILTIN_TOPIC_KEY_DELEGATE_HPP_
 #define CYCLONEDDS_TOPIC_BUILTIN_TOPIC_KEY_DELEGATE_HPP_
 
+#include <array>
 #include <iomanip>
 
 namespace org

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicKeyDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicKeyDelegate.hpp
@@ -29,22 +29,22 @@ namespace topic
 class BuiltinTopicKeyDelegate
 {
 public:
-    typedef uint8_t VALUE_T;
+    typedef std::array<uint8_t, 16> VALUE_T;
 public:
     BuiltinTopicKeyDelegate() { }
-    BuiltinTopicKeyDelegate(uint8_t v[16])
+    BuiltinTopicKeyDelegate(const std::array<uint8_t, 16>& key)
     {
-        std::copy(v, v + 16, key_.begin());
+        key_ = key;
     }
 public:
-    const uint8_t* value() const
+    const std::array<uint8_t, 16>& value() const
     {
-        return &key_[0];
+        return key_;
     }
 
-    void value(uint8_t v[16])
+    void value(const std::array<uint8_t, 16>& key)
     {
-        std::copy(v, v + 16, key_.begin());
+        key_ = key;
     }
 
     bool operator ==(const BuiltinTopicKeyDelegate& other) const
@@ -63,6 +63,11 @@ public:
             os << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(key.key_[i]);
         }
         return os;
+    }
+
+    void set_ddsc_value(uint8_t v[16])
+    {
+        std::copy(v, v + 16, key_.begin());
     }
 
 private:

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
@@ -575,9 +575,19 @@ AnyDataReaderDelegate::matched_publications()
 const dds::topic::PublicationBuiltinTopicData
 AnyDataReaderDelegate::matched_publication_data(const ::dds::core::InstanceHandle& h)
 {
-    ISOCPP_THROW_EXCEPTION(ISOCPP_UNSUPPORTED_ERROR, "Function not currently supported");
     dds::topic::PublicationBuiltinTopicData dataSample;
-    (void)h;
+
+    dds_builtintopic_endpoint_t* endpoint = dds_get_matched_publication_data(ddsc_entity, h->handle());
+    if (endpoint)
+    {
+        dataSample.delegate().set_ddsc_endpoint(endpoint);
+    }
+    else
+    {
+        ISOCPP_THROW_EXCEPTION(ISOCPP_INVALID_ARGUMENT_ERROR,
+            "Failed to get matched publication data. The reader is not valid or ih is not an instance handle of a matched writer.");
+    }
+
     return dataSample;
 }
 


### PR DESCRIPTION
This pr implements `matched_publication_data` function and ostream operator for keys.
It also fixes the datatype for keys.

For example to get the partitions of the writer inside a wildcard-partition reader (`*`) callback.
```cpp
auto handle = sample_iter->info().publication_handle();
auto pub_data = dds::sub::matched_publication_data(reader, handle);
for (auto& n : pub_data.partition()->name()) {
    std::cout << "Partition: " << n << std::endl;
}
std::cout << "key: " << pub_data.key() << std::endl;
std::cout << "topic_name: " << pub_data.topic_name() << std::endl;
std::cout << "type_name: " << pub_data.type_name() << std::endl;
```
Output:
```
Partition: Hello
key: 01104b56-17d6-1860-43c8-032200000202
topic_name: HelloWorldData_Msg
type_name: HelloWorldData::Msg
```

@eboasson could you have a look?