### PR TITLE
fix strict c++20 builds on windows

### DIFF
--- a/src/ddscxx/include/dds/topic/detail/TopicInstanceImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TopicInstanceImpl.hpp
@@ -39,12 +39,6 @@ TopicInstance<T>::TopicInstance(const ::dds::core::InstanceHandle& h, const T& s
     : h_(h), sample_(sample) { }
 
 template <typename T>
-TopicInstance<T>::operator const ::dds::core::InstanceHandle() const
-{
-    return h_;
-}
-
-template <typename T>
 const ::dds::core::InstanceHandle TopicInstance<T>::handle() const
 {
     return h_;
@@ -75,6 +69,12 @@ void TopicInstance<T>::sample(const T& sample)
 }
 
 }
+}
+
+template <typename T>
+dds::topic::TopicInstance<T>::operator const ::dds::core::InstanceHandle() const
+{
+    return h_;
 }
 
 // End of implementation


### PR DESCRIPTION
This PR fixes builds when users want to compile their code with strict c++20 (windows) and include cyclone headers.

It closes #565

@eboasson could you have a look?