### PR TITLE
bugfix/swig-syntax-error

### DIFF
--- a/src/idlcxx/src/traits.c
+++ b/src/idlcxx/src/traits.c
@@ -203,7 +203,7 @@ emit_register_topic_type(
 {
   struct generator *gen = user_data;
   char *name = NULL;
-  static const char *fmt = "REGISTER_TOPIC_TYPE(%s)\n";
+  static const char *fmt = "REGISTER_TOPIC_TYPE(%s);\n";
 
   (void)pstate;
   (void)revisit;


### PR DESCRIPTION
This PR solves a syntax error in swig when trying to create a java or csharp wrapper from the generated code.
```
$ swig -c++ -csharp -module HelloWorld  HelloWorldData.hpp
HelloWorldData.hpp:136: Error: Syntax error in input(1).
```
HelloWorldData.hpp:136: 
```c++
// ...
REGISTER_TOPIC_TYPE(::HelloWorldData::Msg) // missing ";"
// ...
```

To fix this we just need to add a semicolon at the end - which is also more cpp style.
```c++
// ...
REGISTER_TOPIC_TYPE(::HelloWorldData::Msg);
// ...
```

@eboasson could you have a look?