### PR TITLE
`fix:` restrict init/access scope of QosProvider.

### DIFF
--- a/src/ddscxx/include/dds/core/TQosProvider.hpp
+++ b/src/ddscxx/include/dds/core/TQosProvider.hpp
@@ -73,17 +73,41 @@ public:
      *                  ‘file’ scheme that point to an XML file are supported. If profiles and/or QoS
      *                  settings are not uniquely identifiable by name within the resource pointed to by
      *                  uri, a random one of them will be stored.
-     * @param profile   The name of the QoS profile (include parent library name) within the xml file that serves as the default QoS
+     * @param profile   The name of the QoS profile within the xml file that serves as the default QoS
      *                  profile for the get qos operations.
      * @throws dds::core::Error
      *                  An internal error has occurred.
      * @throws dds::core::PreconditionNotMetError
      *                  When multiple thread try to invoke the function concurrently.
-     *                  When provided profile identifier is invalid.
-     * @throws dds::core::UnsupportedError
-     *                  When provided profile name is empty.
      */
     explicit TQosProvider(const std::string& uri, const std::string& profile);
+
+    /**
+     * Constructs a new QosProvider based on the provided uri.
+     *
+     * A QosProvider instance that is instantiated with all profiles and/or QoS’s loaded
+     * from the location specified by the provided uri.
+     *
+     * Initialization of the QosProvider will fail under the following conditions:<br>
+     * - No uri is provided.
+     * - The resource pointed to by uri cannot be found.
+     * - The content of the resource pointed to by uri is malformed (e.g., malformed XML).
+     * When initialization fails (for example, due to a parse error or when the resource
+     * identified by uri cannot be found), then PreconditionNotMetError will be thrown.
+     *
+     * Look @ref DCPS_QoS_Provider "here" for more information.
+     *
+     * @param uri       A Uniform Resource Identifier (URI) that points to the location
+     *                  where the QoS profile needs to be loaded from. Currently only URI’s with a
+     *                  ‘file’ scheme that point to an XML file are supported. If profiles and/or QoS
+     *                  settings are not uniquely identifiable by name within the resource pointed to by
+     *                  uri, a random one of them will be stored.
+     * @throws dds::core::Error
+     *                  An internal error has occurred.
+     * @throws dds::core::PreconditionNotMetError
+     *                  When multiple thread try to invoke the function concurrently.
+     */
+    explicit TQosProvider(const std::string& uri);
 
     /**
      * Resolves the DomainParticipantQos from the uri this QosProvider is associated with.

--- a/src/ddscxx/include/dds/core/TQosProvider.hpp
+++ b/src/ddscxx/include/dds/core/TQosProvider.hpp
@@ -73,41 +73,17 @@ public:
      *                  ‘file’ scheme that point to an XML file are supported. If profiles and/or QoS
      *                  settings are not uniquely identifiable by name within the resource pointed to by
      *                  uri, a random one of them will be stored.
-     * @param profile   The name of the QoS profile within the xml file that serves as the default QoS
+     * @param profile   The name of the QoS profile (include parent library name) within the xml file that serves as the default QoS
      *                  profile for the get qos operations.
      * @throws dds::core::Error
      *                  An internal error has occurred.
      * @throws dds::core::PreconditionNotMetError
      *                  When multiple thread try to invoke the function concurrently.
+     *                  When provided profile identifier is invalid.
+     * @throws dds::core::UnsupportedError
+     *                  When provided profile name is empty.
      */
     explicit TQosProvider(const std::string& uri, const std::string& profile);
-
-    /**
-     * Constructs a new QosProvider based on the provided uri.
-     *
-     * A QosProvider instance that is instantiated with all profiles and/or QoS’s loaded
-     * from the location specified by the provided uri.
-     *
-     * Initialization of the QosProvider will fail under the following conditions:<br>
-     * - No uri is provided.
-     * - The resource pointed to by uri cannot be found.
-     * - The content of the resource pointed to by uri is malformed (e.g., malformed XML).
-     * When initialization fails (for example, due to a parse error or when the resource
-     * identified by uri cannot be found), then PreconditionNotMetError will be thrown.
-     *
-     * Look @ref DCPS_QoS_Provider "here" for more information.
-     *
-     * @param uri       A Uniform Resource Identifier (URI) that points to the location
-     *                  where the QoS profile needs to be loaded from. Currently only URI’s with a
-     *                  ‘file’ scheme that point to an XML file are supported. If profiles and/or QoS
-     *                  settings are not uniquely identifiable by name within the resource pointed to by
-     *                  uri, a random one of them will be stored.
-     * @throws dds::core::Error
-     *                  An internal error has occurred.
-     * @throws dds::core::PreconditionNotMetError
-     *                  When multiple thread try to invoke the function concurrently.
-     */
-    explicit TQosProvider(const std::string& uri);
 
     /**
      * Resolves the DomainParticipantQos from the uri this QosProvider is associated with.

--- a/src/ddscxx/include/dds/core/detail/TQosProviderImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/TQosProviderImpl.hpp
@@ -38,7 +38,7 @@ template <typename DELEGATE>
 dds::domain::qos::DomainParticipantQos
 TQosProvider<DELEGATE>::participant_qos()
 {
-    return this->delegate()->participant_qos(NULL);
+    return this->delegate()->participant_qos();
 }
 
 template <typename DELEGATE>
@@ -52,7 +52,7 @@ template <typename DELEGATE>
 dds::topic::qos::TopicQos
 TQosProvider<DELEGATE>::topic_qos()
 {
-    return this->delegate()->topic_qos(NULL);
+    return this->delegate()->topic_qos();
 }
 
 template <typename DELEGATE>
@@ -67,7 +67,7 @@ template <typename DELEGATE>
 dds::sub::qos::SubscriberQos
 TQosProvider<DELEGATE>::subscriber_qos()
 {
-    return this->delegate()->subscriber_qos(NULL);
+    return this->delegate()->subscriber_qos();
 }
 
 template <typename DELEGATE>
@@ -81,7 +81,7 @@ template <typename DELEGATE>
 dds::sub::qos::DataReaderQos
 TQosProvider<DELEGATE>::datareader_qos()
 {
-    return this->delegate()->datareader_qos(NULL);
+    return this->delegate()->datareader_qos();
 }
 
 template <typename DELEGATE>
@@ -95,7 +95,7 @@ template <typename DELEGATE>
 dds::pub::qos::PublisherQos
 TQosProvider<DELEGATE>::publisher_qos()
 {
-    return this->delegate()->publisher_qos(NULL);
+    return this->delegate()->publisher_qos();
 }
 
 template <typename DELEGATE>
@@ -109,7 +109,7 @@ template <typename DELEGATE>
 dds::pub::qos::DataWriterQos
 TQosProvider<DELEGATE>::datawriter_qos()
 {
-    return this->delegate()->datawriter_qos(NULL);
+    return this->delegate()->datawriter_qos();
 }
 
 template <typename DELEGATE>

--- a/src/ddscxx/include/dds/core/detail/TQosProviderImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/TQosProviderImpl.hpp
@@ -31,10 +31,6 @@ TQosProvider<DELEGATE>::TQosProvider(const std::string& uri, const std::string& 
     : Reference<DELEGATE>(new DELEGATE(uri, profile)) { }
 
 template <typename DELEGATE>
-TQosProvider<DELEGATE>::TQosProvider(const std::string& uri)
-    : Reference<DELEGATE>(new DELEGATE(uri)) { }
-
-template <typename DELEGATE>
 dds::domain::qos::DomainParticipantQos
 TQosProvider<DELEGATE>::participant_qos()
 {

--- a/src/ddscxx/include/dds/core/detail/TQosProviderImpl.hpp
+++ b/src/ddscxx/include/dds/core/detail/TQosProviderImpl.hpp
@@ -31,6 +31,10 @@ TQosProvider<DELEGATE>::TQosProvider(const std::string& uri, const std::string& 
     : Reference<DELEGATE>(new DELEGATE(uri, profile)) { }
 
 template <typename DELEGATE>
+TQosProvider<DELEGATE>::TQosProvider(const std::string& uri)
+    : Reference<DELEGATE>(new DELEGATE(uri)) { }
+
+template <typename DELEGATE>
 dds::domain::qos::DomainParticipantQos
 TQosProvider<DELEGATE>::participant_qos()
 {

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/QosProviderDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/QosProviderDelegate.hpp
@@ -64,7 +64,10 @@ public:
     datawriter_qos(const std::string& id = "");
 
 private:
+    bool is_valid_scope(const std::string& scope, const size_t count, const bool strict);
+
     dds_qos_provider *qosProvider;
+    std::string access_scope;
 };
 
 #endif /* CYCLONEDDS_CORE_QOSPROVIDERDELEGATE_HPP_ */

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/QosProviderDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/QosProviderDelegate.hpp
@@ -41,7 +41,7 @@ struct dds_qos_provider;
 class OMG_DDS_API org::eclipse::cyclonedds::core::QosProviderDelegate
 {
 public:
-    QosProviderDelegate(const std::string& uri, const std::string& id = "");
+    QosProviderDelegate(const std::string& uri, const std::string& id);
 
     ~QosProviderDelegate();
 
@@ -65,6 +65,7 @@ public:
 
 private:
     bool is_valid_scope(const std::string& scope, const size_t count, const bool strict);
+    std::string get_endpoint_access_scope(const std::string& id);
 
     dds_qos_provider *qosProvider;
     std::string access_scope;

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/QosProviderDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/QosProviderDelegate.hpp
@@ -41,7 +41,7 @@ struct dds_qos_provider;
 class OMG_DDS_API org::eclipse::cyclonedds::core::QosProviderDelegate
 {
 public:
-    QosProviderDelegate(const std::string& uri, const std::string& id);
+    QosProviderDelegate(const std::string& uri, const std::string& id = "");
 
     ~QosProviderDelegate();
 
@@ -65,7 +65,7 @@ public:
 
 private:
     bool is_valid_scope(const std::string& scope, const size_t count, const bool strict);
-    std::string get_endpoint_access_scope(const std::string& id);
+    std::string get_entity_scope(const std::string& id);
 
     dds_qos_provider *qosProvider;
     std::string access_scope;

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/QosProviderDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/QosProviderDelegate.cpp
@@ -47,7 +47,7 @@ bool QosProviderDelegate::is_valid_scope(const std::string& scope, const size_t 
   return true;
 }
 
-std::string QosProviderDelegate::get_endpoint_access_scope(const std::string& id)
+std::string QosProviderDelegate::get_entity_scope(const std::string& id)
 {
     dds_return_t ret = DDS_RETCODE_PRECONDITION_NOT_MET;
     std::string scope = id;
@@ -65,12 +65,12 @@ std::string QosProviderDelegate::get_endpoint_access_scope(const std::string& id
 
 QosProviderDelegate::QosProviderDelegate(const std::string& uri, const std::string& id) : qosProvider(nullptr)
 {
-    dds_return_t ret = DDS_RETCODE_PRECONDITION_NOT_MET;
+    dds_return_t ret;
     if (id.empty()) {
       ISOCPP_THROW_EXCEPTION(DDS_RETCODE_UNSUPPORTED, "Unable to create QosProvider without library/profile.");
     }
     if (!is_valid_scope(id, 2U, true)) {
-      ISOCPP_THROW_EXCEPTION(ret, "Unable to create QosProvider with provided library/profile.");
+      ISOCPP_THROW_EXCEPTION(DDS_RETCODE_PRECONDITION_NOT_MET, "Unable to create QosProvider with provided library/profile.");
     }
 
     access_scope = id;
@@ -88,8 +88,8 @@ QosProviderDelegate::participant_qos(const std::string &id)
 {
     dds::domain::qos::DomainParticipantQos dpq;
     const dds_qos_t *c_dpq = NULL;
-    dds_return_t ret = DDS_RETCODE_PRECONDITION_NOT_MET;
-    std::string scope = get_endpoint_access_scope(id);
+    dds_return_t ret;
+    std::string scope = get_entity_scope(id);
 
     ret = dds_qos_provider_get_qos(qosProvider, DDS_PARTICIPANT_QOS, scope.c_str(), &c_dpq);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ret, "Unable to obtain requested participant QoS.");
@@ -104,8 +104,8 @@ QosProviderDelegate::topic_qos(const std::string &id)
 {
     dds::topic::qos::TopicQos tq;
     const dds_qos_t *c_tq = NULL;
-    dds_return_t ret = DDS_RETCODE_PRECONDITION_NOT_MET;
-    std::string scope = get_endpoint_access_scope(id);
+    dds_return_t ret;
+    std::string scope = get_entity_scope(id);
 
     ret = dds_qos_provider_get_qos(qosProvider, DDS_TOPIC_QOS, scope.c_str(), &c_tq);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ret, "Unable to obtain requested topic QoS.");
@@ -121,8 +121,8 @@ QosProviderDelegate::subscriber_qos(const std::string &id)
 {
     dds::sub::qos::SubscriberQos sq;
     const dds_qos_t *c_sq = NULL;
-    dds_return_t ret = DDS_RETCODE_PRECONDITION_NOT_MET;
-    std::string scope = get_endpoint_access_scope(id);
+    dds_return_t ret;
+    std::string scope = get_entity_scope(id);
 
     ret = dds_qos_provider_get_qos(qosProvider, DDS_SUBSCRIBER_QOS, scope.c_str(), &c_sq);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ret, "Unable to obtain requested subscriber QoS.");
@@ -137,8 +137,8 @@ QosProviderDelegate::datareader_qos(const std::string &id)
 {
     dds::sub::qos::DataReaderQos drq;
     const dds_qos_t *c_drq = NULL;
-    dds_return_t ret = DDS_RETCODE_PRECONDITION_NOT_MET;
-    std::string scope = get_endpoint_access_scope(id);
+    dds_return_t ret;
+    std::string scope = get_entity_scope(id);
 
     ret = dds_qos_provider_get_qos(qosProvider, DDS_READER_QOS, scope.c_str(), &c_drq);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ret, "Unable to obtain requested datareader QoS.");
@@ -153,8 +153,8 @@ QosProviderDelegate::publisher_qos(const std::string &id)
 {
     dds::pub::qos::PublisherQos pq;
     const dds_qos_t *c_pq = NULL;
-    dds_return_t ret = DDS_RETCODE_PRECONDITION_NOT_MET;
-    std::string scope = get_endpoint_access_scope(id);
+    dds_return_t ret;
+    std::string scope = get_entity_scope(id);
 
     ret = dds_qos_provider_get_qos(qosProvider, DDS_PUBLISHER_QOS, scope.c_str(), &c_pq);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ret, "Unable to obtain requested publisher QoS.");
@@ -169,8 +169,8 @@ QosProviderDelegate::datawriter_qos(const std::string &id)
 {
     dds::pub::qos::DataWriterQos dwq;
     const dds_qos_t *c_dwq = NULL;
-    dds_return_t ret = DDS_RETCODE_PRECONDITION_NOT_MET;
-    std::string scope = get_endpoint_access_scope(id);
+    dds_return_t ret;
+    std::string scope = get_entity_scope(id);
 
     ret = dds_qos_provider_get_qos(qosProvider, DDS_WRITER_QOS, scope.c_str(), &c_dwq);
     ISOCPP_DDSC_RESULT_CHECK_AND_THROW(ret, "Unable to obtain requested datawriter QoS.");

--- a/src/ddscxx/tests/QosProvider.cpp
+++ b/src/ddscxx/tests/QosProvider.cpp
@@ -946,59 +946,48 @@ static uint32_t b64_encode (const unsigned char *text, const uint32_t sz, unsign
         {
         case DDS_PARTICIPANT_QOS:
         {
-            dds::domain::qos::DomainParticipantQos qpQos0 = qp.participant_qos("lib1::pro00");
             dds::domain::qos::DomainParticipantQos qpQos1 = qp.participant_qos("");
             dds::domain::qos::DomainParticipantQos qpQos2 = qp.participant_qos();
-            ASSERT_TRUE(pQos == qpQos0);
             ASSERT_TRUE(pQos == qpQos1);
             ASSERT_TRUE(pQos == qpQos2);
             break;
         }
         case DDS_PUBLISHER_QOS:
         {
-            dds::pub::qos::PublisherQos qpQos0 = qp.publisher_qos("lib1::pro00");
             dds::pub::qos::PublisherQos qpQos1 = qp.publisher_qos("");
             dds::pub::qos::PublisherQos qpQos2 = qp.publisher_qos();
-            ASSERT_TRUE(pubQos == qpQos0);
             ASSERT_TRUE(pubQos == qpQos1);
             ASSERT_TRUE(pubQos == qpQos2);
             break;
         }
         case DDS_SUBSCRIBER_QOS:
         {
-            dds::sub::qos::SubscriberQos qpQos0 = qp.subscriber_qos("lib1::pro00");
             dds::sub::qos::SubscriberQos qpQos1 = qp.subscriber_qos("");
             dds::sub::qos::SubscriberQos qpQos2 = qp.subscriber_qos();
-            ASSERT_TRUE(subQos == qpQos0);
             ASSERT_TRUE(subQos == qpQos1);
+            ASSERT_TRUE(subQos == qpQos2);
             break;
         }
         case DDS_TOPIC_QOS:
         {
-            dds::topic::qos::TopicQos qpQos0 = qp.topic_qos("lib1::pro00");
             dds::topic::qos::TopicQos qpQos1 = qp.topic_qos("");
             dds::topic::qos::TopicQos qpQos2 = qp.topic_qos();
-            ASSERT_TRUE(tQos == qpQos0);
             ASSERT_TRUE(tQos == qpQos1);
             ASSERT_TRUE(tQos == qpQos2);
             break;
         }
         case DDS_READER_QOS:
         {
-            dds::sub::qos::DataReaderQos qpQos0 = qp.datareader_qos("lib1::pro00");
             dds::sub::qos::DataReaderQos qpQos1 = qp.datareader_qos("");
             dds::sub::qos::DataReaderQos qpQos2 = qp.datareader_qos();
-            ASSERT_TRUE(rQos == qpQos0);
             ASSERT_TRUE(rQos == qpQos1);
             ASSERT_TRUE(rQos == qpQos2);
             break;
         }
         case DDS_WRITER_QOS:
         {
-            dds::pub::qos::DataWriterQos qpQos0 = qp.datawriter_qos("lib1::pro00");
             dds::pub::qos::DataWriterQos qpQos1 = qp.datawriter_qos("");
             dds::pub::qos::DataWriterQos qpQos2 = qp.datawriter_qos();
-            ASSERT_TRUE(wQos == qpQos0);
             ASSERT_TRUE(wQos == qpQos1);
             ASSERT_TRUE(wQos == qpQos2);
             break;
@@ -1117,7 +1106,7 @@ TEST_F(QosProvider, invalid_access_scope)
     ASSERT_EQ(result, DDS_RETCODE_ERROR);
   }
 
-  /* validate one success case the was not handled previously */
+  /* validate one success case that was not handled previously */
   dds::domain::qos::DomainParticipantQos pQos = qp.participant_qos("pp00");
   ASSERT_TRUE (this->pQos == pQos);
 

--- a/src/ddscxx/tests/QosProvider.cpp
+++ b/src/ddscxx/tests/QosProvider.cpp
@@ -772,7 +772,7 @@ static uint32_t b64_encode (const unsigned char *text, const uint32_t sz, unsign
 #undef QOS_FORMAT
 
     static dds_return_t 
-    get_single_configuration(dds_qos_t *qos, sysdef_qos_conf_t *conf, dds_qos_kind_t kind, char **out_conf, uint64_t *validate_mask)
+    get_single_configuration(dds_qos_t *qos, sysdef_qos_conf_t *conf, dds_qos_kind_t kind, const char *name, char **out_conf, uint64_t *validate_mask)
     {
       dds_return_t ret = DDS_RETCODE_OK;
       char *qos_conf = NULL;
@@ -783,168 +783,224 @@ static uint32_t b64_encode (const unsigned char *text, const uint32_t sz, unsign
         switch(kind)
         {
           case DDS_PARTICIPANT_QOS:
-            def = DEF(LIB(lib1,PRO(pro00,ENT("%s",domain_participant))));
+            if (name != NULL) def = DEF(LIB(lib1,PRO(pro00,ENT_N(%s,"%s",domainparticipant))));
+            else def = DEF(LIB(lib1,PRO(pro00,ENT("%s",domain_participant))));
             break;
           case DDS_PUBLISHER_QOS:
-            def = DEF(LIB(lib1,PRO(pro00,ENT("%s",publisher))));
+            if (name != NULL) def = DEF(LIB(lib1,PRO(pro00,ENT_N(%s,"%s",publisher))));
+            else def = DEF(LIB(lib1,PRO(pro00,ENT("%s",publisher))));
             break;
           case DDS_SUBSCRIBER_QOS:
-            def = DEF(LIB(lib1,PRO(pro00,ENT("%s",subscriber))));
+            if (name != NULL) def = DEF(LIB(lib1,PRO(pro00,ENT_N(%s,"%s",subscriber))));
+            else def = DEF(LIB(lib1,PRO(pro00,ENT("%s",subscriber))));
             break;
           case DDS_TOPIC_QOS:
-            def = DEF(LIB(lib1,PRO(pro00,ENT("%s",topic))));
+            if (name != NULL) def = DEF(LIB(lib1,PRO(pro00,ENT_N(%s,"%s",topic))));
+            else def = DEF(LIB(lib1,PRO(pro00,ENT("%s",topic))));
             break;
           case DDS_READER_QOS:
-            def = DEF(LIB(lib1,PRO(pro00,ENT("%s",datareader))));
+            if (name != NULL) def = DEF(LIB(lib1,PRO(pro00,ENT_N(%s,"%s",datareader))));
+            else def = DEF(LIB(lib1,PRO(pro00,ENT("%s",datareader))));
             break;
           case DDS_WRITER_QOS:
-            def = DEF(LIB(lib1,PRO(pro00,ENT("%s",datawriter))));
+            if (name != NULL) def = DEF(LIB(lib1,PRO(pro00,ENT_N(%s,"%s",datawriter))));
+            else def = DEF(LIB(lib1,PRO(pro00,ENT("%s",datawriter))));
             break;
           default:
             ddsrt_free(qos_conf);
             return DDS_RETCODE_ERROR;
         }
-        ret = ddsrt_asprintf(out_conf, def, qos_conf);
+
+        if (name != NULL) ret = ddsrt_asprintf(out_conf, def, name, qos_conf);
+        else ret = ddsrt_asprintf(out_conf, def, qos_conf);
         ddsrt_free(qos_conf);
       }
 
       return ret;
     }
 
+    static dds_qos_t *get_gen_qos(const dds_qos_kind_t kind, QosProvider *qp)
+    {
+      dds::domain::DomainParticipant dp(org::eclipse::cyclonedds::domain::default_id());
+      dds::pub::Publisher pub(dp);
+      dds::sub::Subscriber sub(dp);
+      dds_qos_t *qos = NULL;
+      dds::core::ByteSeq bs;
+      dds::core::StringSeq pList;
+
+      for (unsigned char c = 'a'; c <= 'd'; c++) bs.push_back(c);
+      pList.push_back("abcd");
+      pList.push_back("efgh");
+      pList.push_back("ijkl");
+      switch(kind)
+      {
+      case DDS_PARTICIPANT_QOS:
+      {
+        dds::domain::qos::DomainParticipantQos p_Qos = dds::domain::DomainParticipant::default_participant_qos()
+            << dds::core::policy::UserData(bs)
+            << dds::core::policy::EntityFactory::AutoEnable();
+        if (qp) qp->pQos = p_Qos;
+        qos = p_Qos.delegate().ddsc_qos();
+        break;
+      }
+      case DDS_PUBLISHER_QOS:
+      {
+          dds::pub::qos::PublisherQos pub_Qos = dp.default_publisher_qos()
+              << dds::core::policy::GroupData(bs)
+              << dds::core::policy::Partition(pList)
+              << dds::core::policy::Presentation::InstanceAccessScope(false, false)
+              << dds::core::policy::EntityFactory::AutoEnable();
+          if (qp) qp->pubQos = pub_Qos;
+          qos = pub_Qos.delegate().ddsc_qos();
+          break;
+      }
+      case DDS_SUBSCRIBER_QOS:
+      {
+          dds::sub::qos::SubscriberQos sub_Qos = dp.default_subscriber_qos()
+              << dds::core::policy::GroupData(bs)
+              << dds::core::policy::Partition(pList)
+              << dds::core::policy::Presentation::InstanceAccessScope(false, false)
+              << dds::core::policy::EntityFactory::AutoEnable();
+          if (qp) qp->subQos = sub_Qos;
+          qos = sub_Qos.delegate().ddsc_qos();
+          break;
+      }
+      case DDS_TOPIC_QOS:
+      {
+          dds::topic::qos::TopicQos t_Qos = dp.default_topic_qos()
+              << dds::core::policy::TopicData(bs)
+              << dds::core::policy::Durability::Volatile()
+              << dds::core::policy::Deadline(dds::core::Duration(1,0))
+              << dds::core::policy::LatencyBudget(dds::core::Duration(1,0))
+              << dds::core::policy::Ownership::Exclusive()
+              << dds::core::policy::Liveliness::Automatic(dds::core::Duration::infinite())
+              << dds::core::policy::Reliability::Reliable(dds::core::Duration(1, 0))
+              << dds::core::policy::TransportPriority(1000)
+              << dds::core::policy::Lifespan(dds::core::Duration(1, 0))
+              << dds::core::policy::DestinationOrder::SourceTimestamp()
+              << dds::core::policy::History::KeepLast(1)
+              << dds::core::policy::ResourceLimits(1, 1, 1)
+              << dds::core::policy::DurabilityService(dds::core::Duration(1, 0), dds::core::policy::HistoryKind::KEEP_ALL, -1, 1, 1, 1);
+          if (qp) qp->tQos = t_Qos;
+          qos = t_Qos.delegate().ddsc_qos();
+          break;
+      }
+      case DDS_READER_QOS:
+      {
+          dds::sub::qos::DataReaderQos r_Qos = sub.default_datareader_qos()
+              << dds::core::policy::UserData(bs)
+              << dds::core::policy::Durability::Volatile()
+              << dds::core::policy::Deadline(dds::core::Duration(1,0))
+              << dds::core::policy::LatencyBudget(dds::core::Duration(1,0))
+              << dds::core::policy::Ownership::Exclusive()
+              << dds::core::policy::Liveliness::Automatic(dds::core::Duration::infinite())
+              << dds::core::policy::Reliability::Reliable(dds::core::Duration(1, 0))
+              << dds::core::policy::DestinationOrder::SourceTimestamp()
+              << dds::core::policy::History::KeepLast(1)
+              << dds::core::policy::ResourceLimits(1, 1, 1)
+              << dds::core::policy::TimeBasedFilter(dds::core::Duration(1, 0))
+              << dds::core::policy::ReaderDataLifecycle(dds::core::Duration(1,0), dds::core::Duration(1,0));
+          if (qp) qp->rQos = r_Qos;
+          qos = r_Qos.delegate().ddsc_qos();
+          break;
+      }
+      case DDS_WRITER_QOS:
+      {
+          dds::pub::qos::DataWriterQos w_Qos = pub.default_datawriter_qos()
+              << dds::core::policy::UserData(bs)
+              << dds::core::policy::Durability::Volatile()
+              << dds::core::policy::Deadline(dds::core::Duration(1,0))
+              << dds::core::policy::LatencyBudget(dds::core::Duration(1,0))
+              << dds::core::policy::Ownership::Exclusive()
+              << dds::core::policy::OwnershipStrength(100)
+              << dds::core::policy::Liveliness::Automatic(dds::core::Duration::infinite())
+              << dds::core::policy::Reliability::Reliable(dds::core::Duration(1, 0))
+              << dds::core::policy::DestinationOrder::SourceTimestamp()
+              << dds::core::policy::History::KeepLast(1)
+              << dds::core::policy::ResourceLimits(1, 1, 1)
+              << dds::core::policy::WriterDataLifecycle::AutoDisposeUnregisteredInstances();
+          if (qp) qp->wQos = w_Qos;
+          qos = w_Qos.delegate().ddsc_qos();
+          break;
+      }
+      default:
+          assert(0);
+          break;
+      }
+
+      return qos;
+    }
+
 
     void doTest(dds_qos_kind_t kind)
     {
-        dds::domain::DomainParticipant dp(org::eclipse::cyclonedds::domain::default_id());
-        dds::pub::Publisher pub(dp);
-        dds::sub::Subscriber sub(dp);
-        dds_qos_t *qos = NULL;
-        dds::core::ByteSeq bs;
-        dds::core::StringSeq pList;
-        dds_return_t result;
-        sysdef_qos_conf_t dur_conf = {sec,sec,sec,sec,sec,sec,sec,sec,sec};
         char *full_configuration = NULL;
         uint64_t validate_mask = 0;
+        sysdef_qos_conf_t dur_conf = {sec,sec,sec,sec,sec,sec,sec,sec,sec};
 
-        for (unsigned char c = 'a'; c <= 'd'; c++) bs.push_back(c);
-        pList.push_back("abcd");
-        pList.push_back("efgh");
-        pList.push_back("ijkl");
-        switch(kind)
-        {
-        case DDS_PARTICIPANT_QOS:
-            pQos = dds::domain::DomainParticipant::default_participant_qos()
-                << dds::core::policy::UserData(bs)
-                << dds::core::policy::EntityFactory::AutoEnable();
-            qos = pQos.delegate().ddsc_qos();
-            break;
-        case DDS_PUBLISHER_QOS:
-            pubQos = dp.default_publisher_qos()
-                << dds::core::policy::GroupData(bs)
-                << dds::core::policy::Partition(pList)
-                << dds::core::policy::Presentation::InstanceAccessScope(false, false)
-                << dds::core::policy::EntityFactory::AutoEnable();
-            qos = pubQos.delegate().ddsc_qos();
-            break;
-        case DDS_SUBSCRIBER_QOS:
-            subQos = dp.default_subscriber_qos()
-                << dds::core::policy::GroupData(bs)
-                << dds::core::policy::Partition(pList)
-                << dds::core::policy::Presentation::InstanceAccessScope(false, false)
-                << dds::core::policy::EntityFactory::AutoEnable();
-            qos = subQos.delegate().ddsc_qos();
-            break;
-        case DDS_TOPIC_QOS:
-            tQos = dp.default_topic_qos()
-                << dds::core::policy::TopicData(bs)
-                << dds::core::policy::Durability::Volatile()
-                << dds::core::policy::Deadline(dds::core::Duration(1,0))
-                << dds::core::policy::LatencyBudget(dds::core::Duration(1,0))
-                << dds::core::policy::Ownership::Exclusive()
-                << dds::core::policy::Liveliness::Automatic(dds::core::Duration::infinite())
-                << dds::core::policy::Reliability::Reliable(dds::core::Duration(1, 0))
-                << dds::core::policy::TransportPriority(1000)
-                << dds::core::policy::Lifespan(dds::core::Duration(1, 0))
-                << dds::core::policy::DestinationOrder::SourceTimestamp()
-                << dds::core::policy::History::KeepLast(1)
-                << dds::core::policy::ResourceLimits(1, 1, 1)
-                << dds::core::policy::DurabilityService(dds::core::Duration(1, 0), dds::core::policy::HistoryKind::KEEP_ALL, -1, 1, 1, 1);
-            qos = tQos.delegate().ddsc_qos();
-            break;
-        case DDS_READER_QOS:
-            rQos = sub.default_datareader_qos()
-                << dds::core::policy::UserData(bs)
-                << dds::core::policy::Durability::Volatile()
-                << dds::core::policy::Deadline(dds::core::Duration(1,0))
-                << dds::core::policy::LatencyBudget(dds::core::Duration(1,0))
-                << dds::core::policy::Ownership::Exclusive()
-                << dds::core::policy::Liveliness::Automatic(dds::core::Duration::infinite())
-                << dds::core::policy::Reliability::Reliable(dds::core::Duration(1, 0))
-                << dds::core::policy::DestinationOrder::SourceTimestamp()
-                << dds::core::policy::History::KeepLast(1)
-                << dds::core::policy::ResourceLimits(1, 1, 1)
-                << dds::core::policy::TimeBasedFilter(dds::core::Duration(1, 0))
-                << dds::core::policy::ReaderDataLifecycle(dds::core::Duration(1,0), dds::core::Duration(1,0));
-            qos = rQos.delegate().ddsc_qos();
-            break;
-        case DDS_WRITER_QOS:
-            wQos = pub.default_datawriter_qos()
-                << dds::core::policy::UserData(bs)
-                << dds::core::policy::Durability::Volatile()
-                << dds::core::policy::Deadline(dds::core::Duration(1,0))
-                << dds::core::policy::LatencyBudget(dds::core::Duration(1,0))
-                << dds::core::policy::Ownership::Exclusive()
-                << dds::core::policy::OwnershipStrength(100)
-                << dds::core::policy::Liveliness::Automatic(dds::core::Duration::infinite())
-                << dds::core::policy::Reliability::Reliable(dds::core::Duration(1, 0))
-                << dds::core::policy::DestinationOrder::SourceTimestamp()
-                << dds::core::policy::History::KeepLast(1)
-                << dds::core::policy::ResourceLimits(1, 1, 1)
-                << dds::core::policy::WriterDataLifecycle::AutoDisposeUnregisteredInstances();
-            qos = wQos.delegate().ddsc_qos();
-            break;
-        default:
-            assert(0);
-            break;
-        }
-        result = get_single_configuration(qos, &dur_conf, kind, &full_configuration, &validate_mask);
+        dds_qos_t *qos = get_gen_qos(kind, this);
+        dds_return_t result = get_single_configuration(qos, &dur_conf, kind, NULL, &full_configuration, &validate_mask);
         ASSERT_TRUE(result >= 0);
-        dds::core::QosProvider qp(full_configuration);
+        dds::core::QosProvider qp(full_configuration, "lib1::pro00");
         switch(kind)
         {
         case DDS_PARTICIPANT_QOS:
         {
-            dds::domain::qos::DomainParticipantQos qpQos = qp.participant_qos("lib1::pro00");
-            ASSERT_TRUE(pQos == qpQos);
+            dds::domain::qos::DomainParticipantQos qpQos0 = qp.participant_qos("lib1::pro00");
+            dds::domain::qos::DomainParticipantQos qpQos1 = qp.participant_qos("");
+            dds::domain::qos::DomainParticipantQos qpQos2 = qp.participant_qos();
+            ASSERT_TRUE(pQos == qpQos0);
+            ASSERT_TRUE(pQos == qpQos1);
+            ASSERT_TRUE(pQos == qpQos2);
             break;
         }
         case DDS_PUBLISHER_QOS:
         {
-            dds::pub::qos::PublisherQos qpQos = qp.publisher_qos("lib1::pro00");
-            ASSERT_TRUE(pubQos == qpQos);
+            dds::pub::qos::PublisherQos qpQos0 = qp.publisher_qos("lib1::pro00");
+            dds::pub::qos::PublisherQos qpQos1 = qp.publisher_qos("");
+            dds::pub::qos::PublisherQos qpQos2 = qp.publisher_qos();
+            ASSERT_TRUE(pubQos == qpQos0);
+            ASSERT_TRUE(pubQos == qpQos1);
+            ASSERT_TRUE(pubQos == qpQos2);
             break;
         }
         case DDS_SUBSCRIBER_QOS:
         {
-            dds::sub::qos::SubscriberQos qpQos = qp.subscriber_qos("lib1::pro00");
-            ASSERT_TRUE(subQos == qpQos);
+            dds::sub::qos::SubscriberQos qpQos0 = qp.subscriber_qos("lib1::pro00");
+            dds::sub::qos::SubscriberQos qpQos1 = qp.subscriber_qos("");
+            dds::sub::qos::SubscriberQos qpQos2 = qp.subscriber_qos();
+            ASSERT_TRUE(subQos == qpQos0);
+            ASSERT_TRUE(subQos == qpQos1);
             break;
         }
         case DDS_TOPIC_QOS:
         {
-            dds::topic::qos::TopicQos qpQos = qp.topic_qos("lib1::pro00");
-            ASSERT_TRUE(tQos == qpQos);
+            dds::topic::qos::TopicQos qpQos0 = qp.topic_qos("lib1::pro00");
+            dds::topic::qos::TopicQos qpQos1 = qp.topic_qos("");
+            dds::topic::qos::TopicQos qpQos2 = qp.topic_qos();
+            ASSERT_TRUE(tQos == qpQos0);
+            ASSERT_TRUE(tQos == qpQos1);
+            ASSERT_TRUE(tQos == qpQos2);
             break;
         }
         case DDS_READER_QOS:
         {
-            dds::sub::qos::DataReaderQos qpQos = qp.datareader_qos("lib1::pro00");
-            ASSERT_TRUE(rQos == qpQos);
+            dds::sub::qos::DataReaderQos qpQos0 = qp.datareader_qos("lib1::pro00");
+            dds::sub::qos::DataReaderQos qpQos1 = qp.datareader_qos("");
+            dds::sub::qos::DataReaderQos qpQos2 = qp.datareader_qos();
+            ASSERT_TRUE(rQos == qpQos0);
+            ASSERT_TRUE(rQos == qpQos1);
+            ASSERT_TRUE(rQos == qpQos2);
             break;
         }
         case DDS_WRITER_QOS:
         {
-            dds::pub::qos::DataWriterQos qpQos = qp.datawriter_qos("lib1::pro00");
-            ASSERT_TRUE(wQos == qpQos);
+            dds::pub::qos::DataWriterQos qpQos0 = qp.datawriter_qos("lib1::pro00");
+            dds::pub::qos::DataWriterQos qpQos1 = qp.datawriter_qos("");
+            dds::pub::qos::DataWriterQos qpQos2 = qp.datawriter_qos();
+            ASSERT_TRUE(wQos == qpQos0);
+            ASSERT_TRUE(wQos == qpQos1);
+            ASSERT_TRUE(wQos == qpQos2);
             break;
         }
         }
@@ -990,3 +1046,81 @@ TEST_F(QosProvider, topicQos)
     this->doTest(DDS_TOPIC_QOS);
 }
 
+TEST_F(QosProvider, invalid_scope)
+{
+  (void) this;
+  char *full_configuration = NULL;
+  uint64_t validate_mask = 0;
+
+  QosProvider::sysdef_qos_conf_t dur_conf = {
+#define sec QosProvider::sec
+    sec,sec,sec,sec,sec,sec,sec,sec,sec
+#undef sec
+  };
+
+  dds_qos_kind_t kind = DDS_PARTICIPANT_QOS;
+  dds_qos_t *qos = QosProvider::get_gen_qos(kind, NULL);
+  dds_return_t result = QosProvider::get_single_configuration(qos, &dur_conf, kind, NULL, &full_configuration, &validate_mask);
+  ASSERT_TRUE(result >= 0);
+  std::vector<std::string> invalid_scope = {
+    "", "::", "::::", "*", "*::", "**", "::*::", "::::::",
+    "lib1::", "lib1::*", "lib1::*::", "lib1*::*",
+    "lib1::pro01", "lib1::pro00::*",
+    "::pro00",
+  };
+  for (auto it = invalid_scope.begin(); it != invalid_scope.end(); it++)
+  {
+    result = DDS_RETCODE_OK;
+    try {
+      dds::core::QosProvider qp(full_configuration, *it);
+    } catch (const dds::core::Exception &e) {
+      result = DDS_RETCODE_ERROR;
+    }
+    ASSERT_EQ(result, DDS_RETCODE_ERROR);
+  }
+
+  dds_delete_qos(qos);
+  ddsrt_free(full_configuration);
+}
+
+TEST_F(QosProvider, invalid_access_scope)
+{
+  char *full_configuration = NULL;
+  uint64_t validate_mask = 0;
+
+  QosProvider::sysdef_qos_conf_t dur_conf = {
+#define sec QosProvider::sec
+    sec,sec,sec,sec,sec,sec,sec,sec,sec
+#undef sec
+  };
+
+  dds_qos_kind_t kind = DDS_PARTICIPANT_QOS;
+  dds_qos_t *qos = QosProvider::get_gen_qos(kind, this);
+  dds_return_t result = QosProvider::get_single_configuration(qos, &dur_conf, kind, "pp00", &full_configuration, &validate_mask);
+  ASSERT_TRUE(result >= 0);
+  dds::core::QosProvider qp(full_configuration, "lib1::pro00");
+  std::vector<std::string> invalid_scope = {
+    "::", "::::", "*", "*::", "**", "::*::", "::::::",
+    "lib1::", "lib1::*", "lib1::*::", "lib1*::*",
+    "lib1::pro01", "lib1::pro00::*",
+    "::pro00", "pro00::", "pro00", "pro01",
+    "::pp00"
+  };
+  for (auto it = invalid_scope.begin(); it != invalid_scope.end(); it++)
+  {
+    result = DDS_RETCODE_OK;
+    try{
+      (void) qp.participant_qos(*it);
+    } catch (const dds::core::Exception &e) {
+      result = DDS_RETCODE_ERROR;
+    }
+    ASSERT_EQ(result, DDS_RETCODE_ERROR);
+  }
+
+  /* validate one success case the was not handled previously */
+  dds::domain::qos::DomainParticipantQos pQos = qp.participant_qos("pp00");
+  ASSERT_TRUE (this->pQos == pQos);
+
+  dds_delete_qos(qos);
+  ddsrt_free(full_configuration);
+}


### PR DESCRIPTION
For compatibility purpose reduce QosProvider init/access variants to strict format (for init: `<lib>::<profile>` and for access: `<optional name>`).

> [!IMPORTANT]
> some of the new added tests rely on changes from: https://github.com/eclipse-cyclonedds/cyclonedds/pull/2287/commits/4e3d8f1b7ffea3bb6a99e37a0036db67a186192b
> of course this tests will fail until cyclonedds@master updates