### PR TITLE
feature/implement-entity-name-qos

### DIFF
--- a/src/ddscxx/include/dds/core/policy/CorePolicy.hpp
+++ b/src/ddscxx/include/dds/core/policy/CorePolicy.hpp
@@ -160,6 +160,9 @@ Property;
 typedef dds::core::policy::detail::BinaryProperty
 BinaryProperty;
 
+typedef dds::core::policy::detail::EntityName
+EntityName;
+
 typedef dds::core::policy::detail::WriterDataLifecycle
 WriterDataLifecycle;
 
@@ -209,6 +212,7 @@ OMG_DDS_POLICY_TRAITS(TypeConsistencyEnforcement, 24)
 OMG_DDS_POLICY_TRAITS(WriterBatching,       25)
 OMG_DDS_POLICY_TRAITS(Property,             29)
 OMG_DDS_POLICY_TRAITS(BinaryProperty,       30)
+OMG_DDS_POLICY_TRAITS(EntityName,           31)
 OMG_DDS_POLICY_TRAITS(PSMXInstances,        34)
 OMG_DDS_POLICY_TRAITS(IgnoreLocal,          35)
 

--- a/src/ddscxx/include/dds/core/policy/TCorePolicy.hpp
+++ b/src/ddscxx/include/dds/core/policy/TCorePolicy.hpp
@@ -293,6 +293,63 @@ public:
     bool propagate(const std::string& key) const;
 };
 
+
+//==============================================================================
+/**
+ * \copydoc DCPS_QoS_EntityName
+ */
+template <typename D>
+class TEntityName : public dds::core::Value<D>
+{
+public:
+
+    typedef std::pair<std::string, std::string> Entry;
+
+    /**
+     * Creates a empty EntityName QoS instance
+     */
+    TEntityName();
+
+    /**
+     * Creates a EntityName QoS instance
+     *
+     * @param entity_name the sequence of octets
+     */
+    explicit TEntityName(const std::string &entity_name);
+
+    /**
+     * Copies a EntityName QoS instance
+     *
+     * @param other the Property QoS instance to copy
+     */
+    TEntityName(const TEntityName& other);
+
+    /**
+    * Copies a EntityName QoS instance
+    *
+    * @param other the EntityName QoS instance to copy
+    *
+    * @return Reference to the EntityName QoS instance that was copied to
+    */
+    TEntityName& operator=(const TEntityName& other) = default;
+
+public:
+
+    /**
+     * Sets the entity name
+     *
+     * @param entity_name name of the entity
+     */
+    TEntityName& name(const std::string &entity_name);
+
+    /**
+     * Get the value for name
+     * 
+     * @return a string value
+     */
+    std::string name() const;
+};
+
 //==============================================================================
 
 /**

--- a/src/ddscxx/include/dds/core/policy/detail/CorePolicy.hpp
+++ b/src/ddscxx/include/dds/core/policy/detail/CorePolicy.hpp
@@ -110,6 +110,9 @@ namespace dds { namespace core { namespace policy { namespace detail {
     typedef dds::core::policy::TBinaryProperty<org::eclipse::cyclonedds::core::policy::BinaryPropertyDelegate>
     BinaryProperty;
 
+    typedef dds::core::policy::TEntityName<org::eclipse::cyclonedds::core::policy::EntityNameDelegate>
+    EntityName;
+    
     typedef dds::core::policy::TWriterDataLifecycle<org::eclipse::cyclonedds::core::policy::WriterDataLifecycleDelegate>
     WriterDataLifecycle;
 

--- a/src/ddscxx/include/dds/core/policy/detail/TCorePolicyImpl.hpp
+++ b/src/ddscxx/include/dds/core/policy/detail/TCorePolicyImpl.hpp
@@ -204,6 +204,30 @@ bool TBinaryProperty<D>::propagate(const std::string& key) const
     return this->delegate().propagate(key);
 }
 
+//TEntityName
+
+template <typename D>
+TEntityName<D>::TEntityName() : dds::core::Value<D>() { }
+
+template <typename D>
+TEntityName<D>::TEntityName(const TEntityName& other) : dds::core::Value<D>(other.delegate()) { }
+
+template <typename D>
+TEntityName<D>::TEntityName(const std::string &entity_name) : dds::core::Value<D>(entity_name) { }
+
+template <typename D>
+TEntityName<D>& TEntityName<D>::name(const std::string &entity_name)
+{
+    this->delegate().name(entity_name);
+    return *this;
+}
+
+template <typename D>
+std::string TEntityName<D>::name() const
+{
+    return this->delegate().name();
+}
+
 //TGroupData
 
 template <typename D>

--- a/src/ddscxx/include/dds/domain/qos/detail/DomainParticipantQos.hpp
+++ b/src/ddscxx/include/dds/domain/qos/detail/DomainParticipantQos.hpp
@@ -40,6 +40,7 @@
  * dds::core::policy::UserData                         | Additional information (@ref DCPS_QoS_UserData "info")       | UserData::UserData(empty)
  * dds::core::policy::Property                         | Additional information (@ref DCPS_QoS_Property "info")       | Property::Property(empty)
  * dds::core::policy::BinaryProperty                   | Additional information (@ref DCPS_QoS_BinaryProperty "info") | BinaryProperty::BinaryProperty(empty)
+ * dds::core::policy::EntityName                       | Additional information (@ref DCPS_QoS_EntityName "info")     | EntityName::EntityName(empty)
  * dds::core::policy::EntityFactory                    | Create enabled (@ref DCPS_QoS_EntityFactory "info")          | EntityFactory::AutoEnable()
  *
  * A QosPolicy can be set when the DomainParticipant is created or modified with the

--- a/src/ddscxx/include/dds/pub/qos/detail/DataWriterQos.hpp
+++ b/src/ddscxx/include/dds/pub/qos/detail/DataWriterQos.hpp
@@ -37,8 +37,9 @@
  * QosPolicy                               | Desciption                                                                 | Default Value
  * --------------------------------------- | -------------------------------------------------------------------------- | --------------------
  * dds::core::policy::UserData             | Additional information (@ref DCPS_QoS_UserData "info")                     | UserData::UserData(empty)
- * dds::core::policy::Property             | Additional information (@ref DCPS_QoS_Property "info")                     | Property::Proeprty(empty)
- * dds::core::policy::BinaryProperty       | Additional information (@ref DCPS_QoS_BinaryProperty "info")               | BinaryProperty::Proeprty(empty)
+ * dds::core::policy::Property             | Additional information (@ref DCPS_QoS_Property "info")                     | Property::Property(empty)
+ * dds::core::policy::BinaryProperty       | Additional information (@ref DCPS_QoS_BinaryProperty "info")               | BinaryProperty::BinaryProperty(empty)
+ * dds::core::policy::EntityName           | Additional information (@ref DCPS_QoS_EntityName "info")                   | EntityName::EntityName(empty)
  * dds::core::policy::Durability           | Data storage settings for late joiners (@ref DCPS_QoS_Durability "info")   | Durability::Volatile()
  * dds::core::policy::DurabilityService    | Transient/persistent behaviour (@ref DCPS_QoS_DurabilityService "info")    | DurabilityService::DurabilityService()
  * dds::core::policy::Deadline             | Period in which new sample is written (@ref DCPS_QoS_Deadline "info")      | Deadline::Deadline(infinite)

--- a/src/ddscxx/include/dds/sub/qos/detail/DataReaderQos.hpp
+++ b/src/ddscxx/include/dds/sub/qos/detail/DataReaderQos.hpp
@@ -47,6 +47,7 @@
  * dds::core::policy::UserData                    | Additional information (@ref DCPS_QoS_UserData "info")                              | UserData::UserData(empty)
  * dds::core::policy::Property                    | Additional information (@ref DCPS_QoS_Property "info")                              | Property::Property(empty)
  * dds::core::policy::BinaryProperty              | Additional information (@ref DCPS_QoS_BinaryProperty "info")                        | BinaryProperty::BinaryProperty(empty)
+ * dds::core::policy::EntityName                  | Additional information (@ref DCPS_QoS_EntityName "info")                            | EntityName::EntityName(empty)
  * dds::core::policy::Ownership                   | Exclusive ownership or not (@ref DCPS_QoS_Ownership "info")                         | Ownership::Shared()
  * dds::core::policy::TimeBasedFilter             | Maximum data rate (@ref DCPS_QoS_TimeBasedFilter "info")                            | TimeBasedFilter::TimeBasedFilter(0)
  * dds::core::policy::ReaderDataLifecycle         | Instance state changes and notifications (@ref DCPS_QoS_ReaderDataLifecycle "info") | ReaderDataLifecycle::NoAutoPurgeDisposedSamples()

--- a/src/ddscxx/include/dds/topic/TBuiltinTopic.hpp
+++ b/src/ddscxx/include/dds/topic/TBuiltinTopic.hpp
@@ -97,6 +97,11 @@ public:
      * User-defined BinaryProperty attached to the participant via a QosPolicy
      */
     const ::dds::core::policy::BinaryProperty& binary_property() const;
+
+    /**
+     * User-defined EntityName attached to the participant via a QosPolicy
+     */
+    const ::dds::core::policy::EntityName& entity_name() const;
 };
 
 /// @brief
@@ -334,6 +339,12 @@ public:
     /**
      * QosPolicy attached to the DataWriter
      */
+    const ::dds::core::policy::EntityName& entity_name() const;
+
+
+    /**
+     * QosPolicy attached to the DataWriter
+     */
     const ::dds::core::policy::Ownership&          ownership() const;
 
     #ifdef OMG_DDS_OWNERSHIP_SUPPORT
@@ -477,6 +488,11 @@ public:
      * QosPolicy attached to the DataReader
      */
     const ::dds::core::policy::BinaryProperty&     binary_property() const;
+
+    /**
+     * QosPolicy attached to the DataReader
+     */
+    const ::dds::core::policy::EntityName& entity_name() const;
 
     /**
      * QosPolicy attached to the DataReader

--- a/src/ddscxx/include/dds/topic/detail/TBuiltinTopicImpl.hpp
+++ b/src/ddscxx/include/dds/topic/detail/TBuiltinTopicImpl.hpp
@@ -51,6 +51,12 @@ const ::dds::core::policy::BinaryProperty& TParticipantBuiltinTopicData<D>::bina
     return this->delegate().binary_property();
 }
 
+template <typename D>
+const ::dds::core::policy::EntityName& TParticipantBuiltinTopicData<D>::entity_name() const
+{
+    return this->delegate().entity_name();
+}
+
 //TTopicBuiltinTopicData
 template <typename D>
 const dds::topic::BuiltinTopicKey& TTopicBuiltinTopicData<D>::key() const
@@ -241,6 +247,11 @@ const ::dds::core::policy::BinaryProperty& TPublicationBuiltinTopicData<D>::bina
     return this->delegate().binary_property();
 }
 
+template <typename D>
+const ::dds::core::policy::EntityName& TPublicationBuiltinTopicData<D>::entity_name() const
+{
+    return this->delegate().entity_name();
+}
 
 template <typename D>
 const ::dds::core::policy::Ownership& TPublicationBuiltinTopicData<D>::ownership() const

--- a/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/PolicyDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/core/policy/PolicyDelegate.hpp
@@ -1092,6 +1092,79 @@ private:
 
 //==============================================================================
 
+/**
+ *  @internal EntityName
+ */
+class OMG_DDS_API EntityNameDelegate
+{
+public:
+
+    typedef std::pair<std::string, std::string> Entry;
+
+    /**
+     *  @internal Create a <code>Property</code> instance with an empty user data.
+     */
+    EntityNameDelegate();
+
+    /**
+     *  @internal Create a <code>Property</code> instance.
+     *
+     * @param other the user data to copy
+     */
+    EntityNameDelegate(const EntityNameDelegate& other);
+
+    /**
+     *  @internal Copies a <code>Property</code> instance.
+     *
+     * @param other the user data to copy
+     *
+     * @return reference to the instance that was copied to
+     */
+    EntityNameDelegate& operator=(const EntityNameDelegate& other) = default;
+
+    bool operator ==(const EntityNameDelegate& other) const;
+
+    /**
+     *  @internal Create a <code>EntityName</code> instance.
+     *
+     * @param entity_name The entity name
+     */
+    explicit EntityNameDelegate(const std::string& entity_name);
+
+    /**
+     *  @internal Set or assign entity name.
+    */
+    EntityNameDelegate& name(const std::string& entity_name);
+
+    /**
+     *  @internal Get entity name.
+    */
+    std::string name() const;
+
+    /**
+     *  @internal Check if policy is consistent.
+     */
+    void check() const;
+
+    /**
+     *  @internal Set internals by the ddsc policy.
+     *
+     * @param qos the ddsc policy
+     */
+    void set_iso_policy(const dds_qos_t* qos);
+
+    /**
+     *  @internal Get the ddsc policy representation.
+     */
+    void set_c_policy(dds_qos_t* qos) const;
+
+private:
+    std::string entity_name_;
+};
+
+
+//==============================================================================
+
 
 class OMG_DDS_API WriterDataLifecycleDelegate
 {

--- a/src/ddscxx/include/org/eclipse/cyclonedds/domain/qos/DomainParticipantQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/domain/qos/DomainParticipantQosDelegate.hpp
@@ -38,6 +38,7 @@ public:
     void policy(const dds::core::policy::UserData& ud);
     void policy(const dds::core::policy::Property& prop);
     void policy(const dds::core::policy::BinaryProperty& prop);
+    void policy(const dds::core::policy::EntityName& entity_name);
     void policy(const dds::core::policy::EntityFactory& efp);
 
     template <typename POLICY> const POLICY& policy() const;
@@ -60,6 +61,7 @@ private:
     dds::core::policy::UserData       user_data_;
     dds::core::policy::Property       prop_;
     dds::core::policy::BinaryProperty bin_prop_;
+    dds::core::policy::EntityName     entity_name_;
     dds::core::policy::EntityFactory  entity_factory_;
 };
 
@@ -100,6 +102,17 @@ DomainParticipantQosDelegate::policy<dds::core::policy::BinaryProperty> () const
 template<>
 OMG_DDS_API dds::core::policy::BinaryProperty&
 DomainParticipantQosDelegate::policy<dds::core::policy::BinaryProperty> ();
+
+template<>
+inline const dds::core::policy::EntityName&
+DomainParticipantQosDelegate::policy<dds::core::policy::EntityName> () const
+{
+    return entity_name_;
+}
+
+template<>
+OMG_DDS_API dds::core::policy::EntityName&
+DomainParticipantQosDelegate::policy<dds::core::policy::EntityName> ();
 
 
 template<>

--- a/src/ddscxx/include/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.hpp
@@ -40,6 +40,7 @@ public:
     void policy(const dds::core::policy::UserData&          user_data);
     void policy(const dds::core::policy::Property&          property);
     void policy(const dds::core::policy::BinaryProperty&    binary_property);
+    void policy(const dds::core::policy::EntityName&        entity_name);
     void policy(const dds::core::policy::Durability&        durability);
 #ifdef  OMG_DDS_PERSISTENCE_SUPPORT
     void policy(const dds::core::policy::DurabilityService& durability_service);
@@ -87,6 +88,7 @@ private:
     dds::core::policy::UserData                user_data_;
     dds::core::policy::Property                property_;
     dds::core::policy::BinaryProperty          binary_property_;
+    dds::core::policy::EntityName              entity_name_;
     dds::core::policy::Durability              durability_;
 #ifdef  OMG_DDS_PERSISTENCE_SUPPORT
     dds::core::policy::DurabilityService       durability_service_;
@@ -144,6 +146,15 @@ DataWriterQosDelegate::policy<dds::core::policy::BinaryProperty>() const
 
 template<> OMG_DDS_API dds::core::policy::BinaryProperty&
 DataWriterQosDelegate::policy<dds::core::policy::BinaryProperty>();
+
+template<> inline const dds::core::policy::EntityName&
+DataWriterQosDelegate::policy<dds::core::policy::EntityName>() const
+{
+    return entity_name_;
+}
+
+template<> OMG_DDS_API dds::core::policy::EntityName&
+DataWriterQosDelegate::policy<dds::core::policy::EntityName>();
 
 
 template<> inline const dds::core::policy::Durability&

--- a/src/ddscxx/include/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.hpp
@@ -40,6 +40,7 @@ public:
     void policy(const dds::core::policy::UserData&            user_data);
     void policy(const dds::core::policy::Property&            property);
     void policy(const dds::core::policy::BinaryProperty&      binary_property);
+    void policy(const dds::core::policy::EntityName&          entity_name);
     void policy(const dds::core::policy::Durability&          durability);
     void policy(const dds::core::policy::Deadline&            deadline);
     void policy(const dds::core::policy::LatencyBudget&       budget);
@@ -79,6 +80,7 @@ private:
     dds::core::policy::UserData                user_data_;
     dds::core::policy::Property                property_;
     dds::core::policy::BinaryProperty          binary_property_;
+    dds::core::policy::EntityName              entity_name_;
     dds::core::policy::Durability              durability_;
     dds::core::policy::Deadline                deadline_;
     dds::core::policy::LatencyBudget           budget_;
@@ -142,6 +144,18 @@ DataReaderQosDelegate::policy<dds::core::policy::BinaryProperty>() const
 template<>
 OMG_DDS_API dds::core::policy::BinaryProperty&
 DataReaderQosDelegate::policy<dds::core::policy::BinaryProperty>();
+
+
+template<>
+inline const dds::core::policy::EntityName&
+DataReaderQosDelegate::policy<dds::core::policy::EntityName>() const
+{
+    return entity_name_;
+}
+
+template<>
+OMG_DDS_API dds::core::policy::EntityName&
+DataReaderQosDelegate::policy<dds::core::policy::EntityName>();
 
 
 template<> inline const dds::core::policy::Deadline&

--- a/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicDelegate.hpp
+++ b/src/ddscxx/include/org/eclipse/cyclonedds/topic/BuiltinTopicDelegate.hpp
@@ -88,6 +88,16 @@ public:
         binary_prop_.delegate().set_iso_policy(policy);
     }
 
+    const ::dds::core::policy::EntityName& entity_name() const
+    {
+        return entity_name_;
+    }
+
+    void entity_name(const dds_qos_t* policy)
+    {
+        entity_name_.delegate().set_iso_policy(policy);
+    }
+
     bool operator ==(const ParticipantBuiltinTopicDataDelegate& other) const
     {
         return other.key_ == key_ && other.user_data_ == user_data_ && other.prop_ == prop_ && other.binary_prop_ == binary_prop_;
@@ -98,6 +108,7 @@ protected:
     ::dds::core::policy::UserData     user_data_;
     dds::core::policy::Property       prop_;
     dds::core::policy::BinaryProperty binary_prop_;
+    dds::core::policy::EntityName     entity_name_;
 };
 
 class org::eclipse::cyclonedds::topic::TopicBuiltinTopicDataDelegate
@@ -536,6 +547,16 @@ public:
         binary_property_.delegate().set_iso_policy(policy);
     }
 
+    const ::dds::core::policy::EntityName&     entity_name() const
+    {
+        return entity_name_;
+    }
+
+    void entity_name(const dds_qos_t* policy)
+    {
+        entity_name_.delegate().set_iso_policy(policy);
+    }
+
     const ::dds::core::policy::GroupData&          group_data() const
     {
         return group_data_;
@@ -577,6 +598,7 @@ public:
         group_data(endpoint->qos);
         property(endpoint->qos);
         binary_property(endpoint->qos);
+        entity_name(endpoint->qos);
     }
 
     bool operator ==(const PublicationBuiltinTopicDataDelegate& other) const
@@ -603,7 +625,8 @@ public:
                && other.topic_data_ == topic_data_
                && other.group_data_ == group_data_
                && other.property_ == property_
-               && other.binary_property_ == binary_property_;
+               && other.binary_property_ == binary_property_
+               && other.entity_name_ == entity_name_;
     }
 
 public:
@@ -636,6 +659,7 @@ public:
     ::dds::core::policy::GroupData          group_data_;
     ::dds::core::policy::Property           property_;
     ::dds::core::policy::BinaryProperty     binary_property_;
+    ::dds::core::policy::EntityName         entity_name_;
 
     dds_builtintopic_endpoint_t* ddsc_endpoint_;
 };
@@ -835,6 +859,16 @@ public:
         binary_property_.delegate().set_iso_policy(policy);
     }
 
+    const ::dds::core::policy::EntityName&     entity_name() const
+    {
+        return entity_name_;
+    }
+
+    void entity_name(const dds_qos_t* policy)
+    {
+        entity_name_.delegate().set_iso_policy(policy);
+    }
+
     const ::dds::core::policy::GroupData&          group_data() const
     {
         return group_data_;
@@ -870,6 +904,7 @@ public:
         group_data(endpoint->qos);
         property(endpoint->qos);
         binary_property(endpoint->qos);
+        entity_name(endpoint->qos);
     }
 
     bool operator ==(const SubscriptionBuiltinTopicDataDelegate& other) const
@@ -892,7 +927,8 @@ public:
                && other.topic_data_ == topic_data_
                && other.group_data_ == group_data_
                && other.property_ == property_
-               && other.binary_property_ == binary_property_;
+               && other.binary_property_ == binary_property_
+               && other.entity_name_ == entity_name_;
     }
 
 public:
@@ -915,6 +951,7 @@ public:
     ::dds::core::policy::GroupData          group_data_;
     ::dds::core::policy::Property           property_;
     ::dds::core::policy::BinaryProperty     binary_property_;
+    ::dds::core::policy::EntityName         entity_name_;
 
     dds_builtintopic_endpoint_t* ddsc_endpoint_;
 };

--- a/src/ddscxx/src/dds/core/policy/CorePolicy.cpp
+++ b/src/ddscxx/src/dds/core/policy/CorePolicy.cpp
@@ -19,6 +19,7 @@
 OMG_DDS_DEFINE_POLICY_TRAITS(dds::core::policy::UserData,            UserData)
 OMG_DDS_DEFINE_POLICY_TRAITS(dds::core::policy::Property,            Property)
 OMG_DDS_DEFINE_POLICY_TRAITS(dds::core::policy::BinaryProperty,      BinaryProperty)
+OMG_DDS_DEFINE_POLICY_TRAITS(dds::core::policy::EntityName,          EntityName)
 OMG_DDS_DEFINE_POLICY_TRAITS(dds::core::policy::Durability,          Durability)
 OMG_DDS_DEFINE_POLICY_TRAITS(dds::core::policy::Presentation,        Presentation)
 OMG_DDS_DEFINE_POLICY_TRAITS(dds::core::policy::Deadline,            Deadline)

--- a/src/ddscxx/src/org/eclipse/cyclonedds/core/policy/PolicyDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/core/policy/PolicyDelegate.cpp
@@ -1826,6 +1826,60 @@ void BinaryPropertyDelegate::set_c_policy(dds_qos_t* qos) const
     }
 }
 
+
+//============= EntityNameDelegate =========================================
+
+EntityNameDelegate::EntityNameDelegate()
+    : entity_name_()
+{
+}
+
+EntityNameDelegate::EntityNameDelegate(const EntityNameDelegate& other)
+    : entity_name_(other.entity_name_)
+{
+}
+
+EntityNameDelegate::EntityNameDelegate(const std::string& entity_name)
+    : entity_name_(entity_name)
+{
+    this->check();
+}
+
+EntityNameDelegate& EntityNameDelegate::name(const std::string& entity_name)
+{
+    entity_name_ = entity_name;
+    return *this;
+}
+
+std::string EntityNameDelegate::name() const
+{
+    return entity_name_;
+}
+
+bool EntityNameDelegate::operator==(const EntityNameDelegate& other) const
+{
+    return other.entity_name_ == entity_name_;
+}
+
+void EntityNameDelegate::check() const
+{
+    /* The value_ is just a map: nothing to check. */
+}
+
+void EntityNameDelegate::set_iso_policy(const dds_qos_t* qos)
+{
+    char* name = nullptr;
+    if (dds_qget_entity_name (qos, &name)) {
+        entity_name_ = std::string(name);
+        dds_free(name);
+    }
+}
+
+void EntityNameDelegate::set_c_policy(dds_qos_t* qos) const
+{
+    dds_qset_entity_name (qos, entity_name_.c_str());
+}
+
 //==============================================================================
 
 WriterDataLifecycleDelegate::WriterDataLifecycleDelegate(const WriterDataLifecycleDelegate& other)

--- a/src/ddscxx/src/org/eclipse/cyclonedds/domain/qos/DomainParticipantQosDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/domain/qos/DomainParticipantQosDelegate.cpp
@@ -61,6 +61,14 @@ DomainParticipantQosDelegate::policy(const dds::core::policy::BinaryProperty& bi
 }
 
 void
+DomainParticipantQosDelegate::policy(const dds::core::policy::EntityName& entity_name)
+{
+    entity_name.delegate().check();
+    present_ |= DDSI_QP_ENTITY_NAME;
+    entity_name_ = entity_name;
+}
+
+void
 DomainParticipantQosDelegate::policy(const dds::core::policy::EntityFactory& entity_factory)
 {
     entity_factory.delegate().check();
@@ -84,6 +92,8 @@ DomainParticipantQosDelegate::ddsc_qos() const
         prop_.delegate().set_c_policy(qos);
         bin_prop_.delegate().set_c_policy(qos);
     }
+    if (present_ & DDSI_QP_ENTITY_NAME)
+        entity_name_.delegate().set_c_policy(qos);
     return qos;
 }
 
@@ -102,6 +112,8 @@ DomainParticipantQosDelegate::ddsc_qos(const dds_qos_t* qos, bool copy_flags)
         prop_.delegate().set_iso_policy(qos);
         bin_prop_.delegate().set_iso_policy(qos);
     }
+    if (qos->present & DDSI_QP_ENTITY_NAME)
+        entity_name_.delegate().set_iso_policy(qos);
 }
 
 void
@@ -134,6 +146,7 @@ DomainParticipantQosDelegate::operator ==(const DomainParticipantQosDelegate& ot
            other.user_data_           == user_data_ &&
            other.prop_                == prop_ &&
            other.bin_prop_            == bin_prop_ &&
+           other.entity_name_         == entity_name_ &&
            other.entity_factory_      == entity_factory_;
 
 }
@@ -160,6 +173,14 @@ DomainParticipantQosDelegate::policy<dds::core::policy::BinaryProperty> ()
 {
     present_ |= DDSI_QP_PROPERTY_LIST;
     return bin_prop_;
+}
+
+template<>
+dds::core::policy::EntityName&
+DomainParticipantQosDelegate::policy<dds::core::policy::EntityName> ()
+{
+    present_ |= DDSI_QP_ENTITY_NAME;
+    return entity_name_;
 }
 
 template<>

--- a/src/ddscxx/src/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/pub/qos/DataWriterQosDelegate.cpp
@@ -68,6 +68,14 @@ DataWriterQosDelegate::policy(const dds::core::policy::BinaryProperty& binary_pr
 }
 
 void
+DataWriterQosDelegate::policy(const dds::core::policy::EntityName& entity_name)
+{
+    entity_name.delegate().check();
+    present_ |= DDSI_QP_ENTITY_NAME;
+    entity_name_ = entity_name;
+}
+
+void
 DataWriterQosDelegate::policy(const dds::core::policy::Durability& durability)
 {
     durability.delegate().check();
@@ -283,6 +291,10 @@ DataWriterQosDelegate::ddsc_qos() const
         property_   .delegate().set_c_policy(qos);
         binary_property_   .delegate().set_c_policy(qos);
     }
+    if (present_ & DDSI_QP_ENTITY_NAME)
+    {
+        entity_name_.delegate().set_c_policy(qos);
+    }
     return qos;
 }
 
@@ -343,6 +355,10 @@ DataWriterQosDelegate::ddsc_qos(const dds_qos_t* qos, bool copy_flags)
         property_    .delegate().set_iso_policy(qos);
         binary_property_    .delegate().set_iso_policy(qos);
     }
+    if (qos->present & DDSI_QP_ENTITY_NAME)
+    {
+        entity_name_.delegate().set_iso_policy(qos);
+    }
 }
 
 void
@@ -398,6 +414,7 @@ DataWriterQosDelegate::operator ==(const DataWriterQosDelegate& other) const
            other.user_data_   == user_data_   &&
            other.property_    == property_    &&
            other.binary_property_ == binary_property_ &&
+           other.entity_name_ == entity_name_ &&
            other.durability_  == durability_  &&
 #ifdef  OMG_DDS_PERSISTENCE_SUPPORT
            other.durability_service_ == durability_service_ &&
@@ -483,6 +500,13 @@ DataWriterQosDelegate::policy<dds::core::policy::BinaryProperty>()
 {
     present_ |= DDSI_QP_PROPERTY_LIST;
     return binary_property_;
+}
+
+template<> dds::core::policy::EntityName&
+DataWriterQosDelegate::policy<dds::core::policy::EntityName>()
+{
+    present_ |= DDSI_QP_ENTITY_NAME;
+    return entity_name_;
 }
 
 template<> dds::core::policy::Durability&

--- a/src/ddscxx/src/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.cpp
+++ b/src/ddscxx/src/org/eclipse/cyclonedds/sub/qos/DataReaderQosDelegate.cpp
@@ -68,6 +68,14 @@ DataReaderQosDelegate::policy(const dds::core::policy::BinaryProperty& binary_pr
 }
 
 void
+DataReaderQosDelegate::policy(const dds::core::policy::EntityName& entity_name)
+{
+    entity_name.delegate().check();
+    present_ |= DDSI_QP_ENTITY_NAME;
+    entity_name_ = entity_name;
+}
+
+void
 DataReaderQosDelegate::policy(const dds::core::policy::Durability& durability)
 {
     durability.delegate().check();
@@ -235,6 +243,10 @@ DataReaderQosDelegate::ddsc_qos() const
         property_.delegate().set_c_policy(qos);
         binary_property_.delegate().set_c_policy(qos);
     }
+    if (present_ & DDSI_QP_ENTITY_NAME)
+    {
+        entity_name_.delegate().set_c_policy(qos);
+    }
     return qos;
 }
 
@@ -282,6 +294,10 @@ DataReaderQosDelegate::ddsc_qos(const dds_qos_t* qos, bool copy_flags)
     {
         property_.delegate().set_iso_policy(qos);
         binary_property_.delegate().set_iso_policy(qos);
+    }
+    if (qos->present & DDSI_QP_ENTITY_NAME)
+    {
+        entity_name_.delegate().set_iso_policy(qos);
     }
 }
 
@@ -348,7 +364,8 @@ DataReaderQosDelegate::operator==(const DataReaderQosDelegate& other) const
            other.psmxinstances_ == psmxinstances_ &&
            other.ignorelocal_ == ignorelocal_ &&
            other.property_ == property_ &&
-           other.binary_property_ == binary_property_
+           other.binary_property_ == binary_property_ &&
+           other.entity_name_ == entity_name_
            ;
 }
 
@@ -412,6 +429,14 @@ DataReaderQosDelegate::policy<dds::core::policy::BinaryProperty>()
 {
     present_ |= DDSI_QP_PROPERTY_LIST;
     return binary_property_;
+}
+
+template<>
+dds::core::policy::EntityName&
+DataReaderQosDelegate::policy<dds::core::policy::EntityName>()
+{
+    present_ |= DDSI_QP_ENTITY_NAME;
+    return entity_name_;
 }
 
 template<>

--- a/src/ddscxx/tests/Qos.cpp
+++ b/src/ddscxx/tests/Qos.cpp
@@ -669,7 +669,8 @@ TEST(Qos, policy_name)
 {
     ASSERT_EQ(dds::core::policy::policy_name<UserData>::name(),            "UserData");
     ASSERT_EQ(dds::core::policy::policy_name<Property>::name(),            "Property");
-    ASSERT_EQ(dds::core::policy::policy_name<BinaryProperty>::name(),            "BinaryProperty");
+    ASSERT_EQ(dds::core::policy::policy_name<BinaryProperty>::name(),      "BinaryProperty");
+    ASSERT_EQ(dds::core::policy::policy_name<EntityName>::name(),          "EntityName");
     ASSERT_EQ(dds::core::policy::policy_name<Durability>::name(),          "Durability");
     ASSERT_EQ(dds::core::policy::policy_name<Presentation>::name(),        "Presentation");
     ASSERT_EQ(dds::core::policy::policy_name<Deadline>::name(),            "Deadline");


### PR DESCRIPTION
This PR implements the EntityName QoS.

Example usage:
```c++
dds::domain::qos::DomainParticipantQos dpQos;
dpQos << dds::core::policy::EntityName("HelloWorldParticipant");
```

@eboasson could you have a look?
