### PR TITLE
remove ambiguous operator

### DIFF
--- a/src/ddscxx/include/dds/core/detail/TInstanceHandleImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/TInstanceHandleImpl.hpp
@@ -108,13 +108,6 @@ inline std::ostream& operator << (std::ostream& os, const dds::core::TInstanceHa
     return os;
 }
 
-//Overloaded operator << (workaround issues 252 and 162)
-inline std::ostream& operator << (std::ostream& os, const dds::core::TInstanceHandle<org::eclipse::cyclonedds::core::InstanceHandleDelegate> h)
-{
-     os << h.delegate();
-     return os;
-}
-
 // End of implementation
 
 #endif /* CYCLONEDDS_DDS_CORE_TINSTANCEHANDLE_IMPL_HPP_ */

--- a/src/ddscxx/tests/Condition.cpp
+++ b/src/ddscxx/tests/Condition.cpp
@@ -8,6 +8,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
+#include "Util.hpp"
 #include <gtest/gtest.h>
 
 #include "dds/dds.hpp"

--- a/src/ddscxx/tests/Conversions.cpp
+++ b/src/ddscxx/tests/Conversions.cpp
@@ -8,6 +8,8 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
+#include "Util.hpp"
+
 #include <gtest/gtest.h>
 
 #include "dds/dds.hpp"

--- a/src/ddscxx/tests/DataReader.cpp
+++ b/src/ddscxx/tests/DataReader.cpp
@@ -8,6 +8,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
+#include "Util.hpp"
 #include <gtest/gtest.h>
 
 #include "dds/dds.hpp"

--- a/src/ddscxx/tests/DataReaderManipulatorSelector.cpp
+++ b/src/ddscxx/tests/DataReaderManipulatorSelector.cpp
@@ -8,6 +8,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
+#include "Util.hpp"
 #include <gtest/gtest.h>
 
 #include "dds/dds.hpp"

--- a/src/ddscxx/tests/DataWriter.cpp
+++ b/src/ddscxx/tests/DataWriter.cpp
@@ -8,6 +8,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
+#include "Util.hpp"
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "Space.hpp"

--- a/src/ddscxx/tests/DomainParticipant.cpp
+++ b/src/ddscxx/tests/DomainParticipant.cpp
@@ -7,6 +7,7 @@
 // http://www.eclipse.org/org/documents/edl-v10.php.
 //
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
 #include "Util.hpp"
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>

--- a/src/ddscxx/tests/DomainParticipant.cpp
+++ b/src/ddscxx/tests/DomainParticipant.cpp
@@ -7,7 +7,7 @@
 // http://www.eclipse.org/org/documents/edl-v10.php.
 //
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
-
+#include "Util.hpp"
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "dds/ddsrt/environ.h"

--- a/src/ddscxx/tests/FindDataReader.cpp
+++ b/src/ddscxx/tests/FindDataReader.cpp
@@ -8,6 +8,8 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
+#include "Util.hpp"
+
 #include <iostream>
 #include <gtest/gtest.h>
 

--- a/src/ddscxx/tests/FindDataWriter.cpp
+++ b/src/ddscxx/tests/FindDataWriter.cpp
@@ -8,6 +8,8 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
+#include "Util.hpp"
+
 #include <iostream>
 #include <gtest/gtest.h>
 

--- a/src/ddscxx/tests/FindTopic.cpp
+++ b/src/ddscxx/tests/FindTopic.cpp
@@ -8,6 +8,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
+#include "Util.hpp"
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "Space.hpp"

--- a/src/ddscxx/tests/ListenerStress.cpp
+++ b/src/ddscxx/tests/ListenerStress.cpp
@@ -11,6 +11,8 @@
 #include <chrono>
 #include <thread>
 
+#include "Util.hpp"
+
 #include "dds/dds.hpp"
 #include "dds/ddsrt/sync.h"
 #include "dds/ddsrt/threads.h"

--- a/src/ddscxx/tests/Publisher.cpp
+++ b/src/ddscxx/tests/Publisher.cpp
@@ -8,6 +8,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
+#include "Util.hpp"
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "HelloWorldData.hpp"

--- a/src/ddscxx/tests/Qos.cpp
+++ b/src/ddscxx/tests/Qos.cpp
@@ -8,6 +8,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
+#include "Util.hpp"
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 

--- a/src/ddscxx/tests/Query.cpp
+++ b/src/ddscxx/tests/Query.cpp
@@ -8,6 +8,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
+#include "Util.hpp"
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "Space.hpp"

--- a/src/ddscxx/tests/Regression.cpp
+++ b/src/ddscxx/tests/Regression.cpp
@@ -8,6 +8,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
+#include "Util.hpp"
 #include "dds/ddsrt/misc.h"
 
 DDSRT_WARNING_GNUC_OFF(maybe-uninitialized)

--- a/src/ddscxx/tests/Subscriber.cpp
+++ b/src/ddscxx/tests/Subscriber.cpp
@@ -8,6 +8,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
+#include "Util.hpp"
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "HelloWorldData.hpp"

--- a/src/ddscxx/tests/Topic.cpp
+++ b/src/ddscxx/tests/Topic.cpp
@@ -8,6 +8,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
+#include "Util.hpp"
 #include "dds/dds.hpp"
 #include <gtest/gtest.h>
 #include "Space.hpp"

--- a/src/ddscxx/tests/Util.hpp
+++ b/src/ddscxx/tests/Util.hpp
@@ -11,10 +11,21 @@
 #ifndef _TEST_UTIL_H
 #define _TEST_UTIL_H
 
+#include "dds/dds.hpp"
+
 #include <stdint.h>
 #include <stddef.h>
 
 /* Get unique g_topic name on each invocation. */
 char *create_unique_topic_name (const char *prefix, char *name, size_t size);
+
+/* I have no idea why gcc-10 and gcc-11 fail if this overload isn't available in the tests */
+#if defined __GNUC__ && __GNUC__ < 12
+inline std::ostream& operator << (std::ostream& os, const dds::core::TInstanceHandle<org::eclipse::cyclonedds::core::InstanceHandleDelegate> h)
+{
+  os << h.delegate();
+  return os;
+}
+#endif
 
 #endif /* _TEST_UTIL_H */


### PR DESCRIPTION
This PR removes a ambiguous operator.

It solves the following situation.
```cpp
dds::core::InstanceHandle handle = domainParticipant.instance_handle();
std::ostringstream s;
s << handle;
```
Error:
```
error C2593: 'operator <<' is ambiguous 
D:\conan\short\f72057\1\include\ddscxx\dds/core/detail/TInstanceHandleImpl.hpp(105,22): message : could be 'std::ostream &operator <<( 
std::ostream &,const dds::core::TInstanceHandle<org::eclipse::cyclonedds::core::InstanceHandleDelegate> &)' [found using argument-depe 
ndent lookup]
D:\conan\short\f72057\1\include\ddscxx\dds/core/detail/TInstanceHandleImpl.hpp(112,22): message : or       'std::ostream &operator <<( 
std::ostream &,const dds::core::TInstanceHandle<org::eclipse::cyclonedds::core::InstanceHandleDelegate>)' [found using argument-depend 
ent lookup]
 message : while trying to match the argument list '(std::ostringstream, dds::core::InstanceHandle)'
```