### PR TITLE
fix potential invalid instance handle for matched_publications

### DIFF
--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/AnyDataReaderDelegate.cpp
@@ -581,8 +581,8 @@ AnyDataReaderDelegate::matched_publications()
         rc = dds_get_matched_publications(ddsc_entity, ddsc_instance_handles.data(), ddsc_instance_handles.size());
         ISOCPP_DDSC_RESULT_CHECK_AND_THROW(rc, "dds_get_matched_publications failed.");
 
-        for (const auto& handle : ddsc_instance_handles) {
-            handleSeq.push_back(::dds::core::InstanceHandle(handle));
+        for (size_t i = 0; i < static_cast<size_t>(rc); i++) {
+            handleSeq.push_back(::dds::core::InstanceHandle(ddsc_instance_handles[i]));
         }
     }
 


### PR DESCRIPTION
In the last PR i fixed it for `matched_subscriptions` but forgot `matched_publications` .. sorry, so here it is :)