### PR TITLE
Support recursive types in C++ binding

### DIFF
--- a/src/ddscxx/tests/CDRStreamer.cpp
+++ b/src/ddscxx/tests/CDRStreamer.cpp
@@ -345,6 +345,80 @@ TEST_F(CDRStreamer, cdr_sequence_nested)
   readwrite_deeper_test(SS, SS, SS_basic_normal_delimited, SS_key_v2, xcdr_v2_stream);
 }
 
+template<typename S, typename T>
+static void cdr_roundtrip(const T& in, T& out)
+{
+  S size_stream(endianness::big_endian);
+  ASSERT_TRUE(move(size_stream, in, key_mode::not_key));
+
+  bytes buffer(size_stream.position());
+  S write_stream(endianness::big_endian);
+  write_stream.set_buffer(buffer.data(), buffer.size());
+  ASSERT_TRUE(write(write_stream, in, key_mode::not_key));
+
+  S read_stream(endianness::big_endian);
+  read_stream.set_buffer(buffer.data(), buffer.size());
+  ASSERT_TRUE(read(read_stream, out, key_mode::not_key));
+}
+
+template<typename S>
+static void recursive_node_roundtrip(const recursive_node& in)
+{
+  recursive_node out;
+  cdr_roundtrip<S>(in, out);
+  ASSERT_EQ(out, in);
+}
+
+TEST_F(CDRStreamer, cdr_recursive_sequence)
+{
+  recursive_node root;
+  root.value(1);
+
+  recursive_node child;
+  child.value(2);
+
+  recursive_node grandchild;
+  grandchild.value(3);
+  child.children().push_back(grandchild);
+  root.children().push_back(child);
+
+  recursive_node_roundtrip<xcdr_v1_stream>(root);
+  recursive_node_roundtrip<xcdr_v2_stream>(root);
+}
+
+template<typename S>
+static void recursive_union_roundtrip(const recursive_union& in)
+{
+  recursive_union out;
+  cdr_roundtrip<S>(in, out);
+  ASSERT_EQ(out, in);
+}
+
+TEST_F(CDRStreamer, cdr_recursive_union_sequence)
+{
+  recursive_union leaf;
+  leaf.value(7);
+
+  recursive_union child;
+  child.children({leaf});
+
+  recursive_union root;
+  root.children({child});
+
+  recursive_union_roundtrip<xcdr_v1_stream>(root);
+  recursive_union_roundtrip<xcdr_v2_stream>(root);
+}
+
+TEST_F(CDRStreamer, cdr_recursive_external_metadata)
+{
+  const auto &props = get_type_props<recursive_external_node>();
+
+  ASSERT_EQ(props.size(), 3u);
+  ASSERT_EQ(props[1].m_id, 1u);
+  ASSERT_EQ(props[2].m_id, 2u);
+  ASSERT_EQ(props[2].first_member, nullptr);
+}
+
 
 /*verifying reads/writes of a struct containing arrays*/
 

--- a/src/ddscxx/tests/CMakeLists.txt
+++ b/src/ddscxx/tests/CMakeLists.txt
@@ -28,6 +28,12 @@ idlcxx_generate(TARGET ddscxx_test_types FILES
   data/TraitsModels.idl
   WARNINGS no-implicit-extensibility)
 
+idlcxx_generate(TARGET ddscxx_recursive_probe_types FILES
+  data/RecursiveMutualSequence.idl
+  data/RecursiveOptionalSequenceSelf.idl
+  data/RecursiveOptionalTypedefSequenceSelf.idl
+  WARNINGS no-implicit-extensibility)
+
 configure_file(
   config_simple.xml.in config_simple.xml @ONLY)
 
@@ -104,7 +110,6 @@ target_include_directories(
   PRIVATE
     "$<BUILD_INTERFACE:${CYCLONE_SOURCE_DIR}/src/core/ddsc/src>")
 
-
 set_property(TARGET ddscxx_tests PROPERTY CXX_STANDARD ${cyclonedds_cpp_std_to_use})
 target_link_libraries(
   ddscxx_tests PRIVATE
@@ -112,6 +117,55 @@ target_link_libraries(
     GTest::GTest
     GTest::Main
     ddscxx_test_types)
+
+add_executable(ddscxx_recursive_idlcxx_probes
+  RecursiveIdlcxxProbes.cpp)
+set_property(TARGET ddscxx_recursive_idlcxx_probes PROPERTY CXX_STANDARD ${cyclonedds_cpp_std_to_use})
+target_link_libraries(
+  ddscxx_recursive_idlcxx_probes PRIVATE
+    CycloneDDS-CXX::ddscxx
+    ddscxx_recursive_probe_types)
+add_test(
+  NAME IDLCXXRecursiveProbes.supported_recursive_type_forms
+  COMMAND ddscxx_recursive_idlcxx_probes)
+set_tests_properties(
+  IDLCXXRecursiveProbes.supported_recursive_type_forms
+  PROPERTIES TIMEOUT 30)
+
+function(add_idlcxx_rejection_test name idl_file expect_error)
+  add_test(
+    NAME ${name}
+    COMMAND
+      ${CMAKE_COMMAND}
+      -DIDLC=$<TARGET_FILE:CycloneDDS::idlc>
+      -DIDLCXX_BACKEND=$<TARGET_FILE:CycloneDDS-CXX::idlcxx>
+      -DIDL_FILE=${CMAKE_CURRENT_SOURCE_DIR}/data/${idl_file}
+      -DOUTPUT_DIR=${CMAKE_CURRENT_BINARY_DIR}/${name}
+      "-DEXPECT_ERROR=${expect_error}"
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/check_idlcxx_rejection.cmake)
+  set_tests_properties(${name} PROPERTIES TIMEOUT 30)
+endfunction()
+
+add_idlcxx_rejection_test(
+  IDLCXXRecursiveProbes.optional_self_rejected
+  RecursiveOptionalSelf.idl
+  "Recursive @optional member 'child' is not supported by the C\\+\\+ generator")
+add_idlcxx_rejection_test(
+  IDLCXXRecursiveProbes.optional_array_self_rejected
+  RecursiveOptionalArraySelf.idl
+  "Recursive @optional member 'child' is not supported by the C\\+\\+ generator")
+add_idlcxx_rejection_test(
+  IDLCXXRecursiveProbes.optional_typedef_array_self_rejected
+  RecursiveOptionalTypedefArraySelf.idl
+  "Array has incomplete element type")
+add_idlcxx_rejection_test(
+  IDLCXXRecursiveProbes.external_union_case_rejected
+  RecursiveExternalUnionCase.idl
+  "@external union branches are not supported by the C\\+\\+ generator")
+add_idlcxx_rejection_test(
+  IDLCXXRecursiveProbes.optional_external_rejected
+  RecursiveOptionalExternal.idl
+  "Combining @optional and @external is not supported by the C\\+\\+ generator")
 
 if(ENABLE_ICEORYX)
   target_link_libraries(
@@ -127,6 +181,13 @@ endif()
 target_link_libraries(ddscxx_tests ${TEST_LINK_LIBS})
 
 gtest_add_tests(TARGET ddscxx_tests SOURCES ${sources} TEST_LIST tests)
+list(APPEND tests
+  IDLCXXRecursiveProbes.supported_recursive_type_forms
+  IDLCXXRecursiveProbes.optional_self_rejected
+  IDLCXXRecursiveProbes.optional_array_self_rejected
+  IDLCXXRecursiveProbes.optional_typedef_array_self_rejected
+  IDLCXXRecursiveProbes.external_union_case_rejected
+  IDLCXXRecursiveProbes.optional_external_rejected)
 
 # Ensure shared libraries are found
 if(WIN32)

--- a/src/ddscxx/tests/RecursiveIdlcxxProbes.cpp
+++ b/src/ddscxx/tests/RecursiveIdlcxxProbes.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright(c) 2026 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+#include "RecursiveMutualSequence.hpp"
+#include "RecursiveOptionalSequenceSelf.hpp"
+#include "RecursiveOptionalTypedefSequenceSelf.hpp"
+
+int main()
+{
+  optional_sequence_probe::optional_sequence_node optional_sequence_node;
+  mutual_sequence_probe::a mutual_a;
+  mutual_sequence_probe::b mutual_b;
+  optional_typedef_sequence_probe::node optional_typedef_sequence_node;
+
+  (void) optional_sequence_node;
+  (void) mutual_a;
+  (void) mutual_b;
+  (void) optional_typedef_sequence_node;
+
+  return 0;
+}

--- a/src/ddscxx/tests/check_idlcxx_rejection.cmake
+++ b/src/ddscxx/tests/check_idlcxx_rejection.cmake
@@ -1,0 +1,46 @@
+#
+# Copyright(c) 2026 ZettaScale Technology and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+foreach(required_var IDLC IDLCXX_BACKEND IDL_FILE OUTPUT_DIR EXPECT_ERROR)
+  if(NOT DEFINED ${required_var})
+    message(FATAL_ERROR "${required_var} is required")
+  endif()
+endforeach()
+
+file(REMOVE_RECURSE "${OUTPUT_DIR}")
+file(MAKE_DIRECTORY "${OUTPUT_DIR}")
+
+execute_process(
+  COMMAND
+    "${IDLC}"
+    "-l${IDLCXX_BACKEND}"
+    "-Wno-implicit-extensibility"
+    "-o${OUTPUT_DIR}"
+    "${IDL_FILE}"
+  RESULT_VARIABLE result
+  OUTPUT_VARIABLE stdout
+  ERROR_VARIABLE stderr)
+
+set(output "${stdout}\n${stderr}")
+
+if(result EQUAL 0)
+  message(FATAL_ERROR
+    "Expected ${IDL_FILE} to be rejected, but IDLC succeeded.\n"
+    "Output:\n${output}")
+endif()
+
+if(NOT output MATCHES "${EXPECT_ERROR}")
+  message(FATAL_ERROR
+    "Expected rejection output for ${IDL_FILE} to match:\n"
+    "  ${EXPECT_ERROR}\n"
+    "Actual output:\n${output}")
+endif()

--- a/src/ddscxx/tests/data/CdrDataModels.idl
+++ b/src/ddscxx/tests/data/CdrDataModels.idl
@@ -59,6 +59,26 @@ module CDR_testing {
     sequence<long> l;
   };
 
+  struct recursive_node;
+  @mutable struct recursive_node {
+    @id(1) long value;
+    @id(2) sequence<recursive_node> children;
+  };
+
+  union recursive_union;
+  @mutable union recursive_union switch(long) {
+    case 1:
+      sequence<recursive_union> children;
+    case 0:
+      long value;
+  };
+
+  struct recursive_external_node;
+  @mutable struct recursive_external_node {
+    @id(1) long value;
+    @id(2) @external recursive_external_node child;
+  };
+
   @mutable struct sequence_struct_mutable {
     @key sequence<char> c;
     sequence<long> l;

--- a/src/ddscxx/tests/data/RecursiveExternalUnionCase.idl
+++ b/src/ddscxx/tests/data/RecursiveExternalUnionCase.idl
@@ -1,0 +1,9 @@
+module external_union_probe {
+  union external_union;
+  @mutable union external_union switch(long) {
+    case 1:
+      @external external_union child;
+    case 0:
+      long value;
+  };
+};

--- a/src/ddscxx/tests/data/RecursiveMutualSequence.idl
+++ b/src/ddscxx/tests/data/RecursiveMutualSequence.idl
@@ -1,0 +1,12 @@
+module mutual_sequence_probe {
+  struct a;
+  struct b;
+
+  @mutable struct a {
+    @id(1) sequence<b> bs;
+  };
+
+  @mutable struct b {
+    @id(1) sequence<a> as;
+  };
+};

--- a/src/ddscxx/tests/data/RecursiveOptionalArraySelf.idl
+++ b/src/ddscxx/tests/data/RecursiveOptionalArraySelf.idl
@@ -1,0 +1,6 @@
+module optional_array_probe {
+  struct node;
+  @mutable struct node {
+    @id(1) @optional node child[2];
+  };
+};

--- a/src/ddscxx/tests/data/RecursiveOptionalExternal.idl
+++ b/src/ddscxx/tests/data/RecursiveOptionalExternal.idl
@@ -1,0 +1,9 @@
+module optional_external_probe {
+  struct leaf {
+    long value;
+  };
+
+  @mutable struct holder {
+    @id(1) @optional @external leaf child;
+  };
+};

--- a/src/ddscxx/tests/data/RecursiveOptionalSelf.idl
+++ b/src/ddscxx/tests/data/RecursiveOptionalSelf.idl
@@ -1,0 +1,7 @@
+module optional_probe {
+  struct optional_node;
+  @mutable struct optional_node {
+    @id(1) long value;
+    @id(2) @optional optional_node child;
+  };
+};

--- a/src/ddscxx/tests/data/RecursiveOptionalSequenceSelf.idl
+++ b/src/ddscxx/tests/data/RecursiveOptionalSequenceSelf.idl
@@ -1,0 +1,7 @@
+module optional_sequence_probe {
+  struct optional_sequence_node;
+  @mutable struct optional_sequence_node {
+    @id(1) long value;
+    @id(2) @optional sequence<optional_sequence_node> children;
+  };
+};

--- a/src/ddscxx/tests/data/RecursiveOptionalTypedefArraySelf.idl
+++ b/src/ddscxx/tests/data/RecursiveOptionalTypedefArraySelf.idl
@@ -1,0 +1,7 @@
+module optional_typedef_array_probe {
+  struct node;
+  typedef node node_array[2];
+  @mutable struct node {
+    @id(1) @optional node_array child;
+  };
+};

--- a/src/ddscxx/tests/data/RecursiveOptionalTypedefSequenceSelf.idl
+++ b/src/ddscxx/tests/data/RecursiveOptionalTypedefSequenceSelf.idl
@@ -1,0 +1,7 @@
+module optional_typedef_sequence_probe {
+  struct node;
+  typedef sequence<node> node_sequence;
+  @mutable struct node {
+    @id(1) @optional node_sequence children;
+  };
+};

--- a/src/idlcxx/src/generator.c
+++ b/src/idlcxx/src/generator.c
@@ -611,6 +611,159 @@ idl_type_t unalias_bitmask(const idl_node_t *node)
     return IDL_UINT8;
 }
 
+static bool
+type_in_visit_stack(
+  const idl_type_spec_t *type_spec,
+  const idl_type_spec_t **visited,
+  size_t nvisited)
+{
+  for (size_t i = 0; i < nvisited; i++) {
+    if (visited[i] == type_spec)
+      return true;
+  }
+
+  return false;
+}
+
+static bool
+type_reaches_target_by_value_impl(
+  const idl_type_spec_t *type_spec,
+  const idl_type_spec_t *target,
+  const idl_type_spec_t **visited,
+  size_t *nvisited,
+  size_t visited_max)
+{
+  type_spec = idl_strip(type_spec, IDL_STRIP_ALIASES | IDL_STRIP_ALIASES_ARRAY | IDL_STRIP_FORWARD);
+  target = idl_strip(target, IDL_STRIP_ALIASES | IDL_STRIP_FORWARD);
+
+  if (!type_spec || !target)
+    return false;
+  if (type_spec == target)
+    return true;
+  if (idl_is_sequence(type_spec))
+    return false;
+  if (type_in_visit_stack(type_spec, visited, *nvisited))
+    return false;
+  if (*nvisited == visited_max)
+    return true;
+
+  visited[(*nvisited)++] = type_spec;
+
+  if (idl_is_struct(type_spec)) {
+    const idl_struct_t *_struct = (const idl_struct_t *)type_spec;
+    if (_struct->inherit_spec &&
+        type_reaches_target_by_value_impl(
+          _struct->inherit_spec->base, target, visited, nvisited, visited_max))
+      return true;
+
+    const idl_member_t *member = NULL;
+    IDL_FOREACH(member, _struct->members) {
+      if (is_external(member))
+        continue;
+      if (type_reaches_target_by_value_impl(
+            member->type_spec, target, visited, nvisited, visited_max))
+        return true;
+    }
+  } else if (idl_is_union(type_spec)) {
+    const idl_union_t *_union = (const idl_union_t *)type_spec;
+    const idl_case_t *_case = NULL;
+    IDL_FOREACH(_case, _union->cases) {
+      if (is_external(_case))
+        continue;
+      if (type_reaches_target_by_value_impl(
+            _case->type_spec, target, visited, nvisited, visited_max))
+        return true;
+    }
+  }
+
+  return false;
+}
+
+static bool
+type_reaches_target_by_value(
+  const idl_type_spec_t *type_spec,
+  const idl_type_spec_t *target)
+{
+  const idl_type_spec_t *visited[128];
+  size_t nvisited = 0;
+
+  return type_reaches_target_by_value_impl(
+    type_spec, target, visited, &nvisited, sizeof(visited) / sizeof(visited[0]));
+}
+
+static idl_retcode_t
+validate_member(
+  const idl_pstate_t *pstate,
+  bool revisit,
+  const idl_path_t *path,
+  const void *node,
+  void *user_data)
+{
+  const idl_member_t *member = node;
+  const idl_node_t *owner = ((const idl_node_t *)node)->parent;
+
+  (void)revisit;
+  (void)path;
+  (void)user_data;
+
+  if (is_optional(member) && is_external(member)) {
+    idl_error(pstate, idl_location(member),
+      "Combining @optional and @external is not supported by the C++ generator");
+    return IDL_RETCODE_SEMANTIC_ERROR;
+  }
+
+  if (!is_optional(member) || !owner || !idl_is_struct(owner))
+    return IDL_RETCODE_OK;
+
+  const idl_declarator_t *decl = NULL;
+  IDL_FOREACH(decl, member->declarators) {
+    if (type_reaches_target_by_value(member->type_spec, (const idl_type_spec_t *)owner)) {
+      idl_error(pstate, idl_location(decl),
+        "Recursive @optional member '%s' is not supported by the C++ generator",
+        decl->name->identifier);
+      return IDL_RETCODE_SEMANTIC_ERROR;
+    }
+  }
+
+  return IDL_RETCODE_OK;
+}
+
+static idl_retcode_t
+validate_case(
+  const idl_pstate_t *pstate,
+  bool revisit,
+  const idl_path_t *path,
+  const void *node,
+  void *user_data)
+{
+  const idl_case_t *_case = node;
+
+  (void)revisit;
+  (void)path;
+  (void)user_data;
+
+  if (is_external(_case)) {
+    idl_error(pstate, idl_location(_case),
+      "@external union branches are not supported by the C++ generator");
+    return IDL_RETCODE_SEMANTIC_ERROR;
+  }
+
+  return IDL_RETCODE_OK;
+}
+
+static idl_retcode_t
+validate_types(const idl_pstate_t *pstate)
+{
+  idl_visitor_t visitor;
+
+  memset(&visitor, 0, sizeof(visitor));
+  visitor.visit = IDL_MEMBER | IDL_CASE;
+  visitor.accept[IDL_ACCEPT_MEMBER] = &validate_member;
+  visitor.accept[IDL_ACCEPT_CASE] = &validate_case;
+
+  return idl_visit(pstate, pstate->root, &visitor, NULL);
+}
+
 static char *
 figure_guard(const char *file, const idl_md5_byte_t digest[16])
 {
@@ -922,6 +1075,8 @@ idl_retcode_t generate_nosetup(const idl_pstate_t *pstate, struct generator *gen
 
   if (!(guard = figure_guard(gen->header.path, pstate->digest)))
     return IDL_RETCODE_NO_MEMORY;
+  if ((ret = validate_types(pstate)))
+    goto err_print;
   if ((ret = print_header(gen->header.handle, gen->path, gen->header.path)))
     goto err_print;
   if ((ret = print_impl_header(gen->impl.handle, gen->path, gen->impl.path, gen->header.path)))

--- a/src/idlcxx/src/streamers.c
+++ b/src/idlcxx/src/streamers.c
@@ -344,6 +344,31 @@ write_typedef_streaming_functions(
 static idl_retcode_t
 write_constructed_type_streaming_functions(
   struct streams* streams,
+  const idl_type_spec_t* type_spec,
+  const char* accessor,
+  const char* read_accessor)
+{
+  char *type = NULL;
+  static const char* fmt =
+    "      {\n"
+    "        const auto *subprops = prop->first_member ? prop : get_type_props<%1$s>().data();\n"
+    "        if (!{T}(streamer, %2$s, subprops))\n"
+    "          return false;\n"
+    "      }\n";
+
+  if (IDL_PRINTA(&type, get_cpp11_fully_scoped_name, type_spec, streams->generator) < 0)
+    return IDL_RETCODE_NO_MEMORY;
+
+  if (multi_putf(streams, CONST, fmt, type, accessor)
+   || multi_putf(streams, READ, fmt, type, read_accessor))
+    return IDL_RETCODE_NO_MEMORY;
+
+  return IDL_RETCODE_OK;
+}
+
+static idl_retcode_t
+write_union_streaming_functions(
+  struct streams* streams,
   const char* accessor,
   const char* read_accessor)
 {
@@ -415,8 +440,10 @@ write_streaming_functions(
     return write_streaming_functions(streams, idl_type_spec(type_spec), accessor, read_accessor, loc);
   } else if (idl_is_string(type_spec)) {
     return write_string_streaming_functions(streams, type_spec, accessor, read_accessor);
-  } else if (idl_is_union(type_spec) || idl_is_struct(type_spec)) {
-    return write_constructed_type_streaming_functions(streams, accessor, read_accessor);
+  } else if (idl_is_struct(type_spec)) {
+    return write_constructed_type_streaming_functions(streams, type_spec, accessor, read_accessor);
+  } else if (idl_is_union(type_spec)) {
+    return write_union_streaming_functions(streams, accessor, read_accessor);
   } else {
     return write_base_type_streaming_functions(streams, type_spec, accessor, read_accessor, loc);
   }
@@ -671,11 +698,80 @@ process_entity(
     return IDL_RETCODE_OK;
 }
 
+static bool
+type_in_visit_stack(
+  const idl_type_spec_t *type_spec,
+  const idl_type_spec_t **visited,
+  size_t nvisited)
+{
+  for (size_t i = 0; i < nvisited; i++) {
+    if (visited[i] == type_spec)
+      return true;
+  }
+
+  return false;
+}
+
+static bool
+type_references_type_impl(
+  const idl_type_spec_t *type_spec,
+  const idl_type_spec_t *target,
+  const idl_type_spec_t **visited,
+  size_t *nvisited,
+  size_t visited_max)
+{
+  type_spec = idl_strip(type_spec, IDL_STRIP_ALIASES | IDL_STRIP_FORWARD);
+  target = idl_strip(target, IDL_STRIP_ALIASES | IDL_STRIP_FORWARD);
+
+  if (!type_spec || !target)
+    return false;
+  if (type_spec == target)
+    return true;
+  if (type_in_visit_stack(type_spec, visited, *nvisited))
+    return false;
+  /* Prefer a finite property table if the type graph is unexpectedly deep. */
+  if (*nvisited == visited_max)
+    return true;
+
+  visited[(*nvisited)++] = type_spec;
+
+  if (idl_is_sequence(type_spec)) {
+    const idl_sequence_t *seq = (const idl_sequence_t *)type_spec;
+    return type_references_type_impl(seq->type_spec, target, visited, nvisited, visited_max);
+  } else if (idl_is_struct(type_spec)) {
+    const idl_struct_t *_struct = (const idl_struct_t *)type_spec;
+    if (_struct->inherit_spec &&
+        type_references_type_impl(_struct->inherit_spec->base, target, visited, nvisited, visited_max))
+      return true;
+
+    const idl_member_t *member = NULL;
+    IDL_FOREACH(member, _struct->members) {
+      if (type_references_type_impl(member->type_spec, target, visited, nvisited, visited_max))
+        return true;
+    }
+  }
+
+  return false;
+}
+
+static bool
+type_references_type(
+  const idl_type_spec_t *type_spec,
+  const idl_type_spec_t *target)
+{
+  const idl_type_spec_t *visited[128];
+  size_t nvisited = 0;
+
+  return type_references_type_impl(
+    type_spec, target, visited, &nvisited, sizeof(visited) / sizeof(visited[0]));
+}
+
 static idl_retcode_t
 generate_member_properties(
   const idl_type_spec_t *type_spec,
   const idl_declarator_t *decl,
-  struct streams *streams)
+  struct streams *streams,
+  const idl_struct_t *current_struct)
 {
   bool reset_bit_bound = false;
   while (idl_is_alias(type_spec) || idl_is_sequence(type_spec)) {
@@ -725,6 +821,7 @@ generate_member_properties(
   }
 
   if (idl_is_struct(type_spec) &&
+      !type_references_type(type_spec, current_struct) &&
       putf(&streams->props, "  entity_properties_t::append_struct_contents(props, get_type_props<%1$s>());  //internal contents of ::%2$s\n", type, idl_identifier(decl)))
     return IDL_RETCODE_NO_MEMORY;
 
@@ -754,7 +851,7 @@ generate_struct_properties(
     IDL_FOREACH(_member, base->members) {
       const idl_declarator_t *decl = NULL;
       IDL_FOREACH(decl, _member->declarators) {
-        if (generate_member_properties(_member->type_spec, decl, streams))
+        if (generate_member_properties(_member->type_spec, decl, streams, _struct))
           return IDL_RETCODE_NO_MEMORY;
       }
     }


### PR DESCRIPTION
The C++ code generator doesn't quite handle recursive types yet.

Depends on https://github.com/eclipse-cyclonedds/cyclonedds/pull/2415