### PR TITLE
Disable security/ssl in Cyclone build on CI

### DIFF
--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -93,6 +93,8 @@ steps:
       cmake --build . --config ${BUILD_TYPE} --target install -- ${BUILD_TOOL_OPTIONS}
     condition: eq(variables['iceoryx'], 'on')
     name: install_iceoryx
+  # Linking with OpenSSL causes tests to fail on Windows builds because of path issues,
+  # so we'll disable security/openssl, which is not relevant for c++ tests anyway
   - bash: |
       set -e -x
       git clone --single-branch \
@@ -108,6 +110,8 @@ steps:
             -DENABLE_ICEORYX=${ICEORYX:-off} \
             -DENABLE_TYPELIB=${TYPELIB:-on} \
             -DENABLE_TOPIC_DISCOVERY=${TOPIC_DISCOVERY:-on} \
+            -DENABLE_SSL=off \
+            -DENABLE_SECURITY=off \
             ${GENERATOR:+-G} "${GENERATOR}" -A "${PLATFORM}" -T "${TOOLSET}" ..
       cmake --build . --config ${BUILD_TYPE} --target install -- ${BUILD_TOOL_OPTIONS}
     name: install_cyclonedds


### PR DESCRIPTION
Avoids test failures in C++ Windows CI builds, caused by unresolved OpenSSL library.